### PR TITLE
Updating WebSocket testing methods

### DIFF
--- a/topics/creating_web_socket_chat.md
+++ b/topics/creating_web_socket_chat.md
@@ -138,7 +138,7 @@ Let's start the server by pressing the play button in the gutter next to the def
 
 `Application - Responding at http://0.0.0.0:8080`. 
 
-To try out the service, we can open the WebSocket client provided at [www.websocket.org/echo.html](https://www.websocket.org/echo.html) and use it to connect to `ws://localhost:8080/chat`.
+To try out the service, we can open the WebSocket client provided at [www.websocket.org/echo.html](https://www.websocket.org/echo.html) and use it to connect to `ws://localhost:8080/chat`. Note: some browsers will block connections on the insecure channel `ws` to localhost, so the website above may not work for you. In that case, you can try to use your favourite Websocket Client Testing Library, like [WebSocket Test Client](https://chrome.google.com/webstore/detail/websocket-test-client/fgponpodhbmadfljofbimhhlengambbn) on the Chrome Web Store
 
 ![Echo Test](image-20201022122125926.png){width="951"}
 


### PR DESCRIPTION
Some browsers seem to not allow messages to be sent from https://www.websocket.org/echo.html to `localhost` using `ws`. They only allow `wss` connections. I added a small note to clarify that for future readers in case they get stuck on it like I did.