### PR TITLE
KTOR-6521 restructure the welcome page

### DIFF
--- a/ktor.tree
+++ b/ktor.tree
@@ -2,9 +2,9 @@
 <!DOCTYPE instance-profile
         SYSTEM "https://helpserver.labs.jb.gg/help/schemas/mvp/product-profile.dtd">
 <instance-profile id="ktor"
-                 name="Ktor"
-                 status="release"
-                 start-page="welcome.topic">
+                  name="Ktor"
+                  status="release"
+                  start-page="welcome.topic">
 
     <toc-element topic="welcome.topic"
                  accepts-web-file-names-ref="kotlin_docs"/>
@@ -267,7 +267,8 @@
 
     <toc-element topic="FAQ.topic"
                  accepts-web-file-names="zfaq.html"/>
-
+    <toc-element toc-title="API Documentation" href="https://api.ktor.io/"/>
+    <toc-element toc-title="Community Resources" href="https://github.com/mjovanc/awesome-ktor"/>
     <toc-element hidden="true" accepts-web-file-names="generator.html"
                  target-for-accept-web-file-names="https://start.ktor.io/"/>
     <toc-element hidden="true" accepts-web-file-names-ref="samples"

--- a/topics/Auto_reload.topic
+++ b/topics/Auto_reload.topic
@@ -15,7 +15,7 @@
     </tldr>
 
     <link-summary>
-        Ktor allows you to use Auto-reload to reload application classes on code changes.
+        Learn how to use Auto-reload to reload application classes on code changes.
     </link-summary>
 
     <p>

--- a/topics/Configuration-code.topic
+++ b/topics/Configuration-code.topic
@@ -9,8 +9,7 @@
     <show-structure for="chapter"/>
 
     <link-summary>
-        This topic describes how to configure various server parameters in code.
-        Server parameters include a host address and port, modules to load, and so on.
+        Learn how to configure various server parameters in code.
     </link-summary>
 
     <p>

--- a/topics/Configuration-file.topic
+++ b/topics/Configuration-file.topic
@@ -9,8 +9,7 @@
     <show-structure for="chapter" depth="2"/>
 
     <link-summary>
-        This topic describes how to configure various server parameters in a configuration file.
-        Server parameters include a host address and port, modules to load, and so on.
+        Learn how to configure various server parameters in a configuration file.
     </link-summary>
 
     <p>

--- a/topics/Graalvm.md
+++ b/topics/Graalvm.md
@@ -8,8 +8,11 @@
 </p>
 </tldr>
 
-<link-summary>
+<web-summary>
 Ktor Server applications can make use of GraalVM in order to have native images for different platforms.
