### PR TITLE
Update kotlin_serialization page to contain 2.0.0 package

### DIFF
--- a/topics/kotlin_serialization.md
+++ b/topics/kotlin_serialization.md
@@ -13,7 +13,7 @@ Before registering a required converter, perform the following steps:
 
 1. Add the Kotlin serialization plugin, as described in the [Setup](https://github.com/Kotlin/kotlinx.serialization#setup) section.
 1. Include the following artifacts in the build script: 
-    <var name="artifact_name" value="ktor-serialization"/>
+    <var name="artifact_name" value="ktor-serialization-kotlinx-json"/>
     <include src="lib.xml" include-id="add_ktor_artifact"/>
    
     This will be enough for converting JSON. 


### PR DESCRIPTION
`ktor-serialization` package does not contain `json()` function, but `ktor-serialization-kotlinx-json` does (as far as I understand, that changed with Ktor 2.0.0)