### PR TITLE
IDEA help page was renamed

### DIFF
--- a/topics/lib.xml
+++ b/topics/lib.xml
@@ -246,7 +246,7 @@
             <li>
                 <p>
                     Make sure the <a href="https://plugins.jetbrains.com/plugin/6954-kotlin">Kotlin</a> plugin is installed and enabled. Learn how to do this from the
-                    <a href="https://www.jetbrains.com/help/idea/managing-plugins.html#open-plugin-settings">Manage plugins</a> topic.
+                    <a href="https://www.jetbrains.com/help/idea/managing-plugins.html#open-plugin-settings">Install plugins</a> topic.
                 </p>
             </li>
         </list>


### PR DESCRIPTION
Small fix to follow changes in IDEA help (for 2021.3+).