### PR TITLE
problem maven multiplatform dependencies

### DIFF
--- a/topics/client.md
+++ b/topics/client.md
@@ -15,7 +15,7 @@ The main client functionality is available in the `ktor-client-core` artifact. D
 ### Engine Dependency {id="engine-dependency"}
 An engine is responsible for processing network requests. There are different client engines available for [various platforms](http-client_multiplatform.md), such as Apache, CIO, Android, iOS, and so on. For example, you can add a `CIO` engine dependency as follows:
 <var name="artifact_name" value="ktor-client-cio"/>
-<include src="lib.md" include-id="add_ktor_artifact"/>
+<include src="lib.md" include-id="add_ktor_artifact_maven_jvm"/>
 
 For a full list of dependencies required for a specific engine, see [](http-client_engines.md#dependencies).
 

--- a/topics/http-client_engines.md
+++ b/topics/http-client_engines.md
@@ -85,7 +85,7 @@ The `Jetty` engine supports only HTTP/2 and can be configured in the following w
 CIO is a fully asynchronous coroutine-based engine that can be used for both JVM and Android platforms. It supports only HTTP/1.x for now. To use it, follow the steps below:
 1. Add the `ktor-client-cio` dependency:
    <var name="artifact_name" value="ktor-client-cio"/>
-   <include src="lib.md" include-id="add_ktor_artifact"/>
+   <include src="lib.md" include-id="add_ktor_artifact_maven_jvm"/>
 1. Pass the [CIO](https://api.ktor.io/%ktor_version%/io.ktor.client.engine.cio/-c-i-o/index.html) class as an argument to the `HttpClient` constructor:
    ```kotlin
    ```

--- a/topics/lib.md
+++ b/topics/lib.md
@@ -60,6 +60,32 @@ To enable `%feature_name%` support, you need to include the `%artifact_name%` ar
 </tabs>
 </chunk>
 
+<chunk id="add_ktor_artifact_maven_jvm">
+<tabs>
+    <tab title="Gradle (Groovy)">
+        <code style="block" lang="Groovy" title="Sample" interpolate-variables="true">
+            implementation "io.ktor:%artifact_name%:$ktor_version"
+        </code>
+    </tab>
+    <tab title="Gradle (Kotlin)">
+        <code style="block" lang="Kotlin" title="Sample" interpolate-variables="true">
+            implementation("io.ktor:%artifact_name%:$ktor_version")
+        </code>
+    </tab>
+    <tab title="Maven (jvm)">
+        <code style="block" lang="XML" title="Sample" interpolate-variables="true">
+        <![CDATA[
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>%artifact_name%-jvm</artifactId>
+            <version>${ktor_version}</version>
+        </dependency>
+        ]]>
+        </code>
+   </tab>
+</tabs>
+</chunk>
+
 
 <chunk id="add_artifact">
 <tabs>


### PR DESCRIPTION
Hello.

Artifact ktor-client-cio published as multiplatform artifact. Using dependency snippet provided by add_ktor_artifact results in only metadata jar being downloaded without actual implementation jar.

Following the steps described in "Client Overview" (client.md) with maven results in unresolved reference compilation error for `HttpClient` and `CIO`. The only solution I know is to use platform version of cio artifact. Replacing ktor-client-cio dependency with ktor-client-cio-jvm makes it possible to compile `HttpClient(CIO)`. In that cases ktor-client-core-jvm is downloaded as transitive dependency of ktor-client-cio-jvm.

I'm not sure what is correct documentation change. But I wanted to bring up that maven dependency snippets don't work multiplatform artifacts, ie ktor-client-cio.
