### PR TITLE
Inline explanations for request, connect, and socket timeouts

### DIFF
--- a/topics/timeout.md
+++ b/topics/timeout.md
@@ -29,9 +29,9 @@ val client = HttpClient(CIO) {
 ## Configure timeouts {id="configure_plugin"}
 
 To configure timeouts, you can use corresponding properties:
-* [requestTimeoutMillis](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.plugins/-http-timeout/-http-timeout-capability-configuration/request-timeout-millis.html) for a request timeout.
-* [connectTimeoutMillis](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.plugins/-http-timeout/-http-timeout-capability-configuration/connect-timeout-millis.html) for a connection timeout.
-* [socketTimeoutMillis](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.plugins/-http-timeout/-http-timeout-capability-configuration/socket-timeout-millis.html) for a socket timeout.
+* [requestTimeoutMillis](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.plugins/-http-timeout/-http-timeout-capability-configuration/request-timeout-millis.html) specifies a timeout for a whole HTTP call, from sending a request to receiving a response.
+* [connectTimeoutMillis](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.plugins/-http-timeout/-http-timeout-capability-configuration/connect-timeout-millis.html) specifies a timeout for establishing a connection with a server.
+* [socketTimeoutMillis](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.plugins/-http-timeout/-http-timeout-capability-configuration/socket-timeout-millis.html) specifies a timeout for the maximum time in between two data packets when exchanging data with a server.
 
 You can specify timeouts for all requests inside the `install` block. The code sample below shows how to set a request timout using `requestTimeoutMillis`:
 ```kotlin


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTOR-4261/Explanation-on-request,-connection,-and-socket-missing-in-KDoc

"`requestTimeoutMillis` for a request timeout." does not add the valuable information of what a _request timeout_ even means – it requires readers to manually cross-reference to the listing at the top of the page, which seems like something that could easily be avoided by including the information right at this place. This PR addresses this.