### PR TITLE
KTOR-6483 fix outdated code snippets from gradle.properties

### DIFF
--- a/topics/connection-pooling-caching.md
+++ b/topics/connection-pooling-caching.md
@@ -23,7 +23,7 @@ Open the `gradle.properties` file and specify library versions:
 
 ```kotlin
 ```
-{src="gradle.properties" include-lines="20-21"}
+{src="gradle.properties" include-lines="16-17"}
 
 Then, open `build.gradle.kts` and add the following dependencies:
 

--- a/topics/docker-compose.md
+++ b/topics/docker-compose.md
@@ -22,7 +22,7 @@ First, you need to add dependencies for the PostgreSQL library. Open the `gradle
 
 ```kotlin
 ```
-{src="gradle.properties" include-lines="19"}
+{src="gradle.properties" include-lines="15"}
 
 Then, open `build.gradle.kts` and add the following dependencies:
 

--- a/topics/interactive_website_add_persistence.md
+++ b/topics/interactive_website_add_persistence.md
@@ -25,7 +25,7 @@ First, you need to add dependencies for the Exposed and H2 libraries. Open the `
 
 ```kotlin
 ```
-{src="gradle.properties" include-lines="17-18"}
+{src="gradle.properties" include-lines="13-14"}
 
 Then, open `build.gradle.kts` and add the following dependencies:
 


### PR DESCRIPTION
[KTOR-6483](https://youtrack.jetbrains.com/issue/KTOR-6483/Web-feedback-Incorrect-code-snippet-displayed-in-Database-persistence-with-Exposed)

The `gradle.properties` file had changed some time ago and the code snippets were not updated in the following topics:
- Database persistence with Exposed (https://ktor.shared.aws.intellij.net/docs/interactive-website-add-persistence.html#add-dependencies)
- Connection pooling and caching (https://ktor.shared.aws.intellij.net/docs/connection-pooling-caching.html#add-dependencies)
- Docker Compose (https://ktor.shared.aws.intellij.net/docs/docker-compose.html#add_dependencies)