### PR TITLE
Update double-receive.md regarding cacheRawRequest

### DIFF
--- a/topics/double-receive.md
+++ b/topics/double-receive.md
@@ -52,13 +52,10 @@ With the default configuration, `%plugin_name%` provides the ability to [receive
 - `String`
 - `Parameters` 
 - [data classes](serialization.md#create_data_class) used by the `ContentNegotiation` plugin
-
-By default, `%plugin_name%` doesn't support:
-
 - receiving different types from the same request
 - receiving a [stream or channel](requests.md#raw)
 
-To overcome these limitations, set the `cacheRawRequest` property to `false`:
+Set the `cacheRawRequest` property to `false`, if you do not need to receive different types from the same request or receive a stream or channel:
 
 ```kotlin
 ```


### PR DESCRIPTION
The explanation of `cacheRawRequest` seems misleading. Its default value is `true`, which already allows to receive different types from the same request.