### PR TITLE
Update http-client_engines.md that explains default http/2 behaviour

### DIFF
--- a/topics/http-client_engines.md
+++ b/topics/http-client_engines.md
@@ -114,7 +114,8 @@ In this section, we'll take a look at engines available for JVM.
 
 ### Apache {id="apache"}
 The `Apache` engine supports HTTP/1.1 and provides multiple configuration options. 
-You can also use the `Apache5` engine if you need HTTP/2 support.
+You can also use the `Apache5` engine if you need HTTP/2 support, which has HTTP/2 enabled by default.
+
 1. Add the `ktor-client-apache5` or `ktor-client-apache` dependency:
 
    <var name="artifact_name" value="ktor-client-apache5"/>


### PR DESCRIPTION
It is not clear in the docs that Apache5 automatically has http/2 enabled by default. 
The docs suggest that it is disabled by default and can be enabled if you want to.
But for Apache5 engine the http1/http2 negotiation is automatically enabled.