### PR TITLE
KTOR-6449 Document backward compatibility for new session encryption

### DIFF
--- a/topics/migrating-3.md
+++ b/topics/migrating-3.md
@@ -68,3 +68,32 @@ fun Application.module() {
 </tabs>
 
 For more information on working with `Resources`, refer to [](type-safe-routing.md).
+
+### Session encryption method update
+
+The encryption method offered by the `Sessions` plugin has been updated to enhance
+security.
+
+Specifically, the `SessionTransportTransformerEncrypt` method, which previously derived the MAC from the decrypted
+session value, now computes it from the encrypted value.
+
+To ensure compatibility with existing sessions, Ktor has introduced the `backwardCompatibleRead` property. For current
+configurations, include the property in the constructor
+of `SessionTransportTransformerEncrypt`:
+
+```kotlin
+install(Sessions) {
+  cookie<UserSession>("user_session") {
+    // ...
+    transform(
+      SessionTransportTransformerEncrypt(
+        secretEncryptKey, // your encrypt key here
+        secretSignKey, // your sign key here
+        backwardCompatibleRead = true
+      )
+    )
+  }
+}
+```
+
+For more information on session encryption in Ktor, see [](sessions.md#sign_encrypt_session).

--- a/topics/sessions.md
+++ b/topics/sessions.md
@@ -182,7 +182,14 @@ To sign and encrypt a session, pass a sign/encrypt keys to the `SessionTransport
 
 ```kotlin
 ```
+
 {src="snippets/session-cookie-client/src/main/kotlin/cookieclient/Application.kt" include-lines="12-20"}
+
+> Note that the [encryption method has been updated](migrating-3.md#session-encryption-method-update) in Ktor
+> version `3.0.0`. If you are migrating from an earlier version, use the `backwardCompatibleRead` property in the
+> constructor of `SessionTransportTransformerEncrypt` to ensure compatibility with existing sessions.
+>
+{style="note"}
 
 By default, `SessionTransportTransformerEncrypt` uses the `AES` and `HmacSHA256` algorithms, which can be changed. 
 


### PR DESCRIPTION
[KTOR-6449](https://youtrack.jetbrains.com/issue/KTOR-6449/Document-backward-compatibility-for-new-session-encryption)

Document changes in the session encryption method:

- add a new section in the Migration guide ([preview](https://writerside.labs.jb.gg/staging/staging/ktor/3.0.0/migrating-3.html#session-encryption-method-update))
- add a note to the Sessions topic ([preview](https://writerside.labs.jb.gg/staging/staging/ktor/3.0.0/sessions.html#sign_encrypt_session
))
