### PR TITLE
Fix Netty HTTP/2 samples

### DIFF
--- a/codeSnippets/snippets/http2-netty/build.gradle.kts
+++ b/codeSnippets/snippets/http2-netty/build.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     implementation("io.ktor:ktor-server-netty:$ktor_version")
     implementation("io.ktor:ktor-server-html-builder:$ktor_version")
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    implementation("io.netty:netty-tcnative:$tcnative_version")
     if (tcnative_classifier != null) {
         implementation("io.netty:netty-tcnative-boringssl-static:$tcnative_version:$tcnative_classifier")
     } else {

--- a/codeSnippets/snippets/http2-push/build.gradle.kts
+++ b/codeSnippets/snippets/http2-push/build.gradle.kts
@@ -1,7 +1,7 @@
 val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
-val tcnative_version = "2.0.47.Final"
+val tcnative_version = "2.0.53.Final"
 
 plugins {
     application
@@ -35,7 +35,6 @@ dependencies {
     implementation("io.ktor:ktor-network-tls:$ktor_version")
     implementation("io.ktor:ktor-network-tls-certificates:$ktor_version")
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    implementation("io.netty:netty-tcnative:$tcnative_version")
     if (tcnative_classifier != null) {
         implementation("io.netty:netty-tcnative-boringssl-static:$tcnative_version:$tcnative_classifier")
     } else {

--- a/codeSnippets/snippets/http2-push/src/main/kotlin/com/example/Http2PushApplication.kt
+++ b/codeSnippets/snippets/http2-push/src/main/kotlin/com/example/Http2PushApplication.kt
@@ -10,6 +10,7 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.html.*
 
+@OptIn(UseHttp2Push::class)
 fun Application.main() {
     install(DefaultHeaders)
     install(CallLogging)

--- a/codeSnippets/snippets/http2-push/src/main/kotlin/com/example/Main.kt
+++ b/codeSnippets/snippets/http2-push/src/main/kotlin/com/example/Main.kt
@@ -3,7 +3,7 @@ package com.example
 import io.ktor.network.tls.certificates.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
-import java.io.*
+import java.io.File
 
 fun main(args: Array<String>) {
     // generate SSL certificate
@@ -13,5 +13,5 @@ fun main(args: Array<String>) {
         generateCertificate(file)
     }
     // run embedded server
-    embeddedServer(Netty, commandLineEnvironment(args)).start()
+    embeddedServer(Netty, commandLineEnvironment(args)).start(true)
 }


### PR DESCRIPTION
3 things were broken:
* `ktor-netty` itself. I will open PR in the main repo shortly
* having both `io.netty:netty-tcnative` and `io.netty:netty-tcnative-boringssl-static`. You need to add only one of them (preferably BoringSSL), otherwise Netty fails with duplicate symbol exception
* version of Netty and TCNative should be in sync, since Netty treats TCNative as the internal dependency and relies on the behaviour. 

@andreyaksenov, Do you mind updating tutorials considering points2 and 3?