### PR TITLE
KTOR-6769 Fix discrepancies in the procedure for writing integration tests in the Get started tutorial

### DIFF
--- a/codeSnippets/snippets/tutorial-server-get-started/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-get-started/build.gradle.kts
@@ -19,9 +19,10 @@ repositories {
 
 dependencies {
     implementation("io.ktor:ktor-server-status-pages:$ktor_version")
-    implementation("io.ktor:ktor-server-core-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation("io.ktor:ktor-server-core-jvm")
+    implementation("io.ktor:ktor-server-netty-jvm")
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-tests-jvm:$ktor_version")
+    implementation("io.ktor:ktor-server-config-yaml:$ktor_version")
+    testImplementation("io.ktor:ktor-server-tests-jvm")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
 }

--- a/codeSnippets/snippets/tutorial-server-get-started/src/test/kotlin/com/example/ApplicationTest.kt
+++ b/codeSnippets/snippets/tutorial-server-get-started/src/test/kotlin/com/example/ApplicationTest.kt
@@ -6,21 +6,13 @@ import io.ktor.http.*
 import io.ktor.server.testing.*
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import kotlin.test.assertContains
 
-class ApplicationTestGetStarted {
+class ApplicationTest {
     @Test
     fun testRoot() = testApplication {
         val response = client.get("/")
+
         assertEquals(HttpStatusCode.OK, response.status)
         assertEquals("Hello World!", response.bodyAsText())
-    }
-
-    @Test
-    fun testNewEndpoint() = testApplication {
-        val response = client.get("/test1")
-        assertEquals(HttpStatusCode.OK, response.status)
-        assertEquals("html", response.contentType()?.contentSubtype)
-        assertContains(response.bodyAsText(), "Hello From Ktor")
     }
 }

--- a/topics/server_create_a_new_project.topic
+++ b/topics/server_create_a_new_project.topic
@@ -814,26 +814,31 @@
         </chapter>
         <chapter title="Write an integration test" id="write-an-integration-test">
             <p>
-                Ktor provides support for creating integration tests, and a skeleton test is created for you
-                underneath
-                <path>src/test/kotlin</path>
+                Ktor provides support for <a href="Testing.md">creating integration tests</a>, and your generated
+                project comes bundled with this functionality.
             </p>
-            <p>
-                Assuming you have accepted the default settings the class will be called
-                <path>ApplicationTest</path>
-                and will live in the
-                package
-                <path>com.example</path>
-                .
-            </p>
-            <p>
-                In the
-                <ui-path>Project</ui-path>
-                tool window, navigate to the
-                <path>src/test/kotlin</path>
-                folder and follow the steps:
-            </p>
+            <p>To make use of this, follow the steps below:</p>
             <procedure>
+                <step>
+                    <p>
+                        Create a new directory under
+                        <path>src</path>
+                        called "test" and a subdirectory called "kotlin".
+                    </p>
+                </step>
+                <step>
+                    <p>Create a new package inside
+                        <path>src/test/kotlin</path>
+                        called "com.example".
+                    </p>
+                </step>
+                <step>
+                    <p>
+                        Within
+                        <path>src/test/kotlin/com.example</path>
+                        create a new file called "ApplicationTest.kt".
+                    </p>
+                </step>
                 <step>
                     <p>Open the <code>ApplicationTest.kt</code> file and add the code below:</p>
                     <code-block lang="kotlin">


### PR DESCRIPTION
[KTOR-6769](https://youtrack.jetbrains.com/issue/KTOR-6769)

The generated code doesn't create a sample test. Updated the procedure in "Write an integration test" to include creation of necessary files and folders.

Additionally, updated the code sample to include the correct tests from the tutorial.