### PR TITLE
fix API links containing a current Ktor version

### DIFF
--- a/topics/auto/clients/clients_websockets.md
+++ b/topics/auto/clients/clients_websockets.md
@@ -49,4 +49,4 @@ client.ws(
 }
 ```
 
-For more information about the WebSocketSession, check the [WebSocketSession page](/servers/features/websockets.html#WebSocketSession) and the [API reference](https://api.ktor.io/{{ site.ktor_version }}/io.ktor.client.features.websocket/).
+For more information about the WebSocketSession, check the [WebSocketSession page](/servers/features/websockets.html#WebSocketSession) and the [API reference](https://api.ktor.io/%ktor_version%/io.ktor.client.features.websocket/).

--- a/topics/auto/clients/http-client/http-client_testing.md
+++ b/topics/auto/clients/http-client/http-client_testing.md
@@ -12,7 +12,7 @@ Ktor exposes a `MockEngine` for the HttpClient. This engine allows simulating HT
 
 The usage is straightforward: the MockEngine class has a method `addHandler` in `MockEngineConfig`, that receives a block/callback that will handle the request. This callback receives an `HttpRequest` as a parameter, and must return a `HttpResponseData`. There are many helper methods to construct the response.
 
-Full API description and list of helper methods could be found [here](https://api.ktor.io/{{site.ktor_version}}/io.ktor.client.engine.mock/).
+Full API description and list of helper methods could be found [here](https://api.ktor.io/%ktor_version%/io.ktor.client.engine.mock/).
 
 A sample illustrating this:
 

--- a/topics/auto/clients/http-client/quick-start/client.md
+++ b/topics/auto/clients/http-client/quick-start/client.md
@@ -79,9 +79,9 @@ Ktor HttpClient follows `CoroutineScope` lifecycle. Check out [Coroutines guide]
 
 ## Client configuration
 
-To configure the client you can pass additional functional parameter to client constructor. The client configured with [HttpClientEngineConfig](https://api.ktor.io/{{ site.ktor_version }}/io.ktor.client.engine/-http-client-engine-config/index.html).
+To configure the client you can pass additional functional parameter to client constructor. The client configured with [HttpClientEngineConfig](https://api.ktor.io/%ktor_version%/io.ktor.client.engine/-http-client-engine-config/index.html).
 
-For example you can limit `threadCount` or setup [proxy](/clients/http-client/features/proxy.html):
+For example, you can limit `threadCount` or setup [proxy](/clients/http-client/features/proxy.html):
 
 ```kotlin
 val client = HttpClient(CIO) {
@@ -89,7 +89,7 @@ val client = HttpClient(CIO) {
 }
 ```
 
-You also can configure engine using the `engine` method in block:
+You also can configure an engine using the `engine` method in a block:
 
 ```kotlin
 val client = HttpClient(CIO) {

--- a/topics/auto/clients/http-client/quick-start/request.md
+++ b/topics/auto/clients/http-client/quick-start/request.md
@@ -35,13 +35,13 @@ And in the case you are interested in the raw bits, you can read a `ByteArray`:
 val channel: ByteArray = client.get("https://en.wikipedia.org/wiki/Main_Page")
 ```
 
-Or get full [HttpResponse](https://api.ktor.io/{{ site.ktor_version }}/io.ktor.client.statement/-http-response/index.html):
+Or get full [HttpResponse](https://api.ktor.io/%ktor_version%/io.ktor.client.statement/-http-response/index.html):
 
 ```kotlin
 val response: HttpResponse = client.get("https://en.wikipedia.org/wiki/Main_Page")
 ```
 
-The [HttpResponse](https://api.ktor.io/{{ site.ktor_version }}/io.ktor.client.statement/-http-response/index.html) is downloaded in memory by default. To learn how to download response partially or work with a stream data consult with the [Streaming](/clients/http-client/quick-start/streaming.html) section.
+The [HttpResponse](https://api.ktor.io/%ktor_version%/io.ktor.client.statement/-http-response/index.html) is downloaded in memory by default. To learn how to download response partially or work with a stream data consult with the [Streaming](/clients/http-client/quick-start/streaming.html) section.
 
 And even your data class using [Json](/clients/http-client/features/json-feature.html) feature:
 
@@ -78,7 +78,7 @@ val text = client.post<String>("http://127.0.0.1:8080/") {
 }
 ```
 
-The [HttpRequestBuilder](https://api.ktor.io/{{ site.ktor_version }}/io.ktor.client.request/-http-request-builder/) looks like this:
+The [HttpRequestBuilder](https://api.ktor.io/%ktor_version%/io.ktor.client.request/-http-request-builder/) looks like this:
 
 ```kotlin
 class HttpRequestBuilder : HttpMessageBuilder {
@@ -100,7 +100,7 @@ class HttpRequestBuilder : HttpMessageBuilder {
 ```
 
 The `HttpClient` class only offers some basic functionality, and all the methods for building requests are exposed as extensions.\\
-You can check the standard available [HttpClient build extension methods](https://api.ktor.io/{{ site.ktor_version }}/io.ktor.client.request/).
+You can check the standard available [HttpClient build extension methods](https://api.ktor.io/%ktor_version%/io.ktor.client.request/).
 
 ### Customize method
 
@@ -120,7 +120,7 @@ val call = client.request<String> {
 {id="submit-form"}
 
 There are a couple of convenience extension methods for submitting form information.
-The detailed refrence is listed [here](https://api.ktor.io/{{ site.ktor_version }}/io.ktor.client.request.forms/).
+The detailed reference is listed [here](https://api.ktor.io/%ktor_version%/io.ktor.client.request.forms/).
 
 The `submitForm` method:
 
@@ -189,7 +189,7 @@ headers { // this: HeadersBuilder
 }
 ```
 
-Complete `HeadersBuilder` API is listed [here](https://api.ktor.io/{{ site.ktor_version }}/io.ktor.http/-headers-builder/).
+Complete `HeadersBuilder` API is listed [here](https://api.ktor.io/%ktor_version%/io.ktor.http/-headers-builder/).
 
 ## Specifying a body for requests
 

--- a/topics/auto/clients/http-client/quick-start/response.md
+++ b/topics/auto/clients/http-client/quick-start/response.md
@@ -29,7 +29,7 @@ val helloWorld = client.get<HelloWorld>("http://127.0.0.1:8080/")
 
 {id="HttpResponse"}
 
-`HttpResponse` API reference is listed [here](https://api.ktor.io/{{site.ktor_version}}/io.ktor.client.response/-http-response/).
+`HttpResponse` API reference is listed [here](https://api.ktor.io/%ktor_version%/io.ktor.client.response/-http-response/).
 
 From an `HttpResponse`, you can get the response content easily:
 

--- a/topics/auto/clients/http-client/quick-start/streaming.md
+++ b/topics/auto/clients/http-client/quick-start/streaming.md
@@ -10,7 +10,7 @@ Most of the response types are complete in memory. But you can also fetch stream
 
 ## Scoped streaming
 
-There are multiple ways of doing streaming. The safest way is using [HttpStatement](https://api.ktor.io/{{ site.ktor_version }}/io.ktor.client.statement/-http-statement/) with scoped `execute` block:
+There are multiple ways of doing streaming. The safest way is using [HttpStatement](https://api.ktor.io/%ktor_version%/io.ktor.client.statement/-http-statement/) with scoped `execute` block:
 
 ```kotlin
 client.get<HttpStatement>.execute { response: HttpResponse ->

--- a/topics/auto/quickstart/artifacts.md
+++ b/topics/auto/quickstart/artifacts.md
@@ -12,7 +12,7 @@ The typical Ktor application would require `ktor-server-core` and a correspondin
 
 All artifacts in Ktor belong to `io.ktor` group and hosted on JCenter and Maven Central. Pre-release versions are published at [Bintray](https://bintray.com/kotlin/ktor)
 
-[![Download](https://api.bintray.com/packages/kotlin/ktor/ktor/images/download.svg?version={{site.ktor_version}})](https://bintray.com/kotlin/ktor/ktor/{{site.ktor_version}})
+[![Download](https://api.bintray.com/packages/kotlin/ktor/ktor/images/download.svg?version=%ktor_version%)](https://bintray.com/kotlin/ktor/ktor/{{site.ktor_version}})
     
 Ktor is split into several groups of modules:
 

--- a/topics/auto/quickstart/quickstart/maven.md
+++ b/topics/auto/quickstart/quickstart/maven.md
@@ -110,7 +110,7 @@ You have to add both to the `repositories` block in the `pom.xml` file:
 ``` 
 
 Visit [Bintray](https://bintray.com/kotlin/ktor/ktor) and determine the latest version of ktor.
-In this case it is `{{site.ktor_version}}`.
+In this case it is `%ktor_version%`.
 
 You have to specify that version in each Ktor artifact reference,
 and to avoid repetitions, you can specify that version in an extra property


### PR DESCRIPTION
fixed incorrect API links containing a current Ktor version interpolation