### PR TITLE
KTOR-6156 docs for CallId client plugin

### DIFF
--- a/codeSnippets/gradle.properties
+++ b/codeSnippets/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.configureondemand = false
 
 # versions
 kotlin_version = 1.9.10
-ktor_version = 3.0.0-eap-800
+ktor_version = 3.0.0-eap-808
 kotlinx_coroutines_version = 1.6.4
 kotlinx_serialization_version = 1.4.1
 kotlin_css_version = 1.0.0-pre.625

--- a/codeSnippets/settings.gradle.kts
+++ b/codeSnippets/settings.gradle.kts
@@ -160,6 +160,7 @@ module("snippets", "client-configure-request")
 module("snippets", "request-validation")
 module("snippets", "client-sse")
 module("snippets", "server-sse")
+module("snippets", "client-call-id")
 
 if(!System.getProperty("os.name").startsWith("Windows")) {
     module("snippets", "embedded-server-native")

--- a/codeSnippets/snippets/client-call-id/README.md
+++ b/codeSnippets/snippets/client-call-id/README.md
@@ -21,7 +21,7 @@ The client makes 3 requests to the API and prints out information about the call
 
 The expected output is:
 ```
-in call: call-id-client, in header: call-id-client, in query param: call-id-client
-in call: call-id-client, in header: call-id-client, in query param: null
-in call: call-id-server, in header: null, in query param: call-id-client-2
+Handling request `/call` from client with call.callId: call-id-client and X-RequestId: call-id-client
+Handling request `/call` from client with call.callId: call-id-client and X-RequestId: call-id-client
+Handling request `/call` from client with call.callId: call-id-client-2 and X-RequestId: call-id-client-2
 ```

--- a/codeSnippets/snippets/client-call-id/README.md
+++ b/codeSnippets/snippets/client-call-id/README.md
@@ -1,0 +1,27 @@
+# Client call id
+
+A sample Ktor project showing how to use the [CallId](https://ktor.io/docs/client-call-id.html) client plugin.
+The project consists of two parts: an API service and a client.
+The API service utilizes the `callId` plugin on the server and configures it to retrieve a call ID from the request
+header or use a generated call ID.
+
+> This sample is a part of the [codeSnippets](../../README.md) Gradle project.
+
+## Running
+
+1. To start the API service, navigate to `CallIdService.kt` and click on the play button next to the `main()` function.
+
+2. Run the client sample by executing the following command:
+
+```bash
+./gradlew :client-call-id:run
+```
+
+The client makes 3 requests to the API and prints out information about the call ID.
+
+The expected output is:
+```
+in call: call-id-client, in header: call-id-client, in query param: call-id-client
+in call: call-id-client, in header: call-id-client, in query param: null
+in call: call-id-server, in header: null, in query param: call-id-client-2
+```

--- a/codeSnippets/snippets/client-call-id/build.gradle.kts
+++ b/codeSnippets/snippets/client-call-id/build.gradle.kts
@@ -1,0 +1,32 @@
+val ktor_version: String by project
+val logback_version: String by project
+val junit_version: String by project
+val hamcrest_version: String by project
+
+plugins {
+    application
+    kotlin("jvm")
+}
+
+application {
+    mainClass.set("com.example.ApplicationKt")
+}
+
+repositories {
+    mavenCentral()
+    maven { url = uri("https://maven.pkg.jetbrains.space/public/p/ktor/eap") }
+}
+
+dependencies {
+    implementation("io.ktor:ktor-client-core:$ktor_version")
+    implementation("io.ktor:ktor-client-cio:$ktor_version")
+    implementation("io.ktor:ktor-client-call-id:$ktor_version")
+    implementation("ch.qos.logback:logback-classic:$logback_version")
+    implementation("io.ktor:ktor-server-core:$ktor_version")
+    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation("io.ktor:ktor-server-call-logging:$ktor_version")
+    implementation("io.ktor:ktor-server-call-id:$ktor_version")
+    implementation(project(":e2e"))
+    testImplementation("junit:junit:$junit_version")
+    testImplementation("org.hamcrest:hamcrest:$hamcrest_version")
+}

--- a/codeSnippets/snippets/client-call-id/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/client-call-id/src/main/kotlin/com/example/Application.kt
@@ -1,0 +1,39 @@
+package com.example
+
+import io.ktor.client.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.client.plugins.callid.*
+import io.ktor.http.*
+import kotlinx.coroutines.*
+
+fun main() {
+    runBlocking {
+        val client = HttpClient(CIO) {
+            install(CallId) {
+                useCoroutineContext = true
+                generate { "call-id-client" }
+                addToHeader(HttpHeaders.XRequestId)
+                intercept { request, callId -> request.parameter("callId", callId) }
+            }
+        }
+
+        val response: HttpResponse = client.get("http://0.0.0.0:8090/call")
+        println(response.bodyAsText())
+
+        val responseFromDoubleCall: HttpResponse = client.get("http://0.0.0.0:8090/double-call")
+        println(responseFromDoubleCall.bodyAsText())
+
+        val client2 = HttpClient(CIO) {
+            install(CallId) {
+                generate { "call-id-client-2" }
+                intercept { request, callId -> request.parameter("callId", callId) }
+            }
+        }
+
+        val response2: HttpResponse = client2.get("http://0.0.0.0:8090/call")
+        println(response2.bodyAsText())
+        client.close()
+    }
+}

--- a/codeSnippets/snippets/client-call-id/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/client-call-id/src/main/kotlin/com/example/Application.kt
@@ -12,7 +12,6 @@ fun main() {
     runBlocking {
         val client = HttpClient(CIO) {
             install(CallId) {
-                useCoroutineContext = true
                 generate { "call-id-client" }
                 addToHeader(HttpHeaders.XRequestId)
                 intercept { request, callId -> request.parameter("callId", callId) }
@@ -27,6 +26,7 @@ fun main() {
 
         val client2 = HttpClient(CIO) {
             install(CallId) {
+                useCoroutineContext = false
                 generate { "call-id-client-2" }
                 intercept { request, callId -> request.parameter("callId", callId) }
             }

--- a/codeSnippets/snippets/client-call-id/src/main/kotlin/com/example/CallIdService.kt
+++ b/codeSnippets/snippets/client-call-id/src/main/kotlin/com/example/CallIdService.kt
@@ -20,8 +20,7 @@ fun main(args: Array<String>) {
 
 fun Application.module() {
     val client = HttpClient(CIO) {
-        install(ClientCallId) {
-        }
+        install(ClientCallId)
     }
     install(CallId) {
         retrieveFromHeader(HttpHeaders.XRequestId)

--- a/codeSnippets/snippets/client-call-id/src/main/kotlin/com/example/CallIdService.kt
+++ b/codeSnippets/snippets/client-call-id/src/main/kotlin/com/example/CallIdService.kt
@@ -1,0 +1,47 @@
+package com.example
+
+import io.ktor.client.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.client.plugins.callid.CallId as ClientCallId
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.server.plugins.callid.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+
+fun main(args: Array<String>) {
+    embeddedServer(Netty, port = 8090, host = "0.0.0.0", module = Application::module)
+        .start(wait = true)
+}
+
+fun Application.module() {
+    val client = HttpClient(CIO) {
+        install(ClientCallId) {
+        }
+    }
+    install(CallId) {
+        retrieveFromHeader(HttpHeaders.XRequestId)
+        generate { "call-id-server" }
+        header(HttpHeaders.XRequestId)
+    }
+    routing {
+        get("/") {
+            call.respond("Hello World")
+        }
+        get("/double-call") {
+            val response = client.get("http://0.0.0.0:8090/call")
+            call.respond(response.bodyAsText())
+        }
+        get("/call") {
+            val callIdFromCall = call.callId
+            val callIdFromHeader = call.request.headers[HttpHeaders.XRequestId]
+            val callIdFromParameter = call.request.queryParameters["callId"]
+            call.respond("in call: $callIdFromCall, in header: $callIdFromHeader, in query param: $callIdFromParameter")
+        }
+    }
+
+}

--- a/codeSnippets/snippets/tutorial-client-kmm/shared/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-client-kmm/shared/build.gradle.kts
@@ -17,7 +17,7 @@ kotlin {
     }
 
     sourceSets {
-        val ktorVersion = "3.0.0-eap-800"
+        val ktorVersion = "3.0.0-eap-808"
         val commonMain by getting {
             dependencies {
                 implementation("io.ktor:ktor-client-core:$ktorVersion")

--- a/ktor.tree
+++ b/ktor.tree
@@ -2,9 +2,9 @@
 <!DOCTYPE instance-profile
         SYSTEM "https://helpserver.labs.jb.gg/help/schemas/mvp/product-profile.dtd">
 <instance-profile id="ktor"
-                 name="Ktor"
-                 status="eap"
-                 start-page="welcome.topic">
+                  name="Ktor"
+                  status="eap"
+                  start-page="welcome.topic">
 
     <toc-element topic="welcome.topic"
                  accepts-web-file-names-ref="kotlin_docs"/>
@@ -149,7 +149,6 @@
         </toc-element>
 
 
-
         <toc-element toc-title="Running and debugging">
             <toc-element topic="running.md"
                          accepts-web-file-names="engine.html"/>
@@ -252,6 +251,9 @@
                 <toc-element topic="websocket_client_serialization.md"/>
             </toc-element>
             <toc-element topic="sse_client.md"/>
+            <toc-element toc-title="Monitoring">
+                <toc-element topic="client_call_id.md"/>
+            </toc-element>
             <toc-element topic="client-custom-plugins.md"/>
         </toc-element>
 

--- a/topics/call-id.md
+++ b/topics/call-id.md
@@ -15,6 +15,10 @@
 <include from="lib.topic" element-id="native_server_supported"/>
 </tldr>
 
+<link-summary>
+The %plugin_name% server plugin allows you to trace client requests by using unique call IDs.
+</link-summary>
+
 The [%plugin_name%](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-call-id/io.ktor.server.plugins.callid/-call-id.html) plugin allows you to trace client requests end-to-end by using unique request IDs or call IDs. Typically, working with a call ID in Ktor might look as follows:
 1. First, you need to obtain a call ID for a specific request in one of the following ways:
    * A reverse proxy (such as Nginx) or cloud provider (such as [Heroku](heroku.md)) might add a call ID in a specific header, for example, `X-Request-Id`. In this case, Ktor allows you to [retrieve](#retrieve) a call ID.

--- a/topics/client_call_id.md
+++ b/topics/client_call_id.md
@@ -51,7 +51,7 @@ Generate a call ID for a specific request in one of the following ways:
  ```kotlin
  ```
 
-{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="14,29,32"}
+{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="34-35,37"}
 
 > In a Ktor server, use the [CallId plugin](call-id.md) to add a call ID to the `CoroutineContext`.
 
@@ -61,7 +61,7 @@ Generate a call ID for a specific request in one of the following ways:
  ```kotlin
  ```
 
-{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="14,15,18"}
+{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="34,36-37"}
 
 You can use multiple methods to generate a call ID. In this way, the first non-null value will be applied.
 
@@ -74,7 +74,7 @@ After you retrieve a call ID, you have the following options available to add it
  ```kotlin
  ```
 
-{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="14,17,18"}
+{src="snippets/client-call-id/src/main/kotlin/com/example/CallIdService.kt" include-lines="23-27"}
 
 * The `addToHeader()` function adds a call ID to a specified header. It takes a header as a parameter, which defaults
   to `HttpHeaders.XRequestId`.
@@ -82,7 +82,7 @@ After you retrieve a call ID, you have the following options available to add it
  ```kotlin
  ```
 
-{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="14,16,18"}
+{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="18,20-21"}
 
 ## Example
 
@@ -92,11 +92,10 @@ it to the header:
  ```kotlin
  ```
 
-{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="13-20"}
+{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="17-22"}
 
 The plugin uses the coroutine context to get a call ID and utilizes the `generate()` function to generate a new one. The
-first non-null call ID is then applied to the request header using the `addToHeader()` function and to the request query
-parameter using the `intercept()` function.
+first non-null call ID is then applied to the request header using the `addToHeader()` function.
 
 In a Ktor server, the call ID can then be retrieved from the header using the [retrieve](call-id.md#retrieve) functions
 from the [CallId plugin for the server](call-id.md).
@@ -104,7 +103,7 @@ from the [CallId plugin for the server](call-id.md).
  ```kotlin
  ```
 
-{src="snippets/client-call-id/src/main/kotlin/com/example/CallIdService.kt" include-lines="25-26,29"}
+{src="snippets/client-call-id/src/main/kotlin/com/example/CallIdService.kt" include-lines="29-30,33"}
 
 In this way the Ktor server retrieves the ID of the specified header of the request and applies it to the `callId`
 property of the call.

--- a/topics/client_call_id.md
+++ b/topics/client_call_id.md
@@ -1,0 +1,106 @@
+[//]: # (title: CallId)
+
+<show-structure for="chapter" depth="2"/>
+
+<var name="artifact_name" value="ktor-client-call-id"/>
+<var name="package_name" value="io.ktor.client.plugins.callid"/>
+<var name="plugin_name" value="CallId"/>
+
+<tldr>
+<p>
+<b>Required dependencies</b>: <code>io.ktor:%artifact_name%</code>
+</p>
+<var name="example_name" value="client-call-id"/>
+<include from="lib.topic" element-id="download_example"/>
+</tldr>
+
+The CallId plugin allows you to trace client requests end-to-end by using unique call IDs. It is particularly useful
+in microservice architectures to keep track of calls, regardless of how many services a request goes through.
+
+A calling scope might already have a call ID in its coroutine context. By default, the plugin uses the current context
+to retrieve a call ID and adds it to the context of the specific call using the `HttpHeaders.XRequestId` header.
+
+Additionally, if a scope comes without a call ID, you can configure the plugin to generate and apply a new call ID.
+
+## Add dependencies {id="add_dependencies"}
+
+<include from="lib.topic" element-id="add_ktor_artifact_intro"/>
+<include from="lib.topic" element-id="add_ktor_artifact"/>
+
+## Install %plugin_name% {id="install_plugin"}
+
+<include from="lib.topic" element-id="install_plugin"/>
+
+## Configure %plugin_name% {id="configure"}
+
+The %plugin_name% plugin configuration, provided by the [CallIdConfig]() class, allows you to generate a call ID and add
+it to the call context.
+
+### Generate a call ID
+
+Generate a call ID for a specific request in one of the following ways:
+
+* The `useCoroutineContext` property, enabled by default, adds a generator that uses the current `CoroutineContext` to
+  retrieve a call ID.
+
+ ```kotlin
+ ```
+
+{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="14-15,19"}
+
+* The `generate()` function allows you to generate a call ID for an outgoing request. If it fails to generate a call ID,
+  it returns `null`.
+
+ ```kotlin
+ ```
+
+{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="14,16,19"}
+
+You can use multiple methods to generate a call ID. In this way, the first non-null value will be applied.
+
+### Add a call ID
+
+After you retrieve a call ID, you have the following options available to add it to the request:
+
+* The `intercept()` function allows you to add a call ID to the request by using the [CallIdInterceptor]().
+
+ ```kotlin
+ ```
+
+{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="14,18,19"}
+
+* The `addToHeader()` function adds a call ID to a specified header. It takes a header as a parameter, which defaults
+  to `HttpHeaders.XRequestId`.
+
+ ```kotlin
+ ```
+
+{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="14,17,19"}
+
+## Example
+
+In the following example, the `%plugin_name%` plugin for the Ktor client is configured to generate a new call ID and add
+it to the header:
+
+ ```kotlin
+ ```
+
+{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="13-21"}
+
+The plugin uses the coroutine context to get a call ID and utilizes the `generate()` function to generate a new one. The
+first non-null call ID is then applied to the request header using the `addToHeader()` function and to the request query
+parameter using the `intercept()` function.
+
+In a Ktor server, the call ID can then be retrieved from the header using the [retrieve](call-id.md#retrieve) functions
+from the [CallId plugin for the server](call-id.md).
+
+ ```kotlin
+ ```
+
+{src="snippets/client-call-id/src/main/kotlin/com/example/CallIdService.kt" include-lines="26-27,30"}
+
+In this way the Ktor server retrieves the ID of the specified header of the request and applies it to the `callId`
+property of the call.
+
+For the full example,
+see [client-call-id](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-call-id)

--- a/topics/client_call_id.md
+++ b/topics/client_call_id.md
@@ -14,7 +14,11 @@
 <include from="lib.topic" element-id="download_example"/>
 </tldr>
 
-The CallId plugin allows you to trace client requests end-to-end by using unique call IDs. It is particularly useful
+<link-summary>
+The %plugin_name% client plugin allows you to trace client requests by using unique call IDs.
+</link-summary>
+
+The %plugin_name% plugin allows you to trace client requests end-to-end by using unique call IDs. It is particularly useful
 in microservice architectures to keep track of calls, regardless of how many services a request goes through.
 
 A calling scope might already have a call ID in its coroutine context. By default, the plugin uses the current context
@@ -41,12 +45,14 @@ it to the call context.
 Generate a call ID for a specific request in one of the following ways:
 
 * The `useCoroutineContext` property, enabled by default, adds a generator that uses the current `CoroutineContext` to
-  retrieve a call ID.
+  retrieve a call ID. To disable this functionality, set `useCoroutineContext` to `false`:
 
  ```kotlin
  ```
 
-{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="14-15,19"}
+{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="14,29,32"}
+
+> In a Ktor server, use the [CallId plugin](call-id.md) to add a call ID to the `CoroutineContext`.
 
 * The `generate()` function allows you to generate a call ID for an outgoing request. If it fails to generate a call ID,
   it returns `null`.
@@ -54,7 +60,7 @@ Generate a call ID for a specific request in one of the following ways:
  ```kotlin
  ```
 
-{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="14,16,19"}
+{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="14,15,18"}
 
 You can use multiple methods to generate a call ID. In this way, the first non-null value will be applied.
 
@@ -67,7 +73,7 @@ After you retrieve a call ID, you have the following options available to add it
  ```kotlin
  ```
 
-{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="14,18,19"}
+{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="14,17,18"}
 
 * The `addToHeader()` function adds a call ID to a specified header. It takes a header as a parameter, which defaults
   to `HttpHeaders.XRequestId`.
@@ -75,7 +81,7 @@ After you retrieve a call ID, you have the following options available to add it
  ```kotlin
  ```
 
-{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="14,17,19"}
+{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="14,16,18"}
 
 ## Example
 
@@ -85,7 +91,7 @@ it to the header:
  ```kotlin
  ```
 
-{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="13-21"}
+{src="snippets/client-call-id/src/main/kotlin/com/example/Application.kt" include-lines="13-20"}
 
 The plugin uses the coroutine context to get a call ID and utilizes the `generate()` function to generate a new one. The
 first non-null call ID is then applied to the request header using the `addToHeader()` function and to the request query
@@ -97,7 +103,7 @@ from the [CallId plugin for the server](call-id.md).
  ```kotlin
  ```
 
-{src="snippets/client-call-id/src/main/kotlin/com/example/CallIdService.kt" include-lines="26-27,30"}
+{src="snippets/client-call-id/src/main/kotlin/com/example/CallIdService.kt" include-lines="25-26,29"}
 
 In this way the Ktor server retrieves the ID of the specified header of the request and applies it to the `callId`
 property of the call.

--- a/topics/client_call_id.md
+++ b/topics/client_call_id.md
@@ -18,13 +18,14 @@
 The %plugin_name% client plugin allows you to trace client requests by using unique call IDs.
 </link-summary>
 
-The %plugin_name% plugin allows you to trace client requests end-to-end by using unique call IDs. It is particularly useful
-in microservice architectures to keep track of calls, regardless of how many services a request goes through.
+The %plugin_name% plugin allows you to trace client requests end-to-end by using unique call IDs. It is particularly
+useful in microservice architectures to keep track of calls, regardless of how many services a request goes through.
 
 A calling scope might already have a call ID in its coroutine context. By default, the plugin uses the current context
 to retrieve a call ID and adds it to the context of the specific call using the `HttpHeaders.XRequestId` header.
 
-Additionally, if a scope comes without a call ID, you can configure the plugin to generate and apply a new call ID.
+Additionally, if a scope comes without a call ID, you can [configure the plugin](#configure) to generate and apply a new
+call ID.
 
 ## Add dependencies {id="add_dependencies"}
 

--- a/v.list
+++ b/v.list
@@ -4,7 +4,7 @@
 
 <vars>
 
-    <var name="ktor_version" value="3.0.0-eap-800"/>
+    <var name="ktor_version" value="3.0.0-eap-808"/>
     <var name="kotlin_version" value="1.8.0"/>
     <var name="coroutines_version" value="1.6.4"/>
     <var name="kotlin_css_version" value="1.0.0-pre.625"/>


### PR DESCRIPTION
[KTOR-6156](https://youtrack.jetbrains.com/issue/KTOR-6156/Documentation-for-CallId-Feature-for-Client)
- added documentation for CallId client plugin
- created a new code snippet with example. The example uses a Ktor server to demonstrate how call ID is transferred between multiple calls
- added a link summary to the CallId server plugin doc 