### PR TITLE
change `AtomicInteger` property from `var` to `val`

### DIFF
--- a/codeSnippets/snippets/server-websockets/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/server-websockets/src/main/kotlin/com/example/Application.kt
@@ -62,7 +62,7 @@ fun Application.module() {
 
 class Connection(val session: DefaultWebSocketSession) {
     companion object {
-        var lastId = AtomicInteger(0)
+        val lastId = AtomicInteger(0)
     }
 
     val name = "user${lastId.getAndIncrement()}"


### PR DESCRIPTION
`lastId` itself isn't reassigned - the integer inside `AtomicInteger` is mutated. Therefore `lastId` can be a `val`. This makes it clearer that `lastId` shouldn't be reassigned.

The Coroutines docs have an example where an `AtomicInteger` is defined using `val`

https://kotlinlang.org/docs/shared-mutable-state-and-concurrency.html#thread-safe-data-structures

```kotlin
val counter = AtomicInteger()

fun main() = runBlocking {
    withContext(Dispatchers.Default) {
        massiveRun {
            counter.incrementAndGet()
        }
    }
    println("Counter = $counter")
}
```