### PR TITLE
Release docs for Ktor version 2.3.9

### DIFF
--- a/codeSnippets/gradle.properties
+++ b/codeSnippets/gradle.properties
@@ -6,7 +6,7 @@ kotlin.native.binary.memoryModel = experimental
 org.gradle.configureondemand = false
 # versions
 kotlin_version = 1.9.10
-ktor_version = 2.3.8
+ktor_version = 2.3.9
 kotlinx_coroutines_version = 1.6.4
 kotlinx_serialization_version = 1.4.1
 kotlin_css_version = 1.0.0-pre.699

--- a/codeSnippets/snippets/aws-elastic-beanstalk/build.gradle.kts
+++ b/codeSnippets/snippets/aws-elastic-beanstalk/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.8"
+    id("io.ktor.plugin") version "2.3.9"
 }
 
 application {

--- a/codeSnippets/snippets/deployment-ktor-plugin/build.gradle.kts
+++ b/codeSnippets/snippets/deployment-ktor-plugin/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.8"
+    id("io.ktor.plugin") version "2.3.9"
 }
 
 application {

--- a/codeSnippets/snippets/engine-main-custom-environment/build.gradle.kts
+++ b/codeSnippets/snippets/engine-main-custom-environment/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.8"
+    id("io.ktor.plugin") version "2.3.9"
 }
 
 application {

--- a/codeSnippets/snippets/forwarded-header/build.gradle.kts
+++ b/codeSnippets/snippets/forwarded-header/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.8"
+    id("io.ktor.plugin") version "2.3.9"
 }
 
 application {

--- a/codeSnippets/snippets/migrating-express-ktor/gradle.properties
+++ b/codeSnippets/snippets/migrating-express-ktor/gradle.properties
@@ -1,4 +1,4 @@
-ktor_version=2.3.8
+ktor_version=2.3.9
 kotlin_version=1.9.10
 logback_version=1.4.14
 kotlin.code.style=official

--- a/codeSnippets/snippets/proguard/build.gradle.kts
+++ b/codeSnippets/snippets/proguard/build.gradle.kts
@@ -16,7 +16,7 @@ buildscript {
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.8"
+    id("io.ktor.plugin") version "2.3.9"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-client-kmm/gradle/libs.versions.toml
+++ b/codeSnippets/snippets/tutorial-client-kmm/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.2.2"
 kotlin = "1.9.20"
 coroutines = "1.7.3"
-ktor = "2.3.8"
+ktor = "2.3.9"
 compose = "1.5.4"
 compose-compiler = "1.5.4"
 compose-material3 = "1.1.2"

--- a/codeSnippets/snippets/tutorial-http-api/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-http-api/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     application
     kotlin("jvm")
     kotlin("plugin.serialization") version "1.9.10"
-    id("io.ktor.plugin") version "2.3.8"
+    id("io.ktor.plugin") version "2.3.9"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-server-get-started-maven/pom.xml
+++ b/codeSnippets/snippets/tutorial-server-get-started-maven/pom.xml
@@ -8,7 +8,7 @@
     <name>tutorial-server-get-started-maven</name>
     <description>tutorial-server-get-started-maven</description>
     <properties>
-        <ktor_version>2.3.8</ktor_version>
+        <ktor_version>2.3.9</ktor_version>
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin_version>1.9.22</kotlin_version>
         <logback_version>1.4.14</logback_version>

--- a/codeSnippets/snippets/tutorial-server-get-started/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-get-started/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.8"
+    id("io.ktor.plugin") version "2.3.9"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-website-interactive-docker-compose/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-website-interactive-docker-compose/build.gradle.kts
@@ -7,7 +7,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.8"
+    id("io.ktor.plugin") version "2.3.9"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-website-interactive-persistence-advanced/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-website-interactive-persistence-advanced/build.gradle.kts
@@ -9,7 +9,7 @@ val ehcache_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.8"
+    id("io.ktor.plugin") version "2.3.9"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-website-interactive-persistence/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-website-interactive-persistence/build.gradle.kts
@@ -7,7 +7,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.8"
+    id("io.ktor.plugin") version "2.3.9"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-website-interactive/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-website-interactive/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.8"
+    id("io.ktor.plugin") version "2.3.9"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-website-static/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-website-static/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.8"
+    id("io.ktor.plugin") version "2.3.9"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-websockets-server/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-websockets-server/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.8"
+    id("io.ktor.plugin") version "2.3.9"
 }
 
 application {

--- a/help-versions.json
+++ b/help-versions.json
@@ -5,7 +5,7 @@
     "isCurrent": false
   },
   {
-    "version": "2.3.8",
+    "version": "2.3.9",
     "url": "/docs/",
     "isCurrent": false
   },

--- a/project.ihp
+++ b/project.ihp
@@ -14,7 +14,7 @@
     <categories src="c.list"/>
     <instance src="ktor.tree"
               web-path="/docs/"
-              version="2.3.8"
+              version="2.3.9"
               id="docs"
               keymaps-mode="none"/>
 

--- a/topics/releases.md
+++ b/topics/releases.md
@@ -33,6 +33,12 @@ The following table lists details of the latest Ktor releases.
 
 <table>
 <tr><td>Version</td><td>Release Date</td><td>Highlights</td></tr>
+<tr><td>2.3.9</td><td>March 4, 2024</td><td><p>
+A patch release including a bug fix for the ContentNegotiation client plugin, and an added support for sending secure cookies over HTTP.
+</p>
+<var name="version" value="2.3.9"/>
+<include from="lib.topic" element-id="release_details_link"/>
+</td></tr>
 <tr><td>2.3.8</td><td>January 31, 2024</td><td><p>
 A patch release including various bug fixes for URLBuilder, CORS and WebSocket plugins.
 </p>

--- a/v.list
+++ b/v.list
@@ -4,7 +4,7 @@
 
 <vars>
 
-    <var name="ktor_version" value="2.3.8"/>
+    <var name="ktor_version" value="2.3.9"/>
     <var name="kotlin_version" value="1.8.0"/>
     <var name="coroutines_version" value="1.6.4"/>
     <var name="kotlin_css_version" value="1.0.0-pre.625"/>


### PR DESCRIPTION
- updated Ktor and Ktor plugin version in examples
- updated project version and version picker (change not reflected on staging)
- added an entry to the Releases topic ([preview](https://ktor.shared.aws.intellij.net/docs/releases.html))
