### PR TITLE
KTOR-6380 update native server support for DefaultHeaders

### DIFF
--- a/topics/default_headers.md
+++ b/topics/default_headers.md
@@ -11,7 +11,7 @@
 <p>
 <b>Required dependencies</b>: <code>io.ktor:%artifact_name%</code>
 </p>
-<include from="lib.topic" element-id="native_server_not_supported"/>
+<include from="lib.topic" element-id="native_server_supported"/>
 </tldr>
 
 The [%plugin_name%](%plugin_api_link%) plugin adds the standard `Server` and `Date` headers into each response. Moreover, you can provide additional default headers and override the `Server` header.


### PR DESCRIPTION
[KTOR-6380](https://youtrack.jetbrains.com/issue/KTOR-6380/Documentation-for-Make-DefaultHeaders-plugin-Kotlin-native-compatible)