### PR TITLE
Adding documentation for "wildcard" static file routing

### DIFF
--- a/topics/Serving_Static_Content.md
+++ b/topics/Serving_Static_Content.md
@@ -68,6 +68,17 @@ routing {
 }
 ```
 
+### Serving all files including in subfolders
+The `file` function can also take the string `"."` which will serve up any file as long as the request path and physical filename match. Ktor will use the filename extension to determine the `Content-Type` of the file requested.
+
+```kotlin
+routing {
+    static("static") {
+        file(".")
+    }
+}
+```
+
 ### Defining a default file
 
 For a specific path, we can also define the default file to be loaded:


### PR DESCRIPTION
This is mentioned offhandedly in https://github.com/ktorio/ktor/issues/514 as a workaround solution.
This behavior is not called out in the docs anywhere and is very useful to know.