### PR TITLE
Document that Ktor clients and servers support Android 5+

### DIFF
--- a/topics/FAQ.md
+++ b/topics/FAQ.md
@@ -146,23 +146,9 @@ to have a working project as base.
 ## Can I use ktor on Android?
 {id="android-support"}
 
-Ktor is known to work on Android 7 or greater (API 24). It will fail in lower versions like Android 5.
+Yes, ktor clients and servers are known to work on Android 5 (API 21) or greater, at least with the Netty engine.
 
-In unsupported versions it would fail with an exception similar to:
-
-```text
-E/AndroidRuntime: FATAL EXCEPTION: main Process: com.mypackage.example, PID: 4028 java.lang.NoClassDefFoundError: 
-io.ktor.application.ApplicationEvents$subscribe$1 at io.ktor.application.ApplicationEvents.subscribe(ApplicationEvents.kt:18) at 
-io.ktor.server.engine.BaseApplicationEngine.<init>(BaseApplicationEngine.kt:29) at 
-io.ktor.server.engine.BaseApplicationEngine.<init>(BaseApplicationEngine.kt:15) at 
-io.ktor.server.netty.NettyApplicationEngine.<init>(NettyApplicationEngine.kt:17) at io.ktor.server.netty.Netty.create(Embedded.kt:10) at 
-io.ktor.server.netty.Netty.create(Embedded.kt:8) at io.ktor.server.engine.EmbeddedServerKt.embeddedServer(EmbeddedServer.kt:50) at 
-io.ktor.server.engine.EmbeddedServerKt.embeddedServer(EmbeddedServer.kt:40) at 
-io.ktor.server.engine.EmbeddedServerKt.embeddedServer$default(EmbeddedServer.kt:27)
-```
-
-For more information, check [Issue #495](https://github.com/ktorio/ktor/issues/495) and [StackOverflow
-question](https://stackoverflow.com/questions/49945584/attempting-to-run-an-embedded-ktor-http-server-on-android)
+The repo [gnarea/minimal-ktor-server-android](https://github.com/gnarea/minimal-ktor-server-android) provides a trivial Android 5+ app running a Netty-powered Ktor server with HTTP and WebSocket endpoints.
 
 ## CURL -I returns a 404 Not Found
 {id="curl-head-not-found"}


### PR DESCRIPTION
@relaycorp has been running ktor on Android 5+ devices for a while now. Both [clients](https://github.com/relaycorp/awala-poweb-jvm) and servers, and both backed by Netty.

Except for [this minor regression recently introduced in ktor 1.6.1](https://youtrack.jetbrains.com/issue/KTOR-2924), ktor has been running fine on Android 5+ for us.