### PR TITLE
Update ConversionService and DelegatingConversionService examples with their new signature

### DIFF
--- a/topics/data-conversion.md
+++ b/topics/data-conversion.md
@@ -102,16 +102,18 @@ val dataConversion = call.conversionService
 
 ```kotlin
 interface ConversionService {
-    fun fromValues(values: List<String>, type: Type): Any?
-    fun toValues(value: Any?): List<String>
+
+  fun fromValues(values: List<String>, type: TypeInfo): Any?
+  fun toValues(value: Any?): List<String>
 }
 ```
 {id="ConversionService"}
 
 ```kotlin
-class DelegatingConversionService(private val klass: KClass<*>) : ConversionService {
-    fun decode(converter: (values: List<String>, type: Type) -> Any?)
-    fun encode(converter: (value: Any?) -> List<String>)
+class DelegatingConversionService(private val klass: KClass<*>, private val decoder: ((values: List<String>) -> Any?)?, private val encoder: ((value: Any?) -> List<String>)?) : ConversionService {
+
+  fun fromValues(values: List<String>, type: TypeInfo): Any?
+  fun toValues(value: Any?): List<String>
 }
 ```
 {id="DelegatingConversionService"}


### PR DESCRIPTION
Update the examples of [ConversionService](https://github.com/ktorio/ktor/blob/0de7948fbe3f78673f4f90de9c5ea5986691819a/ktor-utils/common/src/io/ktor/util/converters/ConversionService.kt#L13) and [DelegatingConversionService](https://github.com/ktorio/ktor/blob/99d172d9f8df1e95c58d4335d599ff20ac0d29e6/ktor-utils/common/src/io/ktor/util/converters/DataConversion.kt#L73) so they match their signatures.
