### PR TITLE
Fix ports mapping in docker-compose.yml

### DIFF
--- a/codeSnippets/snippets/tutorial-website-interactive-docker-compose/docker-compose.yml
+++ b/codeSnippets/snippets/tutorial-website-interactive-docker-compose/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       POSTGRES_DB: ktorjournal
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
-      - "54333:5432"
+      - "5432:5432"
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 1s


### PR DESCRIPTION
In docker compose example in the official ktor documentation the port from docker compose configuration doesn't match the port in the source code:
https://github.com/ktorio/ktor-documentation/blob/70822c37b33979538ce08da44f7c93e0eb12ab3e/codeSnippets/snippets/tutorial-website-interactive-docker-compose/src/main/resources/application.conf#L13)

Can be confusing to someone who's reading the documentation