### PR TITLE
Update ProGuard page

### DIFF
--- a/topics/proguard.md
+++ b/topics/proguard.md
@@ -4,22 +4,28 @@
 
 If you have some restrictions on your JAR size, for example, when deploying a free application to [heroku](heroku.md),
 you can use proguard to shrink it. If you are using gradle, it is pretty straightforward to use the
-`proguard-gradle` plugin. You only have to remember to keep: your main module method, the EngineMain
+[`proguard-gradle` plugin](https://www.guardsquare.com/manual/setup/gradle). You only have to remember to keep: your main module method, the EngineMain
 class, and the Kotlin reflect classes. You can then fine-tune it as required:
 
 
 ```groovy
 buildscript {
-    ext.proguard_version = '6.0.1'
+    ext.proguard_version = '7.2.0-beta2'
     dependencies {
-        classpath "net.sf.proguard:proguard-gradle:$proguard_version"
+        classpath "com.guardsquare:proguard-gradle:$proguard_version"
     }
 }
 
 task minimizedJar(type: proguard.gradle.ProGuardTask, dependsOn: shadowJar) {
     injars "build/libs/my-application.jar"
     outjars "build/libs/my-application.min.jar"
-    libraryjars System.properties.'java.home' + "/lib/rt.jar"
+    
+    if (System.getProperty('java.version').startsWith('1.')) {
+        libraryjars "${System.getProperty('java.home')}/lib/rt.jar"
+    } else {
+        libraryjars "${System.getProperty('java.home')}/jmods/java.base.jmod", jarfilter: '!**.jar', filter: '!module-info.class'
+    }
+    
     printmapping "build/libs/my-application.map"
     ignorewarnings
     dontobfuscate
@@ -42,7 +48,7 @@ task minimizedJar(type: proguard.gradle.ProGuardTask, dependsOn: shadowJar) {
 }
 ```
 
->You have a full example on: <https://github.com/ktorio/ktor-samples/tree/1.3.0/other/proguard>
+>You have a full example on: <https://github.com/ktorio/ktor-samples/tree/main/generic/samples/proguard>
 >
 >
 {type="note"}


### PR DESCRIPTION
Updated:

* The new group ID for the `proguard-gradle` artifact.
* The latest ProGuard version.
* Link to the ProGuard Gradle plugin manual page.
* Use the correct Java library jars depending on Java version.
* URL to the latest sample version.

Related sample PR: https://github.com/ktorio/ktor-samples/pull/98