### PR TITLE
KTOR-4118 and KTOR-6414 Update plugin dependencies that have the "-jvm" suffix

### DIFF
--- a/codeSnippets/snippets/tutorial-http-api/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-http-api/build.gradle.kts
@@ -19,10 +19,10 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-content-negotiation:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
+    implementation("io.ktor:ktor-server-core-jvm")
+    implementation("io.ktor:ktor-server-content-negotiation-jvm")
+    implementation("io.ktor:ktor-serialization-kotlinx-json-jvm")
+    implementation("io.ktor:ktor-server-netty-jvm")
     implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation("io.ktor:ktor-server-test-host:$ktor_version")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")

--- a/codeSnippets/snippets/tutorial-website-static/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-website-static/build.gradle.kts
@@ -18,10 +18,10 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-freemarker:$ktor_version")
+    implementation("io.ktor:ktor-server-core-jvm")
+    implementation("io.ktor:ktor-server-freemarker-jvm")
+    implementation("io.ktor:ktor-server-netty-jvm")
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host:$ktor_version")
+    testImplementation("io.ktor:ktor-server-tests-jvm")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
 }

--- a/codeSnippets/snippets/tutorial-website-static/src/main/kotlin/com/example/plugins/Routing.kt
+++ b/codeSnippets/snippets/tutorial-website-static/src/main/kotlin/com/example/plugins/Routing.kt
@@ -6,8 +6,6 @@ import io.ktor.server.routing.*
 
 fun Application.configureRouting() {
     routing {
-        static("/static") {
-            resources("files")
-        }
+        staticResources("/static", "files")
     }
 }

--- a/codeSnippets/snippets/tutorial-websockets-server/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-websockets-server/build.gradle.kts
@@ -18,10 +18,10 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-websockets:$ktor_version")
+    implementation("io.ktor:ktor-server-core-jvm")
+    implementation("io.ktor:ktor-server-websockets-jvm")
+    implementation("io.ktor:ktor-server-netty-jvm")
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host:$ktor_version")
+    testImplementation("io.ktor:ktor-server-tests-jvm")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
 }

--- a/topics/creating_http_apis.md
+++ b/topics/creating_http_apis.md
@@ -68,13 +68,13 @@ First, let's open the `build.gradle.kts` file and examine added dependencies:
 
 Let's briefly go through these dependencies one by one:
 
-- `ktor-server-core` adds Ktor's core components to our project.
-- `ktor-server-netty` adds the Netty [engine](Engines.md) to our project, allowing us to use server functionality without having to rely on an external application container.
-- `ktor-server-content-negotiation` and `ktor-serialization-kotlinx-json` provide a convenient mechanism for converting Kotlin objects into a [serialized form](serialization.md) like JSON, and vice versa. We will use it to format our APIs output, and to consume user input that is structured in JSON. In order to use `ktor-serialization-kotlinx-json`, we also have to apply the `plugin.serialization` plugin.
+- `ktor-server-core-jvm` adds Ktor's core components to our project.
+- `ktor-server-content-negotiation-jvm` and `ktor-serialization-kotlinx-json-jvm` provide a convenient mechanism for converting Kotlin objects into a [serialized form](serialization.md) like JSON, and vice versa. We will use it to format our APIs output, and to consume user input that is structured in JSON. In order to use `ktor-serialization-kotlinx-json`, we also have to apply the `plugin.serialization` plugin.
    ```kotlin
    ```
    {src="snippets/tutorial-http-api/build.gradle.kts" include-lines="5,9-10"}
 
+- `ktor-server-netty-jvm` adds the Netty [engine](Engines.md) to our project, allowing us to use server functionality without having to rely on an external application container.
 - `logback-classic` provides an implementation of SLF4J, allowing us to see nicely formatted [logs](logging.md) in a console.
 - `ktor-server-test-host` and `kotlin-test-junit` allow us to [test](Testing.md) parts of our Ktor application without having to use the whole HTTP stack in the process. We will use this to define unit tests for our project.
 

--- a/topics/creating_static_website.md
+++ b/topics/creating_static_website.md
@@ -69,11 +69,11 @@ First, let's open the `build.gradle.kts` file and examine added dependencies:
 
 Let's briefly go through these dependencies one by one:
 
