### PR TITLE
KTOR-6588 Docs for: Change default session serializer to the one that uses kotlinx-serializaion

### DIFF
--- a/codeSnippets/gradle.properties
+++ b/codeSnippets/gradle.properties
@@ -5,10 +5,10 @@ kotlin.native.binary.memoryModel = experimental
 # gradle configuration
 org.gradle.configureondemand = false
 # versions
-kotlin_version = 1.9.20
-ktor_version = 3.0.0-beta-1
+kotlin_version = 1.9.22
+ktor_version = 3.0.0-beta-2-eap-884
 kotlinx_coroutines_version = 1.6.4
-kotlinx_serialization_version = 1.4.1
+kotlinx_serialization_version = 1.6.2
 kotlin_css_version = 1.0.0-pre.650
 exposed_version = 0.41.1
 h2_version = 2.2.224

--- a/codeSnippets/snippets/auth-form-session-nested/build.gradle.kts
+++ b/codeSnippets/snippets/auth-form-session-nested/build.gradle.kts
@@ -5,6 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
+    kotlin("plugin.serialization") version "1.9.22"
 }
 
 application {

--- a/codeSnippets/snippets/auth-form-session-nested/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/auth-form-session-nested/src/main/kotlin/com/example/Application.kt
@@ -7,7 +7,9 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.sessions.*
 import kotlinx.html.*
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class UserSession(val name: String, val count: Int) : Principal
 
 fun Application.main() {

--- a/codeSnippets/snippets/auth-form-session/build.gradle.kts
+++ b/codeSnippets/snippets/auth-form-session/build.gradle.kts
@@ -5,6 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
+    kotlin("plugin.serialization") version "1.9.22"
 }
 
 application {
@@ -18,6 +19,7 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
     implementation("io.ktor:ktor-server-core:$ktor_version")
     implementation("io.ktor:ktor-server-netty:$ktor_version")
     implementation("io.ktor:ktor-server-auth:$ktor_version")

--- a/codeSnippets/snippets/auth-form-session/build.gradle.kts
+++ b/codeSnippets/snippets/auth-form-session/build.gradle.kts
@@ -19,7 +19,6 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
     implementation("io.ktor:ktor-server-core:$ktor_version")
     implementation("io.ktor:ktor-server-netty:$ktor_version")
     implementation("io.ktor:ktor-server-auth:$ktor_version")

--- a/codeSnippets/snippets/auth-form-session/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/auth-form-session/src/main/kotlin/com/example/Application.kt
@@ -7,7 +7,9 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.sessions.*
 import kotlinx.html.*
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class UserSession(val name: String, val count: Int) : Principal
 
 fun Application.main() {

--- a/codeSnippets/snippets/auth-oauth-google/build.gradle.kts
+++ b/codeSnippets/snippets/auth-oauth-google/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    kotlin("plugin.serialization").version("1.9.20")
+    kotlin("plugin.serialization").version("1.9.22")
 }
 
 application {

--- a/codeSnippets/snippets/auth-oauth-google/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/auth-oauth-google/src/main/kotlin/com/example/Application.kt
@@ -125,6 +125,7 @@ private suspend fun getSession(
     return userSession
 }
 
+@Serializable
 data class UserSession(val state: String, val token: String)
 
 @Serializable

--- a/codeSnippets/snippets/session-cookie-client/build.gradle.kts
+++ b/codeSnippets/snippets/session-cookie-client/build.gradle.kts
@@ -5,6 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
+    kotlin("plugin.serialization") version "1.9.22"
 }
 
 application {

--- a/codeSnippets/snippets/session-cookie-client/src/main/kotlin/cookieclient/Application.kt
+++ b/codeSnippets/snippets/session-cookie-client/src/main/kotlin/cookieclient/Application.kt
@@ -5,7 +5,9 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.sessions.*
 import io.ktor.util.*
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class UserSession(val id: String, val count: Int)
 
 fun Application.main() {

--- a/codeSnippets/snippets/session-cookie-server/build.gradle.kts
+++ b/codeSnippets/snippets/session-cookie-server/build.gradle.kts
@@ -5,6 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
+    kotlin("plugin.serialization") version "1.9.22"
 }
 
 application {

--- a/codeSnippets/snippets/session-cookie-server/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/session-cookie-server/src/main/kotlin/com/example/Application.kt
@@ -5,7 +5,9 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.sessions.*
 import io.ktor.util.*
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class CartSession(val userID: String, val productIDs: MutableList<Int>)
 
 fun Application.main() {

--- a/codeSnippets/snippets/session-header-server/build.gradle.kts
+++ b/codeSnippets/snippets/session-header-server/build.gradle.kts
@@ -5,6 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
+    kotlin("plugin.serialization") version "1.9.22"
 }
 
 application {

--- a/codeSnippets/snippets/session-header-server/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/session-header-server/src/main/kotlin/com/example/Application.kt
@@ -5,8 +5,10 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.sessions.*
 import io.ktor.util.*
+import kotlinx.serialization.Serializable
 import java.io.*
 
+@Serializable
 data class CartSession(val userID: String, val productIDs: MutableList<Int>)
 
 fun Application.main() {

--- a/topics/Testing.md
+++ b/topics/Testing.md
@@ -12,11 +12,14 @@
 Learn how to test your server application using a special testing engine.
 </link-summary>
 
-Ktor provides a special testing engine that doesn't create a web server, doesn't bind to sockets, and doesn't make any real HTTP requests. Instead, it hooks directly into internal mechanisms and processes an application call directly. This results in quicker tests execution compared to running a complete web server for testing. 
-
+Ktor provides a special testing engine that doesn't create a web server, doesn't bind to sockets, and doesn't make any
+real HTTP requests. Instead, it hooks directly into internal mechanisms and processes an application call directly. This
+results in quicker tests execution compared to running a complete web server for testing.
 
 ## Add dependencies {id="add-dependencies"}
+
 To test a server Ktor application, you need to include the following artifacts in the build script:
+
 * Add the `ktor-server-test-host` dependency:
 
    <var name="artifact_name" value="ktor-server-test-host"/>
@@ -29,24 +32,29 @@ To test a server Ktor application, you need to include the following artifacts i
   <var name="version" value="kotlin_version"/>
   <include from="lib.topic" element-id="add_artifact_testing"/>
 
-> To test the [Native server](native_server.md#add-dependencies), add the testing artifacts to the `nativeTest` source set.
-
-  
+> To test the [Native server](native_server.md#add-dependencies), add the testing artifacts to the `nativeTest` source
+set.
 
 ## Testing overview {id="overview"}
 
 To use a testing engine, follow the steps below:
-1. Create a JUnit test class and a test function.
-2. Use the [testApplication](https://api.ktor.io/ktor-server/ktor-server-test-host/io.ktor.server.testing/test-application.html) function to set up a configured instance of a test application running locally.
-3. Use the [Ktor HTTP client](create-client.md) instance inside a test application to make a request to your server, receive a response, and make assertions.
 
-The code below demonstrates how to test the most simple Ktor application that accepts GET requests made to the `/` path and responds with a plain text response.
+1. Create a JUnit test class and a test function.
+2. Use
+   the [testApplication](https://api.ktor.io/ktor-server/ktor-server-test-host/io.ktor.server.testing/test-application.html)
+   function to set up a configured instance of a test application running locally.
+3. Use the [Ktor HTTP client](create-client.md) instance inside a test application to make a request to your server,
+   receive a response, and make assertions.
+
+The code below demonstrates how to test the most simple Ktor application that accepts GET requests made to the `/` path
+and responds with a plain text response.
 
 <tabs>
 <tab title="Test">
 
 ```kotlin
 ```
+
 {src="snippets/engine-main/src/test/kotlin/EngineMainTest.kt" include-lines="3-16,27"}
 
 </tab>
@@ -55,19 +63,21 @@ The code below demonstrates how to test the most simple Ktor application that ac
 
 ```kotlin
 ```
+
 {src="snippets/engine-main/src/main/kotlin/com/example/Application.kt" include-lines="3-15"}
 
 </tab>
 </tabs>
 
-The runnable code example is available here: [engine-main](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main).
-
+The runnable code example is available
+here: [engine-main](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main).
 
 ## Test an application {id="test-app"}
 
 ### Step 1: Configure a test application {id="configure-test-app"}
 
 A configuration of test applications might include the following steps:
+
 - [Adding application modules](#add-modules)
 - [(Optional) Adding routes](#add-routing)
 - [(Optional) Customizing environment](#environment)
@@ -78,21 +88,28 @@ A configuration of test applications might include the following steps:
 > This might be useful if you need to test your application's [lifecycle events](events.md#predefined-events).
 
 #### Add application modules {id="add-modules"}
+
 To test an application, its [modules](Modules.md) should be loaded to `testApplication`.
-Loading modules to `testApplication` depends on the way used to [create a server](create_server.topic): by using a [configuration file](Configuration-file.topic) or in code using the `embeddedServer` function.
+Loading modules to `testApplication` depends on the way used to [create a server](create_server.topic): by using
+a [configuration file](Configuration-file.topic) or in code using the `embeddedServer` function.
 
 ##### Add modules automatically {id="auto"}
 
-If you have the `application.conf` or `application.yaml` configuration file in the `resources` folder, `testApplication` loads all modules and properties specified in the configuration file automatically. To disable the automatic loading of specific modules, you need to:
+If you have the `application.conf` or `application.yaml` configuration file in the `resources` folder, `testApplication`
+loads all modules and properties specified in the configuration file automatically. To disable the automatic loading of
+specific modules, you need to:
 
 1. Provide a [custom configuration file](#environment) for tests.
-2. Use the [ktor.application.modules](Configuration-file.topic#configuration-file-overview) configuration property to specify modules to load.
-
+2. Use the [ktor.application.modules](Configuration-file.topic#configuration-file-overview) configuration property to
+   specify modules to load.
 
 ##### Add modules manually {id="manual"}
+
 If you use `embeddedServer`, you can add modules to a test application manually using the `application` function:
+
 ```kotlin
 ```
+
 {src="snippets/embedded-server-modules/src/test/kotlin/EmbeddedServerTest.kt" include-lines="11-15,19"}
 
 
@@ -103,92 +120,115 @@ If you use `embeddedServer`, you can add modules to a test application manually 
 
 You can add routes to your test application using the `routing` function.
 This might be convenient for the following use-cases:
-- Instead of [adding modules](#manual) to a test application, you can add [specific routes](Routing_in_Ktor.md#route_extension_function) that should be tested. 
-- You can add routes required only in a test application. The example below shows how to add the `/login-test` endpoint used to initialize a user [session](sessions.md) in tests:
+
+- Instead of [adding modules](#manual) to a test application, you can
+  add [specific routes](Routing_in_Ktor.md#route_extension_function) that should be tested.
+- You can add routes required only in a test application. The example below shows how to add the `/login-test` endpoint
+  used to initialize a user [session](sessions.md) in tests:
    ```kotlin
    ```
-   {src="snippets/auth-oauth-google/src/test/kotlin/ApplicationTest.kt" include-lines="18,31-35,51"}
-   
-   You can find the full example with a test here: [auth-oauth-google](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-oauth-google).
+  {src="snippets/auth-oauth-google/src/test/kotlin/ApplicationTest.kt" include-lines="18,31-35,51"}
+
+  You can find the full example with a test
+  here: [auth-oauth-google](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-oauth-google).
 
 #### Customize environment {id="environment"}
 
 To build a custom environment for a test application, use the `environment` function.
-For example, to use a custom configuration for tests, you can create a custom configuration file in the `test/resources` folder and load it using the `config` property:
+For example, to use a custom configuration for tests, you can create a custom configuration file in the `test/resources`
+folder and load it using the `config` property:
 
 ```kotlin
 ```
+
 {src="snippets/auth-oauth-google/src/test/kotlin/ApplicationTest.kt" include-lines="17-21,51"}
 
-Another way to specify configuration properties is using [MapApplicationConfig](https://api.ktor.io/ktor-server/ktor-server-core/io.ktor.server.config/-map-application-config/index.html). This might be useful if you want to access application configuration before the application starts. The example below shows how to pass `MapApplicationConfig` to the `testApplication` function using the `config` property:
+Another way to specify configuration properties is
+using [MapApplicationConfig](https://api.ktor.io/ktor-server/ktor-server-core/io.ktor.server.config/-map-application-config/index.html).
+This might be useful if you want to access application configuration before the application starts. The example below
+shows how to pass `MapApplicationConfig` to the `testApplication` function using the `config` property:
 
 ```kotlin
 ```
+
 {src="snippets/engine-main-custom-environment/src/test/kotlin/ApplicationTest.kt" include-lines="10-14,21"}
 
 #### Mock external services {id="external-services"}
 
 Ktor allows you to mock external services using the `externalServices` function.
 Inside this function, you need to call the `hosts` function that accepts two parameters:
+
 - The `hosts` parameter accepts URLs of external services.
 - The `block` parameter allows you to configure the `Application` that acts as a mock for an external service.
-   You can configure routing and install plugins for this `Application`.
+  You can configure routing and install plugins for this `Application`.
 
 The sample below shows how to use `externalServices` to simulate a JSON response returned by Google API:
 
 ```kotlin
 ```
+
 {src="snippets/auth-oauth-google/src/test/kotlin/ApplicationTest.kt" include-lines="18,36-47,51"}
 
-You can find the full example with a test here: [auth-oauth-google](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-oauth-google).
+You can find the full example with a test
+here: [auth-oauth-google](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-oauth-google).
 
 ### Step 2: (Optional) Configure a client {id="configure-client"}
 
-The `testApplication` provides access to an HTTP client with default configuration using the `client` property. 
-If you need to customize the client and install additional plugins, you can use the `createClient` function. For example, to [send JSON data](#json-data) in a test POST/PUT request, you can install the [ContentNegotiation](serialization-client.md) plugin:
+The `testApplication` provides access to an HTTP client with default configuration using the `client` property.
+If you need to customize the client and install additional plugins, you can use the `createClient` function. For
+example, to [send JSON data](#json-data) in a test POST/PUT request, you can install
+the [ContentNegotiation](serialization-client.md) plugin:
+
 ```kotlin
 ```
-{src="snippets/json-kotlinx/src/test/kotlin/jsonkotlinx/ApplicationTest.kt" include-lines="32-37,44"}
 
+{src="snippets/json-kotlinx/src/test/kotlin/jsonkotlinx/ApplicationTest.kt" include-lines="32-37,44"}
 
 ### Step 3: Make a request {id="make-request"}
 
-To test your application, use the [configured client](#configure-client) to make a [request](request.md) and receive a [response](response.md). The [example below](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/json-kotlinx) shows how to test the `/customer` endpoint that handles `POST` requests:
+To test your application, use the [configured client](#configure-client) to make a [request](request.md) and receive
+a [response](response.md).
+The [example below](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/json-kotlinx)
+shows how to test the `/customer` endpoint that handles `POST` requests:
 
 ```kotlin
 ```
+
 {src="snippets/json-kotlinx/src/test/kotlin/jsonkotlinx/ApplicationTest.kt" include-lines="32-41,44"}
-
-
 
 ### Step 4: Assert results {id="assert"}
 
-After receiving a [response](#make-request), you can verify the results by making assertions provided by the [kotlin.test](https://kotlinlang.org/api/latest/kotlin.test/) library:
+After receiving a [response](#make-request), you can verify the results by making assertions provided by
+the [kotlin.test](https://kotlinlang.org/api/latest/kotlin.test/) library:
 
 ```kotlin
 ```
+
 {src="snippets/json-kotlinx/src/test/kotlin/jsonkotlinx/ApplicationTest.kt" include-lines="32-44"}
-
-
-
-
 
 ## Test POST/PUT requests {id="test-post-put"}
 
 ### Send form data {id="form-data"}
 
-To send form data in a test POST/PUT request, you need to set the `Content-Type` header and specify the request body. To do this, you can use 
- the [header](request.md#headers) and [setBody](request.md#body) functions, respectively. The examples below show how to send form data using both `x-www-form-urlencoded` and `multipart/form-data` types.
+To send form data in a test POST/PUT request, you need to set the `Content-Type` header and specify the request body. To
+do this, you can use
+the [header](request.md#headers) and [setBody](request.md#body) functions, respectively. The examples below show how to
+send form data using both `x-www-form-urlencoded` and `multipart/form-data` types.
 
 #### x-www-form-urlencoded {id="x-www-form-urlencoded"}
 
-A test below from the [post-form-parameters](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/post-form-parameters) example shows how to make a test request with form parameters sent using the `x-www-form-urlencoded` content type. Note that the [formUrlEncode](https://api.ktor.io/ktor-http/io.ktor.http/form-url-encode.html) function is used to encode form parameters from a list of key/value pairs.
+A test below from
+the [post-form-parameters](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/post-form-parameters)
+example shows how to make a test request with form parameters sent using the `x-www-form-urlencoded` content type. Note
+that the [formUrlEncode](https://api.ktor.io/ktor-http/io.ktor.http/form-url-encode.html) function is used to encode
+form parameters from a list of key/value pairs.
 
 <tabs>
 <tab title="Test">
 
 ```kotlin
 ```
+
 {src="snippets/post-form-parameters/src/test/kotlin/formparameters/ApplicationTest.kt" include-lines="3-18,29"}
 
 </tab>
@@ -197,21 +237,23 @@ A test below from the [post-form-parameters](https://github.com/ktorio/ktor-docu
 
 ```kotlin
 ```
+
 {src="snippets/post-form-parameters/src/main/kotlin/formparameters/Application.kt" include-lines="3-16,45-46"}
 
 </tab>
 </tabs>
 
-
 #### multipart/form-data {id="multipart-form-data"}
 
-The code below demonstrates how to build `multipart/form-data` and test file uploading. You can find the full example here: [upload-file](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/upload-file).
+The code below demonstrates how to build `multipart/form-data` and test file uploading. You can find the full example
+here: [upload-file](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/upload-file).
 
 <tabs>
 <tab title="Test">
 
 ```kotlin
 ```
+
 {src="snippets/upload-file/src/test/kotlin/uploadfile/UploadFileTest.kt" include-lines="3-36,69"}
 
 </tab>
@@ -220,21 +262,27 @@ The code below demonstrates how to build `multipart/form-data` and test file upl
 
 ```kotlin
 ```
+
 {src="snippets/upload-file/src/main/kotlin/uploadfile/UploadFile.kt" include-lines="3-38"}
 
 </tab>
 </tabs>
 
-
 ### Send JSON data {id="json-data"}
 
-To send JSON data in a test POST/PUT request, you need to create a new client and install the [ContentNegotiation](serialization-client.md) plugin that allows serializing/deserializing the content in a specific format. Inside a request, you can specify the `Content-Type` header using the `contentType` function and the request body using [setBody](request.md#body). The [example below](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/json-kotlinx) shows how to test the `/customer` endpoint that handles `POST` requests.
+To send JSON data in a test POST/PUT request, you need to create a new client and install
+the [ContentNegotiation](serialization-client.md) plugin that allows serializing/deserializing the content in a specific
+format. Inside a request, you can specify the `Content-Type` header using the `contentType` function and the request
+body using [setBody](request.md#body).
+The [example below](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/json-kotlinx)
+shows how to test the `/customer` endpoint that handles `POST` requests.
 
 <tabs>
 <tab title="Test">
 
 ```kotlin
 ```
+
 {src="snippets/json-kotlinx/src/test/kotlin/jsonkotlinx/ApplicationTest.kt" include-lines="3-14,31-44,56"}
 
 </tab>
@@ -243,16 +291,18 @@ To send JSON data in a test POST/PUT request, you need to create a new client an
 
 ```kotlin
 ```
+
 {src="snippets/json-kotlinx/src/main/kotlin/jsonkotlinx/Application.kt" include-lines="3-16,25-31,38-44"}
 
 </tab>
 </tabs>
 
-
-
 ## Preserve cookies during testing {id="preserving-cookies"}
 
-If you need to preserve cookies between requests when testing, you need to create a new client and install the [HttpCookies](http-cookies.md) plugin. In a test below from the [session-cookie-client](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-cookie-client) example, reload count is increased after each request since cookies are preserved.
+If you need to preserve cookies between requests when testing, you need to create a new client and install
+the [HttpCookies](http-cookies.md) plugin. In a test below from
+the [session-cookie-client](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-cookie-client)
+example, reload count is increased after each request since cookies are preserved.
 
 
 <tabs>
@@ -260,6 +310,7 @@ If you need to preserve cookies between requests when testing, you need to creat
 
 ```kotlin
 ```
+
 {src="snippets/session-cookie-client/src/test/kotlin/cookieclient/ApplicationTest.kt" include-lines="3-27,47"}
 
 </tab>
@@ -268,44 +319,49 @@ If you need to preserve cookies between requests when testing, you need to creat
 
 ```kotlin
 ```
-{src="snippets/session-cookie-client/src/main/kotlin/cookieclient/Application.kt" include-lines="3-38"}
+
+{src="snippets/session-cookie-client/src/main/kotlin/cookieclient/Application.kt" include-lines="3-44"}
 
 </tab>
 </tabs>
 
-
 ## Test HTTPS {id="https"}
 
-If you need to test an [HTTPS endpoint](ssl.md), change the protocol used to make a request using the [URLBuilder.protocol](request.md#url) property:
+If you need to test an [HTTPS endpoint](ssl.md), change the protocol used to make a request using
+the [URLBuilder.protocol](request.md#url) property:
 
 ```kotlin
 ```
+
 {src="snippets/ssl-engine-main/src/test/kotlin/ApplicationTest.kt" include-lines="10-18"}
 
-You can find the full example here: [ssl-engine-main](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/ssl-engine-main).
-
+You can find the full example
+here: [ssl-engine-main](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/ssl-engine-main).
 
 ## Test WebSockets {id="testing-ws"}
 
-You can test [WebSocket conversations](websocket.md) by using the [WebSockets](websocket_client.md) plugin provided by the client:
+You can test [WebSocket conversations](websocket.md) by using the [WebSockets](websocket_client.md) plugin provided by
+the client:
 
 ```kotlin
 ```
+
 {src="snippets/server-websockets/src/test/kotlin/com/example/ModuleTest.kt" include-lines="3-26,41"}
 
-
-
-
-
-
 ## End-to-end testing with HttpClient {id="end-to-end"}
-Apart from a testing engine, you can use the [Ktor HTTP client](create-client.md) for end-to-end testing of your server application.
+
+Apart from a testing engine, you can use the [Ktor HTTP client](create-client.md) for end-to-end testing of your server
+application.
 In the example below, the HTTP client makes a test request to the `TestServer`:
 
 ```kotlin
 ```
+
 {src="snippets/embedded-server/src/test/kotlin/EmbeddedServerTest.kt"}
 
 For complete examples, refer to these samples:
-- [embedded-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/embedded-server): a sample server to be tested.
-- [e2e](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/e2e): contains helper classes and functions for setting up a test server.
+
+- [embedded-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/embedded-server):
+  a sample server to be tested.
+- [e2e](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/e2e): contains helper
+  classes and functions for setting up a test server.

--- a/topics/authentication.md
+++ b/topics/authentication.md
@@ -16,40 +16,66 @@
 The Authentication plugin handles authentication and authorization in Ktor.
 </link-summary>
 
-Ktor provides the [Authentication](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-authentication/index.html) plugin to handle authentication and authorization. Typical usage scenarios include logging in users, granting access to specific resources, and securely transmitting information between parties. You can also use `Authentication` with [Sessions](sessions.md) to keep a user's information between requests.
+Ktor provides
+the [Authentication](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-authentication/index.html)
+plugin to handle authentication and authorization. Typical usage scenarios include logging in users, granting access to
+specific resources, and securely transmitting information between parties. You can also use `Authentication`
+with [Sessions](sessions.md) to keep a user's information between requests.
 
 ## Supported authentication types {id="supported"}
+
 Ktor supports the following authentication and authorization schemes:
 
 ### HTTP authentication {id="http-auth"}
-HTTP provides a [general framework](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication) for access control and authentication. In Ktor, you can use the following HTTP authentication schemes:
-* [Basic](basic.md) - uses `Base64` encoding to provide a username and password. Generally is not recommended if not used in combination with HTTPS.
-* [Digest](digest.md) - an authentication method that communicates user credentials in an encrypted form by applying a hash function to the username and password.
-* [Bearer](bearer.md) - an authentication scheme that involves security tokens called bearer tokens. 
-  The Bearer authentication scheme is used as part of [OAuth](oauth.md) or [JWT](jwt.md), but you can also provide custom logic for authorizing bearer tokens.
 
+HTTP provides a [general framework](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication) for access control
+and authentication. In Ktor, you can use the following HTTP authentication schemes:
+
+* [Basic](basic.md) - uses `Base64` encoding to provide a username and password. Generally is not recommended if not
+  used in combination with HTTPS.
+* [Digest](digest.md) - an authentication method that communicates user credentials in an encrypted form by applying a
+  hash function to the username and password.
+* [Bearer](bearer.md) - an authentication scheme that involves security tokens called bearer tokens.
+  The Bearer authentication scheme is used as part of [OAuth](oauth.md) or [JWT](jwt.md), but you can also provide
+  custom logic for authorizing bearer tokens.
 
 ### Form-based authentication {id="form-auth"}
-[Form-based](form.md) authentication uses a [web form](https://developer.mozilla.org/en-US/docs/Learn/Forms) to collect credential information and authenticate a user.
 
+[Form-based](form.md) authentication uses a [web form](https://developer.mozilla.org/en-US/docs/Learn/Forms) to collect
+credential information and authenticate a user.
 
 ### JSON Web Tokens (JWT) {id="jwt"}
-[JSON Web Token](jwt.md) is an open standard for securely transmitting information between parties as a JSON object. You can use JSON Web Tokens for authorization: when the user is logged in, each request will include a token, allowing the user to access resources that are permitted with that token. In Ktor, you can verify a token and validate the claims contained within it using the `jwt` authentication.
 
+[JSON Web Token](jwt.md) is an open standard for securely transmitting information between parties as a JSON object. You
+can use JSON Web Tokens for authorization: when the user is logged in, each request will include a token, allowing the
+user to access resources that are permitted with that token. In Ktor, you can verify a token and validate the claims
+contained within it using the `jwt` authentication.
 
 ### LDAP {id="ldap"}
-[LDAP](ldap.md) is an open and cross-platform protocol used for directory services authentication. Ktor provides the [ldapAuthenticate](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/io.ktor.server.auth.ldap/ldap-authenticate.html) function to authenticate user credentials against a specified LDAP server.
+
+[LDAP](ldap.md) is an open and cross-platform protocol used for directory services authentication. Ktor provides
+the [ldapAuthenticate](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth-ldap/io.ktor.server.auth.ldap/ldap-authenticate.html)
+function to authenticate user credentials against a specified LDAP server.
 
 ### OAuth {id="oauth"}
-[OAuth](oauth.md) is an open standard for securing access to APIs. The `oauth` provider in Ktor allows you to implement authentication using external providers such as Google, Facebook, Twitter, and so on.
+
+[OAuth](oauth.md) is an open standard for securing access to APIs. The `oauth` provider in Ktor allows you to implement
+authentication using external providers such as Google, Facebook, Twitter, and so on.
 
 ### Session {id="sessions"}
-[Sessions](sessions.md) provide a mechanism to persist data between different HTTP requests. Typical use cases include storing a logged-in user's ID, the contents of a shopping basket, or keeping user preferences on the client. In Ktor, a user that already has an associated session can be authenticated using the `session` provider. Learn how to do this from [](session-auth.md).
+
+[Sessions](sessions.md) provide a mechanism to persist data between different HTTP requests. Typical use cases include
+storing a logged-in user's ID, the contents of a shopping basket, or keeping user preferences on the client. In Ktor, a
+user that already has an associated session can be authenticated using the `session` provider. Learn how to do this
+from [](session-auth.md).
 
 ### Custom {id="custom"}
-Ktor also provides an API for creating [custom plugins](custom_plugins.md), which can be used to implement your own plugin for handling authentication and authorization. 
-For example, the `AuthenticationChecked` [hook](custom_plugins.md#call-handling) is executed after authentication credentials are checked, and it allows you to implement authorization: [custom-plugin-authorization](https://github.com/ktorio/ktor-documentation/blob/%ktor_version%/codeSnippets/snippets/custom-plugin-authorization).
 
+Ktor also provides an API for creating [custom plugins](custom_plugins.md), which can be used to implement your own
+plugin for handling authentication and authorization.
+For example, the `AuthenticationChecked` [hook](custom_plugins.md#call-handling) is executed after authentication
+credentials are checked, and it allows you to implement
+authorization: [custom-plugin-authorization](https://github.com/ktorio/ktor-documentation/blob/%ktor_version%/codeSnippets/snippets/custom-plugin-authorization).
 
 ## Add dependencies {id="add_dependencies"}
 
@@ -58,20 +84,20 @@ For example, the `AuthenticationChecked` [hook](custom_plugins.md#call-handling)
 
 Note that some authentication providers, such as [JWT](jwt.md) and [LDAP](ldap.md), require additional artifacts.
 
-
-
 ## Install Authentication {id="install"}
 
 <include from="lib.topic" element-id="install_plugin"/>
 
-
 ## Configure Authentication {id="configure"}
-After [installing Authentication](#install), you can configure and use `Authentication` as follows:
 
+After [installing Authentication](#install), you can configure and use `Authentication` as follows:
 
 ### Step 1: Choose an authentication provider {id="choose-provider"}
 
-To use a specific authentication provider ([basic](basic.md), [digest](digest.md), [form](form.md), and so on), you need to call the corresponding function inside the `install` block. For example, to use the `basic` authentication, call the [basic](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/basic.html) function:
+To use a specific authentication provider ([basic](basic.md), [digest](digest.md), [form](form.md), and so on), you need
+to call the corresponding function inside the `install` block. For example, to use the `basic` authentication, call
+the [basic](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/basic.html)
+function:
 
 ```kotlin
 import io.ktor.server.application.*
@@ -83,12 +109,16 @@ install(Authentication) {
     }
 }
 ```
-Inside this function, you can [configure](#configure-provider) settings specific to this provider.
 
+Inside this function, you can [configure](#configure-provider) settings specific to this provider.
 
 ### Step 2: Specify a provider name {id="provider-name"}
 
-A function for [using a specific provider](#choose-provider) optionally allows you to specify a provider name. A code sample below installs the [basic](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/basic.html) and [form](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/form.html) providers with the _auth-basic_ and _auth-form_ names, respectively:
+A function for [using a specific provider](#choose-provider) optionally allows you to specify a provider name. A code
+sample below installs
+the [basic](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/basic.html)
+and [form](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/form.html) providers
+with the _auth-basic_ and _auth-form_ names, respectively:
 
 ```kotlin
 install(Authentication) {
@@ -101,41 +131,66 @@ install(Authentication) {
     // ...
 }
 ```
+
 {disable-links="false"}
 
 These names can be used later to [authenticate different routes](#authenticate-route) using different providers.
 > Note that a provider name should be unique, and you can define only one provider without a name.
 
-
 ### Step 3: Configure a provider {id="configure-provider"}
 
-Each [provider type](#choose-provider) has its own configuration. For instance, the [BasicAuthenticationProvider.Config](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-basic-authentication-provider/-config/index.html) class contains options passed to the [basic](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/basic.html) function. The most important function exposed by this class is [validate](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-basic-authentication-provider/-config/validate.html) that validates a username and password. A code sample below shows how it can look:
+Each [provider type](#choose-provider) has its own configuration. For instance,
+the [BasicAuthenticationProvider.Config](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-basic-authentication-provider/-config/index.html)
+class contains options passed to
+the [basic](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/basic.html)
+function. The most important function exposed by this class
+is [validate](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-basic-authentication-provider/-config/validate.html)
+that validates a username and password. A code sample below shows how it can look:
 
 ```kotlin
 ```
+
 {src="snippets/auth-basic/src/main/kotlin/authbasic/Application.kt" include-lines="9-20"}
 
 To understand how the `validate` function works, we need to introduce two terms:
-* A _principal_ is an entity that can be authenticated: a user, a computer, a service, etc. In Ktor, various authentication providers might use different principals. For example, the `basic`, `digest`, and `form` providers authenticate [UserIdPrincipal](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-user-id-principal/index.html) while the `jwt` provider verifies [JWTPrincipal](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/io.ktor.server.auth.jwt/-j-w-t-principal/index.html).
-  > You can also create a custom principal by implementing the [Principal](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-principal/index.html) interface.
+
+* A _principal_ is an entity that can be authenticated: a user, a computer, a service, etc. In Ktor, various
+  authentication providers might use different principals. For example, the `basic`, `digest`, and `form` providers
+  authenticate [UserIdPrincipal](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-user-id-principal/index.html)
+  while the `jwt` provider
+  verifies [JWTPrincipal](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/io.ktor.server.auth.jwt/-j-w-t-principal/index.html).
+  > You can also create a custom principal by implementing
+  the [Principal](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-principal/index.html)
+  interface.
   > This might be useful in the following cases:
-  > - Mapping the credentials to a custom principal allows you to have additional information about the authenticated principal inside a [route handler](#get-principal).
+  > - Mapping the credentials to a custom principal allows you to have additional information about the authenticated
+      principal inside a [route handler](#get-principal).
   > - If you use [session authentication](session-auth.md), a principal might be a data class that stores session data.
-* A _credential_ is a set of properties for a server to authenticate a principal: a user/password pair, an API key, and so on. For instance, the `basic` and `form` providers use [UserPasswordCredential](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-user-password-credential/index.html) to validate a username and password while `jwt` validates [JWTCredential](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/io.ktor.server.auth.jwt/-j-w-t-credential/index.html).
+* A _credential_ is a set of properties for a server to authenticate a principal: a user/password pair, an API key, and
+  so on. For instance, the `basic` and `form` providers
+  use [UserPasswordCredential](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-user-password-credential/index.html)
+  to validate a username and password while `jwt`
+  validates [JWTCredential](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/io.ktor.server.auth.jwt/-j-w-t-credential/index.html).
 
-So, the `validate` function checks a specified [Credential](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-credential/index.html) and returns a [Principal](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-principal/index.html) in the case of successful authentication or `null` if authentication fails.
+So, the `validate` function checks a
+specified [Credential](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-credential/index.html)
+and returns
+a [Principal](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-principal/index.html)
+in the case of successful authentication or `null` if authentication fails.
 
-> To skip authentication based on specific criteria, use [skipWhen](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-authentication-provider/-config/skip-when.html). For example, you can skip `basic` authentication if a [session](sessions.md) already exists:
+> To skip authentication based on specific criteria,
+use [skipWhen](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-authentication-provider/-config/skip-when.html).
+For example, you can skip `basic` authentication if a [session](sessions.md) already exists:
 > ```kotlin
 > basic {
 >     skipWhen { call -> call.sessions.get<UserSession>() != null }
 > }
 
-
 ### Step 4: Protect specific resources {id="authenticate-route"}
 
 The final step is to protect specific resources in our application. You can do this by using the
-[authenticate](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/authenticate.html) function. This function accepts two optional parameters:
+[authenticate](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/authenticate.html)
+function. This function accepts two optional parameters:
 
 - A [name of a provider](#provider-name) used to authenticate nested routes.
   The code snippet below uses a provider with the _auth-basic_ name to protect the `/login` and `/orders` routes:
@@ -155,10 +210,12 @@ The final step is to protect specific resources in our application. You can do t
    }
    ```
 - A strategy used to resolve nested authentication providers.
-  This strategy is represented by the [AuthenticationStrategy](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-authentication-strategy/index.html) enumeration value.
-  For instance, the client should provide authentication data for all providers registered 
+  This strategy is represented by
+  the [AuthenticationStrategy](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-authentication-strategy/index.html)
+  enumeration value.
+  For instance, the client should provide authentication data for all providers registered
   with the `AuthenticationStrategy.Required` strategy.
-  In the code snippet below, only a user that passed [session authentication](session-auth.md) 
+  In the code snippet below, only a user that passed [session authentication](session-auth.md)
   can try to access the `/admin` route using basic authentication:
    ```kotlin
    routing {
@@ -174,34 +231,39 @@ The final step is to protect specific resources in our application. You can do t
        }
    }
    ```
-  
-  You can find the full example here: [auth-form-session-nested](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-form-session-nested).
-   
 
-
+  You can find the full example
+  here: [auth-form-session-nested](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-form-session-nested).
 
 ### Step 5: Get a principal inside a route handler {id="get-principal"}
 
-In the case of successful authentication, you can retrieve an authenticated [Principal](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-principal/index.html) inside a route handler using the `call.principal` function. This function accepts a specific principal type returned by the [configured authentication provider](#configure-provider). In a code sample below, `call.principal` is used to obtain `UserIdPrincipal` and get a name of an authenticated user.
+In the case of successful authentication, you can retrieve an
+authenticated [Principal](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-principal/index.html)
+inside a route handler using the `call.principal` function. This function accepts a specific principal type returned by
+the [configured authentication provider](#configure-provider). In a code sample below, `call.principal` is used to
+obtain `UserIdPrincipal` and get a name of an authenticated user.
 
 ```kotlin
 ```
+
 {src="snippets/auth-basic/src/main/kotlin/authbasic/Application.kt" include-lines="21-27"}
 
-
-If you use [session authentication](session-auth.md), a principal might be a data class that stores session data. So, you need to pass this data class to `call.principal`:
+If you use [session authentication](session-auth.md), a principal might be a data class that stores session data. So,
+you need to pass this data class to `call.principal`:
 
 ```kotlin
 ```
-{src="snippets/auth-form-session/src/main/kotlin/com/example/Application.kt" include-lines="75-77,80-81"}
 
-In the case of [nested authentication providers](#authenticate-route), 
+{src="snippets/auth-form-session/src/main/kotlin/com/example/Application.kt" include-lines="77-79,82-83"}
+
+In the case of [nested authentication providers](#authenticate-route),
 you can pass a [provider name](#provider-name) to `call.principal` to get a principal for the desired provider.
 In the example below, the _auth-session_ value is passed to get a principal for a topmost session provider:
 
 ```kotlin
 ```
-{src="snippets/auth-form-session-nested/src/main/kotlin/com/example/Application.kt" include-lines="85,91-93,95-97"}
+
+{src="snippets/auth-form-session-nested/src/main/kotlin/com/example/Application.kt" include-lines="87,93-95,97-99"}
 
 
 

--- a/topics/session-auth.md
+++ b/topics/session-auth.md
@@ -12,13 +12,17 @@
 </tldr>
 
 
-[Sessions](sessions.md) provide a mechanism to persist data between different HTTP requests. Typical use cases include storing a logged-in user's ID, the contents of a shopping basket, or keeping user preferences on the client. 
+[Sessions](sessions.md) provide a mechanism to persist data between different HTTP requests. Typical use cases include
+storing a logged-in user's ID, the contents of a shopping basket, or keeping user preferences on the client.
 
-In Ktor, a user that already has an associated session can be authenticated using the `session` provider. For example, when a user logs in using a [web form](form.md) for the first time, you can save a username to a cookie session and authorize this user on subsequent requests using the `session` provider.
+In Ktor, a user that already has an associated session can be authenticated using the `session` provider. For example,
+when a user logs in using a [web form](form.md) for the first time, you can save a username to a cookie session and
+authorize this user on subsequent requests using the `session` provider.
 
 > You can get general information about authentication and authorization in Ktor in the [](authentication.md) section.
 
 ## Add dependencies {id="add_dependencies"}
+
 To enable `session` authentication, you need to include the following artifacts in the build script:
 
 * Add the `ktor-server-sessions` dependency for using sessions:
@@ -33,16 +37,22 @@ To enable `session` authentication, you need to include the following artifacts 
 
 ## Session authentication flow {id="flow"}
 
-The authentication flow with sessions might vary and depends on how users are authenticated in your application. Let's see how it might look with the [form-based authentication](form.md):
+The authentication flow with sessions might vary and depends on how users are authenticated in your application. Let's
+see how it might look with the [form-based authentication](form.md):
 
 1. A client makes a request containing web form data (which includes the username and password) to a server.
-2. A server validates credentials sent by a client, saves a username to a cookie session, and responds with the requested content and a cookie containing a username.
+2. A server validates credentials sent by a client, saves a username to a cookie session, and responds with the
+   requested content and a cookie containing a username.
 3. A client makes a subsequent request with a cookie to the protected resource.
-4. Based on received cookie data, Ktor checks that a cookie session exists for this user and, optionally, performs additional validations on received session data. In a case of successful validation, a server responds with the requested content.
-
+4. Based on received cookie data, Ktor checks that a cookie session exists for this user and, optionally, performs
+   additional validations on received session data. In a case of successful validation, a server responds with the
+   requested content.
 
 ## Install session authentication {id="install"}
-To install the `session` authentication provider, call the [session](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/session.html) function with the required session type inside the `install` block:
+
+To install the `session` authentication provider, call
+the [session](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/session.html)
+function with the required session type inside the `install` block:
 
 ```kotlin
 import io.ktor.server.application.*
@@ -57,35 +67,55 @@ install(Authentication) {
 ```
 
 ## Configure session authentication {id="configure"}
-This section demonstrates how to authenticate a user with a [form-based authentication](form.md), save information about this user to a cookie session, and then authorize this user on subsequent requests using the `session` provider. You can find the complete example here: [auth-form-session](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-form-session).
+
+This section demonstrates how to authenticate a user with a [form-based authentication](form.md), save information about
+this user to a cookie session, and then authorize this user on subsequent requests using the `session` provider. You can
+find the complete example
+here: [auth-form-session](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-form-session).
 
 ### Step 1: Create a data class {id="data-class"}
-First, you need to create a data class for storing session data. Note that this class should inherit [Principal](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-principal/index.html) since the [validate](#configure-session-auth) function should return a `Principal` in the case of successful authentication.
+
+First, you need to create a data class for storing session data. Note that this class should
+inherit [Principal](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-principal/index.html)
+since the [validate](#configure-session-auth) function should return a `Principal` in the case of successful
+authentication.
+
+To make the class serializable, use the `@Serializable` annotation
+from [kotlinx.serialization](https://kotlinlang.org/docs/serialization.html):
 
 ```kotlin
 ```
-{src="snippets/auth-form-session/src/main/kotlin/com/example/Application.kt" include-lines="11"}
+
+{src="snippets/auth-form-session/src/main/kotlin/com/example/Application.kt" include-lines="12-13"}
 
 ### Step 2: Install and configure a session {id="install-session"}
-After creating a data class, you need to install and configure the `Sessions` plugin. A code snippet below shows how to install and configure a cookie session with the specified cookie path and expiration time.
+
+After creating a data class, you need to install and configure the `Sessions` plugin. A code snippet below shows how to
+install and configure a cookie session with the specified cookie path and expiration time.
 
 ```kotlin
 ```
-{src="snippets/auth-form-session/src/main/kotlin/com/example/Application.kt" include-lines="14-19"}
+
+{src="snippets/auth-form-session/src/main/kotlin/com/example/Application.kt" include-lines="15-20"}
 
 You can learn more about configuring sessions from [](sessions.md#configuration_overview).
 
-
 ### Step 3: Configure session authentication {id="configure-session-auth"}
 
-The `session` authentication provider exposes its settings via the [SessionAuthenticationProvider.Config](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-session-authentication-provider/-config/index.html) class. In the example below, the following settings are specified:
-* The `validate` function checks the [session instance](#data-class) and returns `Principal` in the case of successful authentication.
-* The `challenge` function specifies an action performed if authentication fails. For instance, you can redirect back to a login page or send [UnauthorizedResponse](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-unauthorized-response/index.html).
+The `session` authentication provider exposes its settings via
+the [SessionAuthenticationProvider.Config](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-session-authentication-provider/-config/index.html)
+class. In the example below, the following settings are specified:
+
+* The `validate` function checks the [session instance](#data-class) and returns `Principal` in the case of successful
+  authentication.
+* The `challenge` function specifies an action performed if authentication fails. For instance, you can redirect back to
+  a login page or
+  send [UnauthorizedResponse](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-unauthorized-response/index.html).
 
 ```kotlin
 ```
-{src="snippets/auth-form-session/src/main/kotlin/com/example/Application.kt" include-lines="20,32-44"}
 
+{src="snippets/auth-form-session/src/main/kotlin/com/example/Application.kt" include-lines="22,34-46"}
 
 ### Step 4: Save user data in a session {id="save-session"}
 
@@ -93,14 +123,20 @@ To save information about a logged-in user to a session, use the [call.sessions.
 
 ```kotlin
 ```
-{src="snippets/auth-form-session/src/main/kotlin/com/example/Application.kt" include-lines="67-73"}
+
+{src="snippets/auth-form-session/src/main/kotlin/com/example/Application.kt" include-lines="69-75"}
 
 ### Step 5: Protect specific resources {id="authenticate-route"}
 
-After configuring the `session` provider, you can protect specific resources in our application using the **[authenticate](authentication.md#authenticate-route)** function. In the case of successful authentication, you can retrieve an authenticated `Principal` (the [UserSession](#data-class) instance) inside a route handler using the `call.principal` function and information about a user.
+After configuring the `session` provider, you can protect specific resources in our application using the *
+*[authenticate](authentication.md#authenticate-route)** function. In the case of successful authentication, you can
+retrieve an authenticated `Principal` (the [UserSession](#data-class) instance) inside a route handler using
+the `call.principal` function and information about a user.
 
 ```kotlin
 ```
-{src="snippets/auth-form-session/src/main/kotlin/com/example/Application.kt" include-lines="75-81"}
 
-You can find the full example here: [auth-form-session](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-form-session).
+{src="snippets/auth-form-session/src/main/kotlin/com/example/Application.kt" include-lines="77-83"}
+
+For the full example,
+see [auth-form-session](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-form-session).

--- a/topics/sessions.md
+++ b/topics/sessions.md
@@ -22,11 +22,17 @@
 The Sessions plugin provides a mechanism to persist data between different HTTP requests.
 </link-summary>
 
-The [%plugin_name%](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-sessions/io.ktor.server.sessions/-sessions.html) plugin provides a mechanism to persist data between different HTTP requests. Typical use cases include storing a logged-in user's ID, the contents of a shopping basket, or keeping user preferences on the client. In Ktor, you can implement sessions by using cookies or custom headers, choose whether to store session data on the server or pass it to the client, sign and encrypt session data and more.
+The [%plugin_name%](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-sessions/io.ktor.server.sessions/-sessions.html)
+plugin provides a mechanism to persist data between different HTTP requests. Typical use cases include storing a
+logged-in user's ID, the contents of a shopping basket, or keeping user preferences on the client. In Ktor, you can
+implement sessions by using cookies or custom headers, choose whether to store session data on the server or pass it to
+the client, sign and encrypt session data and more.
 
-In this topic, we'll look at how to install the `%plugin_name%` plugin, configure it, and access session data inside [route handlers](Routing_in_Ktor.md#define_route).
+In this topic, we'll look at how to install the `%plugin_name%` plugin, configure it, and access session data
+inside [route handlers](Routing_in_Ktor.md#define_route).
 
 ## Add dependencies {id="add_dependencies"}
+
 To enable support for sessions, you need to include the `%artifact_name%` artifact in the build script:
 
 <include from="lib.topic" element-id="add_ktor_artifact"/>
@@ -36,49 +42,70 @@ To enable support for sessions, you need to include the `%artifact_name%` artifa
 <include from="lib.topic" element-id="install_plugin"/>
 <include from="lib.topic" element-id="install_plugin_route"/>
 
-
 ## Session configuration overview {id="configuration_overview"}
+
 To configure the `%plugin_name%` plugin, you need to perform the following steps:
-1. *[Create a data class](#data_class)*: before configuring a session, you need to create a [data class](https://kotlinlang.org/docs/data-classes.html) for storing session data.
-2. *[Choose how to pass data between the server and client](#cookie_header)*: using cookies or a custom header. Cookies suit better for plain HTML applications, while custom headers are intended for APIs.
-3. *[Choose where to store the session payload](#client_server)*: on the client or server. You can pass the serialized session's data to the client using a cookie/header value or store the payload on the server and pass only a session identifier.
 
-   If you want to store the session payload on the server, you can *[choose how to store it](#storages)*: in the server memory or in a folder. You can also implement a custom storage for keeping session data.
-4. *[Protect session data](#protect_session)*: to protect sensitive session data passed to the client, you need to sign and encrypt the session's payload.
+1. *[Create a data class](#data_class)*: before configuring a session, you need to create
+   a [data class](https://kotlinlang.org/docs/data-classes.html) for storing session data.
+2. *[Choose how to pass data between the server and client](#cookie_header)*: using cookies or a custom header. Cookies
+   suit better for plain HTML applications, while custom headers are intended for APIs.
+3. *[Choose where to store the session payload](#client_server)*: on the client or server. You can pass the serialized
+   session's data to the client using a cookie/header value or store the payload on the server and pass only a session
+   identifier.
 
+   If you want to store the session payload on the server, you can *[choose how to store it](#storages)*: in the server
+   memory or in a folder. You can also implement a custom storage for keeping session data.
+4. *[Protect session data](#protect_session)*: to protect sensitive session data passed to the client, you need to sign
+   and encrypt the session's payload.
 
-After configuring `%plugin_name%`, you can [get and set session data](#use_sessions) inside [route handlers](Routing_in_Ktor.md#define_route).
-
+After configuring `%plugin_name%`, you can [get and set session data](#use_sessions)
+inside [route handlers](Routing_in_Ktor.md#define_route).
 
 ## Create a data class {id="data_class"}
 
-Before configuring a session, you need to create a [data class](https://kotlinlang.org/docs/data-classes.html) for storing session data. 
+Before configuring a session, you need to create a [data class](https://kotlinlang.org/docs/data-classes.html) for
+storing session data. To make the class serializable, use the `@Serializable` annotation
+from [kotlinx.serialization](https://kotlinlang.org/docs/serialization.html).
+
 For example, the `UserSession` class below will be used to store the session ID and the number of page views:
 
 ```kotlin
 ```
-{src="snippets/session-cookie-client/src/main/kotlin/cookieclient/Application.kt" include-lines="9"}
+
+{src="snippets/session-cookie-client/src/main/kotlin/cookieclient/Application.kt" include-lines="10-11"}
 
 You need to create several data classes if you are going to use several sessions.
 
-> You can optionally inherit your data class from [Principal](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-principal/index.html) to use a session for [](authentication.md). Learn more from [](session-auth.md).
+> You can optionally inherit your data class from
+> [Principal](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-principal/index.html)
+> to use a session for [](authentication.md). Learn more from [](session-auth.md).
 
 ## Pass session data: Cookie vs Header {id="cookie_header"}
 
 ### Cookie {id="cookie"}
-To pass session data using cookies, call the `cookie` function with the specified name and data class inside the `install(Sessions)` block:
+
+To pass session data using cookies, call the `cookie` function with the specified name and data class inside
+the `install(Sessions)` block:
+
 ```kotlin
 install(Sessions) {
     cookie<UserSession>("user_session")
 }
 ```
-In the example above, session data will be passed to the client using the `user_session` attribute added to the `Set-Cookie` header. You can configure other cookie attributes by passing them inside the `cookie` block. For example, the code snippet below shows how to specify a cookie's path and expiration time:
+
+In the example above, session data will be passed to the client using the `user_session` attribute added to
+the `Set-Cookie` header. You can configure other cookie attributes by passing them inside the `cookie` block. For
+example, the code snippet below shows how to specify a cookie's path and expiration time:
 
 ```kotlin
 ```
+
 {src="snippets/session-cookie-client/src/main/kotlin/cookieclient/Application.kt" include-lines="12,15-17,19-20"}
 
-If the required attribute is not exposed explicitly, use the `extensions` property. For example, you can pass the `SameSite`attribute in the following way:
+If the required attribute is not exposed explicitly, use the `extensions` property. For example, you can pass
+the `SameSite`attribute in the following way:
+
 ```kotlin
 install(Sessions) {
     cookie<UserSession>("user_session") {
@@ -86,14 +113,20 @@ install(Sessions) {
     }
 }
 ```
-To learn more about available configurations settings, see [CookieConfiguration](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-sessions/io.ktor.server.sessions/-cookie-configuration/index.html).
 
-> Before [deploying](deploy.md) your application to production, make sure the `secure` property is set to `true`. This enables transferring cookies via a [secure connection](ssl.md) only and protects session data from HTTPS downgrade attacks.
+To learn more about available configurations settings,
+see [CookieConfiguration](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-sessions/io.ktor.server.sessions/-cookie-configuration/index.html).
+
+> Before [deploying](deploy.md) your application to production, make sure the `secure` property is set to `true`. This
+enables transferring cookies via a [secure connection](ssl.md) only and protects session data from HTTPS downgrade
+attacks.
 >
 {type="warning"}
 
 ### Header {id="header"}
-To pass session data using a custom header, call the `header` function with the specified name and data class inside the `install(Sessions)` block:
+
+To pass session data using a custom header, call the `header` function with the specified name and data class inside
+the `install(Sessions)` block:
 
 ```kotlin
 install(Sessions) {
@@ -101,10 +134,11 @@ install(Sessions) {
 }
 ```
 
-In the example above, session data will be passed to the client using the `cart_session` custom header. 
+In the example above, session data will be passed to the client using the `cart_session` custom header.
 On the client side, you need to append this header to each request to get session data.
 
-> If you use the [CORS](cors.md) plugin to handle cross-origin requests, add your custom header to the `CORS` configuration as follows:
+> If you use the [CORS](cors.md) plugin to handle cross-origin requests, add your custom header to the `CORS`
+configuration as follows:
 > ```kotlin
 > install(CORS) {
 >     allowHeader("cart_session")
@@ -112,46 +146,61 @@ On the client side, you need to append this header to each request to get sessio
 > }
 > ```
 
-
 ## Store session payload: Client vs Server {id="client_server"}
 
 In Ktor, you can manage the session data in two ways:
+
 - _Pass session data between the client and server_.
-   
-  If you pass only the session name to the [cookie or header](#cookie_header) function, session data will be passed between the client and server. In this case, you need to [sign and encrypt](#protect_session) the session's payload to protect sensitive session data passed to the client.
+
+  If you pass only the session name to the [cookie or header](#cookie_header) function, session data will be passed
+  between the client and server. In this case, you need to [sign and encrypt](#protect_session) the session's payload to
+  protect sensitive session data passed to the client.
 - _Store session data on the server and pass only a session ID between the client and server_.
-   
-  In such a case, you can choose [where to store the payload](#storages) on the server. For example, you can store session data in memory, in a specified folder, or you can implement your own custom storage.
 
-
+  In such a case, you can choose [where to store the payload](#storages) on the server. For example, you can store
+  session data in memory, in a specified folder, or you can implement your own custom storage.
 
 ## Store session payload on server {id="storages"}
 
-Ktor allows you to store session data [on the server](#client_server) and pass only a session ID between the server and the client. In this case, you can choose where to keep the payload on the server.
+Ktor allows you to store session data [on the server](#client_server) and pass only a session ID between the server and
+the client. In this case, you can choose where to keep the payload on the server.
 
 ### In-memory storage {id="in_memory_storage"}
-[SessionStorageMemory](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-sessions/io.ktor.server.sessions/-session-storage-memory/index.html) enables storing a session's content in memory. This storage keeps data while the server is running and discards information once the server stops. For example, you can store cookies in the server memory as follows:
+
+[SessionStorageMemory](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-sessions/io.ktor.server.sessions/-session-storage-memory/index.html)
+enables storing a session's content in memory. This storage keeps data while the server is running and discards
+information once the server stops. For example, you can store cookies in the server memory as follows:
 
 ```kotlin
 ```
-{src="snippets/session-cookie-server/src/main/kotlin/com/example/Application.kt" include-lines="14,17"}
 
-You can find the full example here: [session-cookie-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-cookie-server).
+{src="snippets/session-cookie-server/src/main/kotlin/com/example/Application.kt" include-lines="16,19"}
+
+For the full example,
+see [session-cookie-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-cookie-server).
 
 > Note that `SessionStorageMemory` is intended for development only.
 
 ### Directory storage {id="directory_storage"}
 
-[directorySessionStorage](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-sessions/io.ktor.server.sessions/directory-session-storage.html) can be used to store a session's data in a file under the specified directory. For example, to store session data in a file under the `build/.sessions` directory, create the `directorySessionStorage` in this way:
+[directorySessionStorage](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-sessions/io.ktor.server.sessions/directory-session-storage.html)
+can be used to store a session's data in a file under the specified directory. For example, to store session data in a
+file under the `build/.sessions` directory, create the `directorySessionStorage` in this way:
+
 ```kotlin
 ```
-{src="snippets/session-header-server/src/main/kotlin/com/example/Application.kt" include-lines="15,17"}
 
-You can find the full example here: [session-header-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-header-server).
+{src="snippets/session-header-server/src/main/kotlin/com/example/Application.kt" include-lines="17,19"}
+
+For the full example,
+see [session-header-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-header-server).
 
 ### Custom storage {id="custom_storage"}
 
-Ktor provides the [SessionStorage](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-sessions/io.ktor.server.sessions/-session-storage/index.html) interface that allows you to implement a custom storage.
+Ktor provides
+the [SessionStorage](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-sessions/io.ktor.server.sessions/-session-storage/index.html)
+interface that allows you to implement a custom storage.
+
 ```kotlin
 interface SessionStorage {
     suspend fun invalidate(id: String)
@@ -159,31 +208,37 @@ interface SessionStorage {
     suspend fun read(id: String): String
 }
 ```
-All three functions are [suspending](https://kotlinlang.org/docs/composing-suspending-functions.html). You can use [SessionStorageMemory](https://github.com/ktorio/ktor/blob/main/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionStorageMemory.kt) as a reference.
 
+All three functions are [suspending](https://kotlinlang.org/docs/composing-suspending-functions.html). You can
+use [SessionStorageMemory](https://github.com/ktorio/ktor/blob/main/ktor-server/ktor-server-plugins/ktor-server-sessions/jvmAndNix/src/io/ktor/server/sessions/SessionStorageMemory.kt)
+as a reference.
 
 ## Protect session data {id="protect_session"}
 
 ### Sign session data {id="sign_session"}
 
 Signing session data prevents modifying a session's content but allows users to see this content.
-To sign a session, pass a sign key to the `SessionTransportTransformerMessageAuthentication` constructor and pass this instance to the `transform` function:
+To sign a session, pass a sign key to the `SessionTransportTransformerMessageAuthentication` constructor and pass this
+instance to the `transform` function:
 
 ```kotlin
 ```
-{src="snippets/session-cookie-server/src/main/kotlin/com/example/Application.kt" include-lines="12-18"}
 
-`SessionTransportTransformerMessageAuthentication` uses `HmacSHA265` as the default authentication algorithm, which can be changed. 
+{src="snippets/session-cookie-server/src/main/kotlin/com/example/Application.kt" include-lines="14-20"}
+
+`SessionTransportTransformerMessageAuthentication` uses `HmacSHA265` as the default authentication algorithm, which can
+be changed.
 
 ### Sign and encrypt session data {id="sign_encrypt_session"}
 
 Signing and encrypting session data prevents reading and modifying a session's content.
-To sign and encrypt a session, pass a sign/encrypt keys to the `SessionTransportTransformerEncrypt` constructor and pass this instance to the `transform` function:
+To sign and encrypt a session, pass a sign/encrypt keys to the `SessionTransportTransformerEncrypt` constructor and pass
+this instance to the `transform` function:
 
 ```kotlin
 ```
 
-{src="snippets/session-cookie-client/src/main/kotlin/cookieclient/Application.kt" include-lines="12-20"}
+{src="snippets/session-cookie-client/src/main/kotlin/cookieclient/Application.kt" include-lines="14-22"}
 
 > Note that the [encryption method has been updated](migrating-3.md#session-encryption-method-update) in Ktor
 > version `3.0.0`. If you are migrating from an earlier version, use the `backwardCompatibleRead` property in the
@@ -191,49 +246,61 @@ To sign and encrypt a session, pass a sign/encrypt keys to the `SessionTransport
 >
 {style="note"}
 
-By default, `SessionTransportTransformerEncrypt` uses the `AES` and `HmacSHA256` algorithms, which can be changed. 
+By default, `SessionTransportTransformerEncrypt` uses the `AES` and `HmacSHA256` algorithms, which can be changed.
 
-> Note that signing/encryption keys shouldn't be specified in code. You can use a custom group in the [configuration file](Configuration-file.topic#configuration-file-overview) to store signing/encryption keys and initialize them using [environment variables](Configuration-file.topic#environment-variables).
+> Note that signing/encryption keys shouldn't be specified in code. You can use a custom group in
+the [configuration file](Configuration-file.topic#configuration-file-overview) to store signing/encryption keys and
+initialize them using [environment variables](Configuration-file.topic#environment-variables).
 >
 {type="warning"}
 
-
-
 ## Get and set session content {id="use_sessions"}
-To set the session content for a specific [route](Routing_in_Ktor.md), use the `call.sessions` property. The `set` method allows you to create a new session instance:
+
+To set the session content for a specific [route](Routing_in_Ktor.md), use the `call.sessions` property. The `set`
+method allows you to create a new session instance:
 
 ```kotlin
 ```
-{src="snippets/session-cookie-client/src/main/kotlin/cookieclient/Application.kt" include-lines="22-25"}
+
+{src="snippets/session-cookie-client/src/main/kotlin/cookieclient/Application.kt" include-lines="24-27"}
 
 To get the session content, you can call `get` receiving one of the registered session types as type parameter:
 
 ```kotlin
 ```
-{src="snippets/session-cookie-client/src/main/kotlin/cookieclient/Application.kt" include-lines="27-28,35"}
+
+{src="snippets/session-cookie-client/src/main/kotlin/cookieclient/Application.kt" include-lines="29-30,37"}
 
 To modify a session, for example, to increment a counter, you need to call the `copy` method of the data class:
 
 ```kotlin
 ```
-{src="snippets/session-cookie-client/src/main/kotlin/cookieclient/Application.kt" include-lines="27-35"}
+
+{src="snippets/session-cookie-client/src/main/kotlin/cookieclient/Application.kt" include-lines="29-37"}
 
 When you need to clear a session for any reason (for example, when a user logs out), call the `clear` function:
 
 ```kotlin
 ```
-{src="snippets/session-cookie-client/src/main/kotlin/cookieclient/Application.kt" include-lines="37-40"}
 
-You can find the full example here: [session-cookie-client](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-cookie-client).
+{src="snippets/session-cookie-client/src/main/kotlin/cookieclient/Application.kt" include-lines="39-42"}
 
+For the full example,
+see [session-cookie-client](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-cookie-client).
 
 ## Examples {id="examples"}
 
 The runnable examples below demonstrate how to use the `%plugin_name%` plugin:
 
-- [session-cookie-client](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-cookie-client) shows how to pass [signed and encrypted](#sign_encrypt_session) session payload to the [client](#client_server) using [cookies](#cookie).
-- [session-cookie-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-cookie-server) shows how to keep session payload in a [server memory](#in_memory_storage) and pass a [signed](#sign_session) session ID to the client using [cookies](#cookie).
-- [session-header-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-header-server) shows how to keep session payload on a server in a [directory storage](#directory_storage) and pass [signed](#sign_session) session ID to the client using a [custom header](#header).
+- [session-cookie-client](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-cookie-client)
+  shows how to pass [signed and encrypted](#sign_encrypt_session) session payload to the [client](#client_server)
+  using [cookies](#cookie).
+- [session-cookie-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-cookie-server)
+  shows how to keep session payload in a [server memory](#in_memory_storage) and pass a [signed](#sign_session) session
+  ID to the client using [cookies](#cookie).
+- [session-header-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-header-server)
+  shows how to keep session payload on a server in a [directory storage](#directory_storage) and
+  pass [signed](#sign_session) session ID to the client using a [custom header](#header).
 
 
 

--- a/v.list
+++ b/v.list
@@ -4,8 +4,8 @@
 
 <vars>
 
-    <var name="ktor_version" value="3.0.0-beta-1"/>
-    <var name="kotlin_version" value="1.9.20"/>
+    <var name="ktor_version" value="3.0.0-beta-2-eap-884"/>
+    <var name="kotlin_version" value="1.9.22"/>
     <var name="coroutines_version" value="1.6.4"/>
     <var name="kotlin_css_version" value="1.0.0-pre.625"/>
     <var name="logback_version" value="1.2.11"/>


### PR DESCRIPTION
[KTOR-6588](https://youtrack.jetbrains.com/issue/KTOR-6588/Documentation-for-Change-default-session-serializer-to-the-one-that-uses-kotlinx-serializaion)

Preview on staging (WS):
 [Sessions]()  |  [Session authentication]()

- added the `@Serializable` annotation from `kotlinx.serialization` (Please confirm that this is the required change in the code examples)
- updated kotlin version to `1.9.22`
- added a mention of the annotation in the "Sessions" and "Session authentication" topics
- updated the code snippets references
- auto-format the edited topics to fix issues