### PR TITLE
change "artifact" to "setArtifact"

### DIFF
--- a/codeSnippets/snippets/google-appengine-standard/build.gradle
+++ b/codeSnippets/snippets/google-appengine-standard/build.gradle
@@ -15,7 +15,7 @@ repositories {
 
 appengine {
     stage {
-        artifact = "build/libs/${project.name}-${project.version}-all.jar"
+        setArtifact("build/libs/${project.name}-${project.version}-all.jar")
     }
     deploy {
         version = "GCLOUD_CONFIG"


### PR DESCRIPTION
`artifact = "..."` was not supported. 

setArtifact("...") works. 