+</web-summary>
+<link-summary>
+Learn how to use GraalVM for native images on different platforms.
 </link-summary>
 
 Ktor Server applications can make use of [GraalVM](https://graalvm.org) in order to have native images for different platforms, and of course, take advantage of the faster start-up times and other benefits that GraalVM provides.

--- a/topics/Plugins.md
+++ b/topics/Plugins.md
@@ -3,7 +3,7 @@
 <show-structure for="chapter" depth="2"/>
 
 <link-summary>
-Plugins provide common functionality, for example, serialization and content encoding, compression, headers, cookie support, etc.
+Plugins provide common functionality, such as serialization, content encoding, compression, and so on.
 </link-summary>
 
 A typical request/response pipeline in Ktor looks like the following:

--- a/topics/Routing_in_Ktor.md
+++ b/topics/Routing_in_Ktor.md
@@ -2,7 +2,9 @@
 
 <show-structure for="chapter" depth="2"/>
 
-<link-summary>Routing is the core Ktor plugin for handling incoming requests in a server application.</link-summary>
+<link-summary>
+Routing is a core plugin for handling incoming requests in a server application.
+</link-summary>
 
 Routing is the core Ktor [plugin](Plugins.md) for handling incoming requests in a server application. When the client makes a request to a specific URL (for example, `/hello`), the routing mechanism allows us to define how we want this request to be served. 
 

--- a/topics/Serving_Static_Content.md
+++ b/topics/Serving_Static_Content.md
@@ -10,7 +10,7 @@
 </tldr>
 
 <link-summary>
-Ktor allows you to serve static files, such as stylesheets, scripts, images, and so on.
+Learn how to serve static content, such as stylesheets, scripts, images, and so on.
 </link-summary>
 
 Whether we're creating a website or an HTTP endpoint, many applications need to serve files (such as stylesheets, scripts, images, etc.). 

--- a/topics/Templating.md
+++ b/topics/Templating.md
@@ -1,6 +1,6 @@
 [//]: # (title: Templating)
 
-<link-summary>Ktor provides different ways for working with views: you can build HTML/CSS using Kotlin DSL, or you can choose between JVM template engines, such as FreeMarker, Velocity, and so on.</link-summary>
+<link-summary>Learn how to work with views built with HTML/CSS or JVM template engines.</link-summary>
 
 Ktor provides different ways for working with views: you can build HTML/CSS using Kotlin DSL, or you can choose between JVM template engines, such as FreeMarker, Velocity, and so on. 
 * [](html_dsl.md)

--- a/topics/Testing.md
+++ b/topics/Testing.md
@@ -9,7 +9,7 @@
 </tldr>
 
 <link-summary>
-Learn how to test server Ktor applications using a special testing engine.
+Learn how to test your server application using a special testing engine.
 </link-summary>
 
 Ktor provides a special testing engine that doesn't create a web server, doesn't bind to sockets, and doesn't make any real HTTP requests. Instead, it hooks directly into internal mechanisms and processes an application call directly. This results in quicker tests execution compared to running a complete web server for testing. 

--- a/topics/authentication.md
+++ b/topics/authentication.md
@@ -13,7 +13,7 @@
 </tldr>
 
 <link-summary>
-The Authentication plugin handles authentication and authorization in Ktor: logging in users, granting access to specific resources, etc.
+The Authentication plugin handles authentication and authorization in Ktor.
 </link-summary>
 
 Ktor provides the [Authentication](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-authentication/index.html) plugin to handle authentication and authorization. Typical usage scenarios include logging in users, granting access to specific resources, and securely transmitting information between parties. You can also use `Authentication` with [Sessions](sessions.md) to keep a user's information between requests.

--- a/topics/client-caching.md
+++ b/topics/client-caching.md
@@ -6,7 +6,7 @@
 </tldr>
 
 <link-summary>
-The HttpCache allows you to save previously fetched resources in an in-memory or persistent cache.
+The HttpCache plugin allows you to save previously fetched resources in an in-memory or persistent cache.
 </link-summary>
 
 The Ktor client provides the [HttpCache](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.plugins.cache/-http-cache/index.html) plugin that allows you to save previously fetched resources in an in-memory or persistent cache.

--- a/topics/client-custom-plugins.md
+++ b/topics/client-custom-plugins.md
@@ -7,6 +7,10 @@
 <include from="lib.topic" element-id="download_example"/>
 </tldr>
 
+<link-summary>
+Learn how to create your own custom client plugin.
+</link-summary>
+
 Starting with v2.2.0, Ktor provides a new API for creating custom client [plugins](http-client_plugins.md). In general, this API doesn't require an understanding of internal Ktor concepts, such as pipelines, phases, and so on. 
 Instead, you have access to different stages of [handling requests and responses](#call-handling) using a set of handlers, such as `onRequest`, `onResponse`, and so on.
 

--- a/topics/client-dependencies.md
+++ b/topics/client-dependencies.md
@@ -2,7 +2,7 @@
 
 <show-structure for="chapter" depth="2"/>
 
-<link-summary>Learn how to add client dependencies to the existing project.</link-summary>
+<link-summary>Learn how to add client dependencies to an existing project.</link-summary>
 
 To use the Ktor HTTP client in your project, you need to [configure repositories](#repositories) and add the following
 dependencies:

--- a/topics/client_retry.md
+++ b/topics/client_retry.md
@@ -8,7 +8,7 @@
 </tldr>
 
 <link-summary>
-The `HttpRequestRetry` plugin allows you to configure the retry policy for failed requests in various ways: specify the number of retries, configure conditions for retrying a request, or specify delay logic.
+The HttpRequestRetry plugin allows you to configure the retry policy for failed requests.
 </link-summary>
 
 By default, the Ktor client doesn't retry [requests](request.md) that failed due to network or server errors.

--- a/topics/create-client.md
+++ b/topics/create-client.md
@@ -2,7 +2,7 @@
 
 <show-structure for="chapter" depth="2"/>
 
-<link-summary>Learn how to create and configure the Ktor client.</link-summary>
+<link-summary>Learn how to create and configure a Ktor client.</link-summary>
 
 After adding the [client dependencies](client-dependencies.md), you can instantiate the client by creating the [HttpClient](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client/-http-client/index.html) class instance and passing an [engine](http-client_engines.md) as a parameter:
 

--- a/topics/create_server.topic
+++ b/topics/create_server.topic
@@ -18,7 +18,7 @@
     </tldr>
 
     <link-summary>
-        Choose how to create a Ktor server - using the 'embeddedServer' function to configure parameters in code or using 'EngineMain' to load server configuration from an external file.
+        Learn how to create a server depending on your application deployment needs.
     </link-summary>
 
     <p>

--- a/topics/custom_plugins.md
+++ b/topics/custom_plugins.md
@@ -7,6 +7,10 @@
 <include from="lib.topic" element-id="download_example"/>
 </tldr>
 
+<link-summary>
+Learn how to create your own custom plugins.
+</link-summary>
+
 Starting with v2.0.0, Ktor provides a new API for creating custom [plugins](Plugins.md). In general, this API doesn't require an understanding of internal Ktor concepts, such as pipelines, phases, and so on. Instead, you have access to different stages of [handling requests and responses](#call-handling) using the `onCall`, `onCallReceive`, and `onCallRespond` handlers.
 
 > The API described in this topic is in effect for v2.0.0 and higher. For the old versions, you can use the [base API](custom_plugins-base-api.md).

--- a/topics/docker.md
+++ b/topics/docker.md
@@ -7,8 +7,12 @@
 <include from="lib.topic" element-id="download_example"/>
 </tldr>
 
-<link-summary>
+<web-summary>
 Learn how to deploy a Ktor application to a Docker container, which can then be run either locally or on your cloud provider of choice.
+</web-summary>
+
+<link-summary>
+Learn how to deploy your application to a Docker container.
 </link-summary>
 
 In this section, we'll see how to use the [Ktor Gradle plugin](https://github.com/ktorio/ktor-build-plugins) for packaging, running, and deploying applications using [Docker](https://www.docker.com).

--- a/topics/google-app-engine.md
+++ b/topics/google-app-engine.md
@@ -11,8 +11,12 @@
 </p>
 </tldr>
 
-<link-summary>
+<web-summary>
 This tutorial shows how to prepare and deploy a Ktor project to a Google App Engine standard environment.
+</web-summary>
+
+<link-summary>
+Learn how to deploy your project to a Google App Engine standard environment.
 </link-summary>
 
 In this tutorial, we'll show you how to prepare and deploy a Ktor project to a Google App Engine standard environment. This tutorial uses the [engine-main](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main) sample project as a starting project.

--- a/topics/http-client_testing.md
+++ b/topics/http-client_testing.md
@@ -12,8 +12,12 @@
 <include from="lib.topic" element-id="download_example"/>
 </tldr>
 
-<link-summary>
+<web-summary>
 Ktor provides a MockEngine that simulates HTTP calls without connecting to the endpoint.
+</web-summary>
+
+<link-summary>
+Learn how to test your client with MockEngine by simulating HTTP calls.
 </link-summary>
 
 Ktor provides a [MockEngine](https://api.ktor.io/ktor-client/ktor-client-mock/io.ktor.client.engine.mock/-mock-engine/index.html) that simulates HTTP calls without connecting to the endpoint.

--- a/topics/intellij-idea.topic
+++ b/topics/intellij-idea.topic
@@ -11,7 +11,7 @@
         <include from="lib.topic" element-id="download_example"/>
     </tldr>
 
-    <link-summary>This guide shows how to create, run, and test a simple Ktor application.</link-summary>
+    <link-summary>Create, run, and test your first Ktor server application.</link-summary>
 
     <p>
         Ktor is an asynchronous framework for creating microservices, web applications, and more.

--- a/topics/openapi.md
+++ b/topics/openapi.md
@@ -13,6 +13,10 @@
 <include from="lib.topic" element-id="native_server_not_supported"/>
 </tldr>
 
+<link-summary>
+The OpenAPI plugin allows you to generate OpenAPI documentation for your project.
+</link-summary>
+
 Ktor allows you to generate and serve OpenAPI documentation for your project based on the existing OpenAPI specification.
 
 <include from="swagger-ui.md" element-id="open-api-note"/>

--- a/topics/requests.md
+++ b/topics/requests.md
@@ -2,7 +2,7 @@
 
 <show-structure for="chapter" depth="2"/>
 
-<link-summary>Learn how to handle incoming requests inside route handlers: get request information, receive body contents, etc.</link-summary>
+<link-summary>Learn how to handle incoming requests inside route handlers.</link-summary>
 
 Ktor allows you to handle incoming requests and send [responses](responses.md) inside [route handlers](Routing_in_Ktor.md#define_route). You can perform various actions when handling requests:
 * Get [request information](#request_information), such as headers, cookies, and so on.

--- a/topics/response-validation.md
+++ b/topics/response-validation.md
@@ -10,7 +10,7 @@
 </tldr>
 
 <link-summary>
-Ktor allows you to validate a response depending on its status code.
+Learn how to validate a response depending on its status code.
 </link-summary>
 
 By default, Ktor doesn't validate a [response](response.md) depending on its status code.

--- a/topics/response.md
+++ b/topics/response.md
@@ -3,7 +3,7 @@
 <show-structure for="chapter" depth="2"/>
 
 <link-summary>
-Learn how to receive responses: get a response body in various ways (raw bytes, JSON objects, etc.) and obtain response parameters (a status code, content type, etc.).
+Learn how to receive responses, get a response body and obtain response parameters.
 </link-summary>
 
 All functions used to [make an HTTP request](request.md) (`request`, `get`, `post`, etc.) allow you to receive a response as an [HttpResponse](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.statement/-http-response/index.html) object. `HttpResponse` exposes the API required to get a [response body](#body) in various ways (raw bytes, JSON objects, etc.) and obtain [response parameters](#parameters), such as a status code, content type, headers, and so on. For example, you can receive `HttpResponse` for a `GET` request without parameters as follows:

--- a/topics/responses.md
+++ b/topics/responses.md
@@ -2,7 +2,7 @@
 
 <show-structure for="chapter" depth="2"/>
 
-<link-summary>Learn how to send different types of responses: plain text, HTML documents and templates, serialized data objects, and so on.</link-summary>
+<link-summary>Learn how to send different types of responses.</link-summary>
 
 Ktor allows you to handle incoming [requests](requests.md) and send responses inside [route handlers](Routing_in_Ktor.md#define_route). You can send different types of responses: plain text, HTML documents and templates, serialized data objects, and so on. For each response, you can also configure various [response parameters](#parameters), such as a content type, headers, and cookies.
 

--- a/topics/server-dependencies.topic
+++ b/topics/server-dependencies.topic
@@ -8,7 +8,7 @@
 
     <show-structure for="chapter" depth="2"/>
 
-    <link-summary>Learn how to add Ktor dependencies to the existing Gradle/Maven project.</link-summary>
+    <link-summary>Learn how to add Ktor dependencies to an existing Gradle/Maven project.</link-summary>
 
     <p>
         In this topic, we'll show you how to add dependencies required for Ktor to the existing Gradle/Maven project.

--- a/topics/sessions.md
+++ b/topics/sessions.md
@@ -19,7 +19,7 @@
 </tldr>
 
 <link-summary>
-Sessions provide a mechanism to persist data between different HTTP requests. Typical use cases include storing a logged-in user's ID, the contents of a shopping basket, or keeping user preferences on the client.
+The Sessions plugin provides a mechanism to persist data between different HTTP requests.
 </link-summary>
 
 The [%plugin_name%](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-sessions/io.ktor.server.sessions/-sessions.html) plugin provides a mechanism to persist data between different HTTP requests. Typical use cases include storing a logged-in user's ID, the contents of a shopping basket, or keeping user preferences on the client. In Ktor, you can implement sessions by using cookies or custom headers, choose whether to store session data on the server or pass it to the client, sign and encrypt session data and more.

--- a/topics/swagger-ui.md
+++ b/topics/swagger-ui.md
@@ -13,6 +13,10 @@
 <include from="lib.topic" element-id="native_server_not_supported"/>
 </tldr>
 
+<link-summary>
+The SwaggerUI plugin allows you to generate Swagger UI for your project.
+</link-summary>
+
 Ktor allows you to generate and serve Swagger UI for your project based on the existing OpenAPI specification.
 With Swagger UI, you can visualize and interact with the API resources. 
 

--- a/topics/type-safe-routing.md
+++ b/topics/type-safe-routing.md
@@ -15,7 +15,7 @@
 <include from="lib.topic" element-id="native_server_supported"/>
 </tldr>
 
-<link-summary>Ktor provides the Resources plugin that allows you to implement type-safe routing.</link-summary>
+<link-summary>The Resources plugin allows you to implement type-safe routing.</link-summary>
 
 Ktor provides the [Resources](https://api.ktor.io/ktor-shared/ktor-resources/io.ktor.resources/-resources/index.html) plugin that allows you to implement type-safe [routing](Routing_in_Ktor.md). To accomplish this, you need to create a class that should act as a typed route and then annotate this class using the `@Resource` keyword. Note that the `@Resource` annotation has `@Serializable` behavior provided by the kotlinx.serialization library.
 

--- a/topics/welcome.topic
+++ b/topics/welcome.topic
@@ -42,6 +42,7 @@
             <links narrow="true">
                 <group>
                     <title>Server configuration</title>
+                    <a href="intellij-idea.topic"/>
                     <a href="server-dependencies.topic"/>
                     <a href="create_server.topic"/>
                     <a href="Configuration-code.topic"/>
@@ -97,6 +98,7 @@
             <links narrow="true">
                 <group>
                     <title>Client setup</title>
+                    <a href="getting_started_ktor_client.topic"/>
                     <a href="client-dependencies.md"/>
                     <a href="create-client.md"/>
                     <a href="http-client_engines.md"/>

--- a/topics/welcome.topic
+++ b/topics/welcome.topic
@@ -5,351 +5,129 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        title="Welcome"
        id="welcome">
+    <section-starting-page>
+        <title>Ktor Documentation</title>
+        <description>
+            Ktor is a framework for building asynchronous server-side and client-side applications with ease.
+        </description>
 
-    <img src="ktor_logo.svg" alt="Ktor logo" width="306" height="127"/>
-    <p>
-        Ktor is a framework to easily build connected applications – web applications, HTTP services, mobile and browser applications.
-        Modern connected applications need to be asynchronous to provide the best experience to users, and Kotlin coroutines provide
-        awesome facilities to do it in an easy and straightforward way.
-        The goal of Ktor is to provide an end-to-end multiplatform framework for connected applications.
-    </p>
+        <spotlight>
+            <a href="intellij-idea.topic" type="server"
+               summary="Learn how to create, run and test a server application with Ktor.">
+                Get started with Ktor Server
+            </a>
+            <a href="getting_started_ktor_client.topic" type="cross-platform"
+               summary="Learn how to create, run and test a client application with Ktor.">
+                Get started with Ktor Client
+            </a>
+        </spotlight>
 
-    <tabs>
-        <tab title="Ktor Server">
-            <list columns="2">
-                <li>
-                    <p>
-                        <b>
-                            Getting started
-                        </b>
-                    </p>
-                    <list style="none">
-                        <li>
-                            <p>
-                                <a href="intellij-idea.topic"/>
-                            </p>
-                        </li>
-                        <li>
-                            <p>
-                                <a href="creating_http_apis.md"/>
-                            </p>
-                        </li>
-                        <li>
-                            <p>
-                                <a href="creating_interactive_website.md"/>
-                            </p>
-                        </li>
-                        <li>
-                            <p>
-                                <a href="creating_web_socket_chat.md"/>
-                            </p>
-                        </li>
-                        <li>
-
-                        </li>
-                    </list>
-                </li>
-
-                <li>
-                    <p>
-                        <b>
-                            Configuring a server
-                        </b>
-                    </p>
-                    <list style="none">
-                        <li>
-                            <a href="server-dependencies.topic"/>
-                        </li>
-                        <li>
-                            <a href="create_server.topic"/>
-                        </li>
-                        <li>
-                            <a href="Configuration-code.topic">Configuring a server in code</a> or in a <a href="Configuration-file.topic">file</a>
-                        </li>
-                        <li>
-                            <a href="Plugins.md"/>
-                        </li>
-                        <li>
-
-                        </li>
-                    </list>
-                </li>
-
-                <li>
-                    <p>
-                        <b>
-                            Routing
-                        </b>
-                    </p>
-                    <list style="none">
-                        <li>
-                            <a href="Routing_in_Ktor.md"/>
-                        </li>
-                        <li>
-                            <a href="type-safe-routing.md"/>
-                        </li>
-                        <li>
-                            <a href="Structuring_Applications.md"/>
-                        </li>
-                        <li>
-                            <a href="requests.md"/>
-                        </li>
-                        <li>
-                            <a href="responses.md"/>
-                        </li>
-                        <li>
-                            <a href="Serving_Static_Content.md"/>
-                        </li>
-                        <li>
-
-                        </li>
-                    </list>
-                </li>
-
-                <li>
-                    <p>
-                        <b>
-                            Plugins
-                        </b>
-                    </p>
-                    <list style="none">
-                        <li>
-                            <a href="serialization.md"/>
-                        </li>
-                        <li>
-                            <a href="Templating.md"/>
-                        </li>
-                        <li>
-                            <a href="authentication.md"/>
-                        </li>
-                        <li>
-                            <a href="sessions.md"/>
-                        </li>
-                        <li>
-                            <a href="websocket.md"/>
-                        </li>
-                        <li>
-                            <a href="swagger-ui.md"/> / <a href="openapi.md"/>
-                        </li>
-                        <li>
-                            <a href="custom_plugins.md"/>
-                        </li>
-                        <li>
-
-                        </li>
-                    </list>
-                </li>
-
-                <li>
-                    <p>
-                        <b>
-                            Running, debugging, and testing
-                        </b>
-                    </p>
-                    <list style="none">
-                        <li>
-                            <a href="running.md"/>
-                        </li>
-                        <li>
-                            <a href="Auto_reload.topic"/>
-                        </li>
-                        <li>
-                            <a href="Testing.md"/>
-                        </li>
-                        <li>
-
-                        </li>
-                    </list>
-                </li>
-
-                <li>
-                    <p>
-                        <b>
-                            Deployment
-                        </b>
-                    </p>
-                    <list style="none">
-                        <li>
-                            <a href="fatjar.md">Creating Fat JARs</a>
-                        </li>
-                        <li>
-                            <a href="war.md"/>
-                        </li>
-                        <li>
-                            <a href="Graalvm.md"/>
-                        </li>
-                        <li>
-                            <a href="docker.md"/>
-                        </li>
-                        <li>
-                            <a href="google-app-engine.md"/>
-                        </li>
-                        <li>
-                            <a href="heroku.md"/>
-                        </li>
-                        <li>
-
-                        </li>
-                    </list>
-                </li>
-            </list>
-        </tab>
-        <tab title="Ktor Client">
-            <list columns="2">
-                <li>
-                    <p>
-                        <b>
-                            Getting started
-                        </b>
-                    </p>
-                    <list style="none">
-                        <li>
-                            <p>
-                                <a href="getting_started_ktor_client.topic"/>
-                            </p>
-                        </li>
-                        <li>
-                            <p>
-                                <a href="getting_started_ktor_client_chat.md"/>
-                            </p>
-                        </li>
-                        <li>
-                            <p>
-                                <a href="getting_started_ktor_client_multiplatform_mobile.md"/>
-                            </p>
-                        </li>
-                        <li>
-
-                        </li>
-                    </list>
-                </li>
-
-                <li>
-                    <p>
-                        <b>
-                            Setting up the client
-                        </b>
-                    </p>
-                    <list style="none">
-                        <li>
-                            <a href="client-dependencies.md"/>
-                        </li>
-                        <li>
-                            <a href="create-client.md"/>
-                        </li>
-                        <li>
-                            <a href="http-client_engines.md"/>
-                        </li>
-                        <li>
-                            <a href="http-client_plugins.md"/>
-                        </li>
-                        <li>
-
-                        </li>
-                    </list>
-                </li>
-
-                <li>
-                    <p>
-                        <b>
-                            Requests
-                        </b>
-                    </p>
-                    <list style="none">
-                        <li>
-                            <a href="request.md"/>
-                        </li>
-                        <li>
-                            <a href="type-safe-request.md"/>
-                        </li>
-                        <li>
-                            <a href="default-request.md"/>
-                        </li>
-                        <li>
-                            <a href="client_retry.md"/>
-                        </li>
-                        <li>
-
-                        </li>
-                    </list>
-                </li>
-
-                <li>
-                    <p>
-                        <b>
-                            Responses
-                        </b>
-                    </p>
-                    <list style="none">
-                        <li>
-                            <a href="response.md"/>
-                        </li>
-                        <li>
-                            <a href="response-validation.md"/>
-                        </li>
-                        <li>
-
-                        </li>
-                    </list>
-                </li>
-
-                <li>
-                    <p>
-                        <b>
-                            Plugins
-                        </b>
-                    </p>
-                    <list style="none">
-                        <li>
-                            <a href="serialization-client.md"/>
-                        </li>
-                        <li>
-                            <a href="auth.md"/>
-                        </li>
-                        <li>
-                            <a href="http-cookies.md"/>
-                        </li>
-                        <li>
-                            <a href="content-encoding.md"/>
-                        </li>
-                        <li>
-                            <a href="client-caching.md"/>
-                        </li>
-                        <li>
-                            <a href="websocket_client.md"/>
-                        </li>
-                        <li>
-                            <a href="client-custom-plugins.md"/>
-                        </li>
-                        <li>
-
-                        </li>
-                    </list>
-                </li>
-
-                <li>
-                    <p>
-                        <b>
-                            Testing
-                        </b>
-                    </p>
-                    <list style="none">
-                        <li>
-                            <a href="http-client_testing.md"/>
-                        </li>
-                        <li>
-
-                        </li>
-                    </list>
-                </li>
-            </list>
-        </tab>
-    </tabs>
-
-    <p>
-        <b><a href="https://api.ktor.io/">API Docs</a></b>
-    </p>
-    <p>
-        <b><a href="https://github.com/mjovanc/awesome-ktor">Community Resources</a></b>
-    </p>
+        <primary>
+            <title>Ktor Server</title>
+            <a href="creating_http_apis.md"
+               summary="Learn how routing and serialization work in Ktor by creating an HTTP API.">
+                Create an HTTP API
+            </a>
+            <a href="creating_interactive_website.md"
+               summary="Discover the process of turning a static website into an interactive one using the StaticContent and Freemarker plugins.">
+                Create an interactive website
+            </a>
+            <a href="creating_web_socket_chat.md"
+               summary="Create a chat application with the WebSockets plugin.">
+                Create a server chat application
+            </a>
+        </primary>
+        <secondary></secondary>
+        <misc>
+            <links narrow="true">
+                <group>
+                    <title>Server configuration</title>
+                    <a href="server-dependencies.topic"/>
+                    <a href="create_server.topic"/>
+                    <a href="Configuration-code.topic"/>
+                    <a href="Configuration-file.topic"/>
+                    <a href="Plugins.md"/>
+                </group>
+                <group>
+                    <title>Routing</title>
+                    <a href="Routing_in_Ktor.md"/>
+                    <a href="type-safe-routing.md"/>
+                    <a href="Structuring_Applications.md"/>
+                    <a href="requests.md"/>
+                    <a href="responses.md"/>
+                    <a href="Serving_Static_Content.md"/>
+                </group>
+                <group>
+                    <title>Plugins</title>
+                    <a href="serialization.md"/>
+                    <a href="Templating.md"/>
+                    <a href="authentication.md"/>
+                    <a href="sessions.md"/>
+                    <a href="websocket.md"/>
+                    <a href="swagger-ui.md"/> / <a href="openapi.md"/>
+                    <a href="custom_plugins.md"/>
+                </group>
+                <group>
+                    <title>Run, debug and test</title>
+                    <a href="running.md"/>
+                    <a href="Auto_reload.topic"/>
+                    <a href="Testing.md"/>
+                </group>
+                <group>
+                    <title>Deployment</title>
+                    <a href="fatjar.md">Creating Fat JARs</a>
+                    <a href="war.md"/>
+                    <a href="Graalvm.md"/>
+                    <a href="docker.md"/>
+                    <a href="google-app-engine.md"/>
+                    <a href="heroku.md"/>
+                </group>
+            </links>
+            <cards>
+                <title>Ktor Client</title>
+                <a href="getting_started_ktor_client_chat.md"
+                   summary="Create a console chat application with the WebSockets plugin.">
+                    Create a chat client application
+                </a>
+                <a href="getting_started_ktor_client_multiplatform_mobile.md"
+                   summary="Create a Kotlin Multiplatform Mobile application and learn how to make requests and receive responses with the Ktor Client.">
+                    Create a cross-platform mobile application
+                </a>
+            </cards>
+            <links narrow="true">
+                <group>
+                    <title>Client setup</title>
+                    <a href="client-dependencies.md"/>
+                    <a href="create-client.md"/>
+                    <a href="http-client_engines.md"/>
+                    <a href="http-client_plugins.md"/>
+                </group>
+                <group>
+                    <title>Requests</title>
+                    <a href="request.md"/>
+                    <a href="type-safe-request.md"/>
+                    <a href="default-request.md"/>
+                    <a href="client_retry.md"/>
+                </group>
+                <group>
+                    <title>Responses</title>
+                    <a href="response.md"/>
+                    <a href="response-validation.md"/>
+                </group>
+                <group>
+                    <title>Plugins</title>
+                    <a href="auth.md"/>
+                    <a href="http-cookies.md"/>
+                    <a href="content-encoding.md"/>
+                    <a href="client-caching.md"/>
+                    <a href="websocket_client.md"/>
+                    <a href="client-custom-plugins.md"/>
+                </group>
+                <group>
+                    <title>Testing</title>
+                    <a href="http-client_testing.md"/>
+                </group>
+            </links>
+        </misc>
+    </section-starting-page>
 </topic>


### PR DESCRIPTION
[KTOR-6521](https://youtrack.jetbrains.com/issue/KTOR-6521/Documentation-Restructuring-Welcome-page)
Preview: https://ktor.shared.aws.intellij.net/docs/welcome.html

Restructure the _Welcome_ page to use **starting-page-section** element from Writerside.
- updated title
- spotlight 'get started' guides
- tutorials stand out in **cards**
- external links have moved to the left-side navigation (will be moved to the footer in a separate PR)

This required some additional changes as the structure of this section is not very flexible, such as:
- shorter intro
- tabs are removed