### PR TITLE
There is no SOCKS proxy support on Darwin.

### DIFF
--- a/topics/proxy.md
+++ b/topics/proxy.md
@@ -18,9 +18,10 @@ The table below shows supported proxy types for specific [engines](http-client_e
 | Android    | ✅          |   ✅         |
 | OkHttp     | ✅          |   ✅         |
 | JavaScript | ✖️          |   ✖️         |
-| Darwin     | ✅          |   ✅         |
+| Darwin     | ✅          |   ✖️          |
 | Curl       | ✅          |   ✅         |
 
+* Note that HTTPS proxy is not supported on Darwin due to [KTOR-4737](https://youtrack.jetbrains.com/issue/KTOR-4737)
 
 ## Add dependencies {id="add_dependencies"}
 


### PR DESCRIPTION
See [ProxySupportCommon.kt#L21](https://github.com/ktorio/ktor/blob/491acd80bda5196a93b418d111ccda5da347fb0a/ktor-client/ktor-client-darwin/darwin/src/io/ktor/client/engine/darwin/ProxySupportCommon.kt#L21), SOCKS not supported by Darwin.