### PR TITLE
Fix `standard plugins` link

### DIFF
--- a/topics/http-client_plugins.md
+++ b/topics/http-client_plugins.md
@@ -9,7 +9,7 @@ there is a pipeline for client HTTP requests, and there are interceptors and ins
 
 ## Creating custom plugins
 
-If you want to create plugins, you can use the [standard plugins](https://github.com/ktorio/ktor/tree/main/ktor-client/ktor-client-core/common/src/io/ktor/client/features) as a reference.
+If you want to create plugins, you can use the [standard plugins](https://github.com/ktorio/ktor/tree/main/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins) as a reference.
 
 >You can also check the [HttpRequestPipeline.Phases](https://github.com/ktorio/ktor/blob/main/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequestPipeline.kt)
 >and [HttpResponsePipeline.Phases](https://github.com/ktorio/ktor/blob/main/ktor-client/ktor-client-core/common/src/io/ktor/client/statement/HttpResponsePipeline.kt)


### PR DESCRIPTION
Fixes documentation link pointing to a non-existing packages; due to renaming `features` to `plugins`.