### PR TITLE
Make native server limitations a bit more clear

### DIFF
--- a/topics/native_server.md
+++ b/topics/native_server.md
@@ -10,10 +10,10 @@ Ktor supports [Kotlin/Native](https://kotlinlang.org/docs/native-overview.html) 
 ## Limitations {id="limitations"}
 
 Currently, running a Ktor server under Kotlin/Native has the following limitations:
-* Only the [CIO engine](Engines.md) is supported.
-* [WebSockets](websocket.md) are not supported.
-* [HTTPS](ssl.md) is not supported.
-* Windows is not supported.
+* only the [CIO engine](Engines.md) is supported
+* [WebSockets](websocket.md) are not supported
+* [HTTPS](ssl.md) without a reverse proxy is not supported
+* Windows target is not supported
 
 
 ## Add dependencies {id="add-dependencies"}


### PR DESCRIPTION
- make sure to mention the reverse proxy option for HTTPS
- mention that only the windows target is not supported, you can still develop on windows