### PR TITLE
KTOR-2325 remove Examples and add redirect

### DIFF
--- a/ktor.tree
+++ b/ktor.tree
@@ -207,7 +207,6 @@
             <toc-element id="streaming.md"/>
         </toc-element>
         <toc-element id="http-client_testing.md"/>
-        <toc-element id="examples.md"/>
         <toc-element id="http-client_features.md">
             <toc-element id="features_auth.md" accepts-web-file-names="auth.html"/>
             <toc-element id="default-request.md"/>

--- a/redirection-rules.xml
+++ b/redirection-rules.xml
@@ -48,6 +48,7 @@
         <accepts>samples-fullstack-mpp.html</accepts>
         <accepts>fullstack.html</accepts>
         <accepts>open-source.html</accepts>
+        <accepts>examples.html</accepts>
     </rule>
     <rule id="kotlin_docs">
         <accepts>quickstart-index.html</accepts>


### PR DESCRIPTION
Removed https://ktor.io/docs/examples.html and added a redirect to https://ktor.io/docs/samples.html