-- `ktor-server-core` adds Ktor's core components to our project.
-- `ktor-server-netty` adds the Netty [engine](Engines.md) to our project, allowing us to use server functionality without having to rely on an external application container.
-- `ktor-server-freemarker` allows us to use the [FreeMarker](freemarker.md) template engine, which we'll use to create the main page of our journal.
+- `ktor-server-core-jvm` adds Ktor's core components to our project.
+- `ktor-server-freemarker-jvm` allows us to use the [FreeMarker](freemarker.md) template engine, which we'll use to create the main page of our journal.
+- `ktor-server-netty-jvm` adds the Netty [engine](Engines.md) to our project, allowing us to use server functionality without having to rely on an external application container.
 - `logback-classic` provides an implementation of SLF4J, allowing us to see nicely formatted [logs](logging.md) in a console.
-- `ktor-server-test-host` and `kotlin-test-junit` allow us to [test](Testing.md) parts of our Ktor application without having to use the whole HTTP stack in the process.
+- `ktor-server-test-jvm` and `kotlin-test-junit` allow us to [test](Testing.md) parts of our Ktor application without having to use the whole HTTP stack in the process.
 
 ### Configurations: application.conf and logback.xml {id="configurations"}
 
@@ -119,13 +119,13 @@ Before we dive into making a _[dynamic](creating_interactive_website.md)_ applic
 
 1. Create the `files` directory inside `src/main/resources`.
 2. Download the [ktor_logo.png](https://github.com/ktorio/ktor-documentation/blob/%ktor_version%/codeSnippets/snippets/tutorial-website-static/src/main/resources/files/ktor_logo.png) image file and add it to the created `files` folder.
-3. To serve static content, we can use a specific routing function already built into Ktor named [static](Serving_Static_Content.md). The function takes two parameters: the route under which the static content should be made available, and a lambda where we can define the location from where the content should be served.
+3. To serve static content, we can use a specific routing function already built into Ktor named [staticResources](Serving_Static_Content.md). The function takes two parameters: the route under which the static content should be made available, and a lambda where we can define the location from where the content should be served.
 
    In the `plugins/Routing.kt` file, let's change the implementation for `Application.configureRouting()` to look like this:
 
    ```kotlin
    ```
-   {src="snippets/tutorial-website-static/src/main/kotlin/com/example/plugins/Routing.kt" include-lines="3-13"}
+   {src="snippets/tutorial-website-static/src/main/kotlin/com/example/plugins/Routing.kt" include-lines="3-11"}
 
    This instructs Ktor that everything under the URL `/static` should be served using the `files` directory inside `resources`.
 

--- a/topics/creating_web_socket_chat.md
+++ b/topics/creating_web_socket_chat.md
@@ -101,15 +101,15 @@ First, open the `build.gradle.kts` file and examine the added dependencies:
 
 {src="snippets/tutorial-websockets-server/build.gradle.kts" include-lines="20-23,25-27"}
 
-- `ktor-server-core` adds Ktor's core components to the project.
-- `ktor-server-netty` adds the Netty [engine](Engines.md) to the project, allowing you to use server functionality
-  without having to rely on an external application container.
-- `ktor-server-websockets` allows you to use the [WebSocket plugin](websocket.md), the main communication mechanism for
+- `ktor-server-core-jvm` adds Ktor's core components to the project.
+- `ktor-server-websockets-jvm` allows you to use the [WebSocket plugin](websocket.md), the main communication mechanism for
   the chat.
+- `ktor-server-netty-jvm` adds the Netty [engine](Engines.md) to the project, allowing you to use server functionality
+  without having to rely on an external application container.
 
 [//]: # (- `logback-classic` provides an implementation of SLF4J, allowing you to see nicely formatted [logs]&#40;logging.md&#41; in a console.)
 
-- `ktor-server-test-host` and `kotlin-test-junit` allow you to [test](Testing.md) parts of your Ktor application without
+- `ktor-server-tests-jvm` and `kotlin-test-junit` allow you to [test](Testing.md) parts of your Ktor application without
   having to use the whole HTTP stack in the process.
 
 ### Configurations: application.conf and logback.xml {id="configurations"}


### PR DESCRIPTION
[KTOR-4118](https://youtrack.jetbrains.com/issue/KTOR-4118/The-generator-adds-the-jvm-suffix-to-all-dependencies)

Affected topics:
Creating HTTP APIs
- updated dependencies and list order in topic

Creating a static website
- updated dependencies and list order in topic
- replaced `static` function with `staticResources` ([KTOR-6414](https://youtrack.jetbrains.com/issue/KTOR-6414/Web-feedback-from-Creating-a-static-website-https-ktor.io-docs-creating-static-website.html))

Creating a Websocket chat
- updated dependencies and list order in topic