### PR TITLE
Add onUpload/onDownload examples

### DIFF
--- a/codeSnippets/snippets/client-download-file/src/Downloader.kt
+++ b/codeSnippets/snippets/client-download-file/src/Downloader.kt
@@ -7,7 +7,6 @@ import io.ktor.utils.io.*
 import io.ktor.utils.io.jvm.javaio.*
 import kotlinx.coroutines.runBlocking
 import java.io.File
-import kotlin.concurrent.fixedRateTimer
 
 fun main() {
     val client = HttpClient()
@@ -21,9 +20,7 @@ fun main() {
 suspend fun HttpClient.downloadMainPage(file: File) {
     val channel = get<ByteReadChannel>("https://ktor.io/index.html") {
         onDownload { bytesSentTotal, contentLength ->
-            fixedRateTimer("timer", true, 0L, 200L) {
-                println("Received $bytesSentTotal bytes from $contentLength")
-            }
+            println("Received $bytesSentTotal bytes from $contentLength")
         }
     }
 

--- a/codeSnippets/snippets/client-upload-file/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/client-upload-file/src/main/kotlin/com/example/Application.kt
@@ -8,7 +8,6 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
 import java.io.File
-import kotlin.concurrent.fixedRateTimer
 
 fun main() {
     runBlocking {
@@ -25,9 +24,7 @@ fun main() {
             }
         ) {
             onUpload { bytesSentTotal, contentLength ->
-                fixedRateTimer("timer", true, 0L, 50L) {
-                    println("Sent $bytesSentTotal bytes from $contentLength")
-                }
+                println("Sent $bytesSentTotal bytes from $contentLength")
             }
         }
 

--- a/codeSnippets/snippets/client-upload-file/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/client-upload-file/src/main/kotlin/com/example/Application.kt
@@ -2,11 +2,13 @@ package com.example
 
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
+import io.ktor.client.features.*
 import io.ktor.client.request.forms.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
 import java.io.File
+import kotlin.concurrent.fixedRateTimer
 
 fun main() {
     runBlocking {
@@ -21,7 +23,13 @@ fun main() {
                     append(HttpHeaders.ContentDisposition, "filename=ktor_logo.png")
                 })
             }
-        )
+        ) {
+            onUpload { bytesSentTotal, contentLength ->
+                fixedRateTimer("timer", true, 0L, 50L) {
+                    println("Sent $bytesSentTotal bytes from $contentLength")
+                }
+            }
+        }
 
         println(response.readText())
     }

--- a/topics/request.md
+++ b/topics/request.md
@@ -97,12 +97,13 @@ If you need to send a file with a form, use the [submitFormWithBinaryData](https
 
 ```kotlin
 ```
-{src="snippets/client-upload-file/src/main/kotlin/com/example/Application.kt" include-symbol="main"}
+{src="snippets/client-upload-file/src/main/kotlin/com/example/Application.kt" lines="15-34"}
 
-If you need to react on upload progress change, use `onUpload` extension function in `HttpRequestBuilder`:
+Note that in this example the [onUpload](https://api.ktor.io/ktor-client/ktor-client-core/ktor-client-core/io.ktor.client.features/on-upload.html) extension function is used to display upload progress:
+
 ```kotlin
 ```
-{src="snippets/_misc_client/UploadProgress.kt"}
+{src="snippets/client-upload-file/src/main/kotlin/com/example/Application.kt" lines="27-31"}
 
 
 ## Parallel requests {id="parallel_requests"}

--- a/topics/request.md
+++ b/topics/request.md
@@ -97,13 +97,13 @@ If you need to send a file with a form, use the [submitFormWithBinaryData](https
 
 ```kotlin
 ```
-{src="snippets/client-upload-file/src/main/kotlin/com/example/Application.kt" lines="15-34"}
+{src="snippets/client-upload-file/src/main/kotlin/com/example/Application.kt" lines="15-29"}
 
 Note that in this example the [onUpload](https://api.ktor.io/ktor-client/ktor-client-core/ktor-client-core/io.ktor.client.features/on-upload.html) extension function is used to display upload progress:
 
 ```kotlin
 ```
-{src="snippets/client-upload-file/src/main/kotlin/com/example/Application.kt" lines="27-31"}
+{src="snippets/client-upload-file/src/main/kotlin/com/example/Application.kt" lines="26-28"}
 
 
 ## Parallel requests {id="parallel_requests"}

--- a/topics/response.md
+++ b/topics/response.md
@@ -22,10 +22,10 @@ val helloWorld = client.get<HelloWorld>("http://127.0.0.1:8080/")
 
 ### Download progress {id="download-progress"}
 
-If you need to react on download progress change, use `onDownload` extension function in `HttpRequestBuilder`:
+If you need to react on download progress change, use the [onDownload](https://api.ktor.io/ktor-client/ktor-client-core/ktor-client-core/io.ktor.client.features/on-download.html) extension function in `HttpRequestBuilder`:
 ```kotlin
 ```
-{src="snippets/_misc_client/DownloadProgress.kt"}
+{src="snippets/client-download-file/src/Downloader.kt" lines="22-28"}
 
 
 ## API reference {id="HttpResponse"}

--- a/topics/response.md
+++ b/topics/response.md
@@ -25,7 +25,7 @@ val helloWorld = client.get<HelloWorld>("http://127.0.0.1:8080/")
 If you need to react on download progress change, use the [onDownload](https://api.ktor.io/ktor-client/ktor-client-core/ktor-client-core/io.ktor.client.features/on-download.html) extension function in `HttpRequestBuilder`:
 ```kotlin
 ```
-{src="snippets/client-download-file/src/Downloader.kt" lines="22-28"}
+{src="snippets/client-download-file/src/Downloader.kt" lines="21-25"}
 
 
 ## API reference {id="HttpResponse"}


### PR DESCRIPTION
Added the `onUpload`/`onDownload` functions to existing examples for uploading/downloading files and referenced them in docs.