### PR TITLE
Update ProGuard keep rules for Ktor 2.3.0

### DIFF
--- a/codeSnippets/snippets/proguard/proguard.pro
+++ b/codeSnippets/snippets/proguard/proguard.pro
@@ -3,3 +3,4 @@
 -keep class com.example.ApplicationKt { *; }
 -keep class kotlin.reflect.jvm.internal.** { *; }
 -keep class kotlin.text.RegexOption { *; }
+-keep class io.ktor.serialization.kotlinx.json.KotlinxSerializationJsonExtensionProvider { *; }


### PR DESCRIPTION
I was getting runtime crashes with after updating to Ktor 2.3.0, and it looks like the ProGuard rules needed a small update.