### PR TITLE
staticBasePackage takes a string instead of File

### DIFF
--- a/topics/Serving_Static_Content.md
+++ b/topics/Serving_Static_Content.md
@@ -191,12 +191,12 @@ routing {
 
 Ktor also provides us the ability to specify a different base resource package from where contents is served.
 
-We can do this by setting the value of the `staticBasePackage` property: 
+We can do this by setting the value of the `staticBasePackage` property. This snippet will serve up all files under the `resourcespath` directory: 
 
 ```kotlin
 static("docs") {
-    staticBasePackage = File("/system/folder/docs")
-    files("public")
+    staticBasePackage = resourcespath"
+    resources(".")
 }
 ```
 

--- a/topics/Serving_Static_Content.md
+++ b/topics/Serving_Static_Content.md
@@ -195,7 +195,7 @@ We can do this by setting the value of the `staticBasePackage` property. This sn
 
 ```kotlin
 static("docs") {
-    staticBasePackage = resourcespath"
+    staticBasePackage = "resourcespath"
     resources(".")
 }
 ```


### PR DESCRIPTION
Adjusting the documentation to show how to use this properly

https://api.ktor.io/ktor-server/ktor-server-core/ktor-server-core/io.ktor.http.content/static-base-package.html