### PR TITLE
Fix broken API links in the "Choosing an engine" topic

### DIFF
--- a/topics/Engines.md
+++ b/topics/Engines.md
@@ -44,7 +44,7 @@ A Ktor server application can be [created and run in two ways](create_server.top
 
 ### embeddedServer {id="embeddedServer"}
 
-The [embeddedServer](https://api.ktor.io/ktor-server/ktor-server-host-common/io.ktor.server.engine/embedded-server.html) function accepts an engine factory used to create an engine of a specific type. In the example below, we pass the [Netty](https://api.ktor.io/ktor-server/ktor-server-netty/io.ktor.server.netty/-netty/index.html) factory to run a server with the Netty engine and listen on the `8080` port:
+The [embeddedServer](https://api.ktor.io/ktor-server/ktor-server-core/io.ktor.server.engine/-embedded-server/index.html) function accepts an engine factory used to create an engine of a specific type. In the example below, we pass the [Netty](https://api.ktor.io/ktor-server/ktor-server-netty/io.ktor.server.netty/-netty/index.html) factory to run a server with the Netty engine and listen on the `8080` port:
 
 ```kotlin
 ```
@@ -124,7 +124,7 @@ In this section, we'll take a look at how to specify various engine-specific opt
 
 ### In code {id="embedded-server-configure"}
 
-The `embeddedServer` function allows you to pass engine-specific options using the `configure` optional parameter. This parameter includes options common for all engines and exposed by the [ApplicationEngine.Configuration](https://api.ktor.io/ktor-server/ktor-server-host-common/io.ktor.server.engine/-application-engine/-configuration/index.html) class.
+The `embeddedServer` function allows you to pass engine-specific options using the `configure` optional parameter. This parameter includes options common for all engines and exposed by the [ApplicationEngine.Configuration](https://api.ktor.io/ktor-server/ktor-server-core/io.ktor.server.engine/-application-engine/-configuration/index.html) class.
 
 ```kotlin
 ```


### PR DESCRIPTION
- Choosing an engine
  - [embeddedServer﻿](https://ktor.io/docs/engines.html#embeddedServer)
  - [ApplicationEngine.Configuration](https://ktor.io/docs/engines.html#configure-engine)

