### PR TITLE
Wrong parameters

### DIFF
--- a/codeSnippets/snippets/client-logging-napier/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/client-logging-napier/src/main/kotlin/com/example/Application.kt
@@ -15,7 +15,7 @@ fun main() {
             install(Logging) {
                 logger = object: Logger {
                     override fun log(message: String) {
-                        Napier.v("HTTP Client", null, message)
+                        Napier.v(message, "HTTP Client", null)
                     }
                 }
                 level = LogLevel.HEADERS


### PR DESCRIPTION
fix order of parameters in Napier.v() function