### PR TITLE
Update Ktor version to 2.3.11

### DIFF
--- a/codeSnippets/gradle.properties
+++ b/codeSnippets/gradle.properties
@@ -6,7 +6,7 @@ kotlin.native.binary.memoryModel = experimental
 org.gradle.configureondemand = false
 # versions
 kotlin_version = 1.9.10
-ktor_version = 2.3.10
+ktor_version = 2.3.11
 kotlinx_coroutines_version = 1.6.4
 kotlinx_serialization_version = 1.4.1
 kotlin_css_version = 1.0.0-pre.721

--- a/codeSnippets/snippets/aws-elastic-beanstalk/build.gradle.kts
+++ b/codeSnippets/snippets/aws-elastic-beanstalk/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.10"
+    id("io.ktor.plugin") version "2.3.11"
 }
 
 application {

--- a/codeSnippets/snippets/deployment-ktor-plugin/build.gradle.kts
+++ b/codeSnippets/snippets/deployment-ktor-plugin/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.10"
+    id("io.ktor.plugin") version "2.3.11"
 }
 
 application {

--- a/codeSnippets/snippets/engine-main-custom-environment/build.gradle.kts
+++ b/codeSnippets/snippets/engine-main-custom-environment/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.10"
+    id("io.ktor.plugin") version "2.3.11"
 }
 
 application {

--- a/codeSnippets/snippets/forwarded-header/build.gradle.kts
+++ b/codeSnippets/snippets/forwarded-header/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.10"
+    id("io.ktor.plugin") version "2.3.11"
 }
 
 application {

--- a/codeSnippets/snippets/migrating-express-ktor/gradle.properties
+++ b/codeSnippets/snippets/migrating-express-ktor/gradle.properties
@@ -1,4 +1,4 @@
-ktor_version=2.3.10
+ktor_version=2.3.11
 kotlin_version=1.9.10
 logback_version=1.5.3
 kotlin.code.style=official

--- a/codeSnippets/snippets/proguard/build.gradle.kts
+++ b/codeSnippets/snippets/proguard/build.gradle.kts
@@ -16,7 +16,7 @@ buildscript {
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.10"
+    id("io.ktor.plugin") version "2.3.11"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-client-kmm/gradle/libs.versions.toml
+++ b/codeSnippets/snippets/tutorial-client-kmm/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.3.1"
 kotlin = "1.9.20"
 coroutines = "1.8.0"
-ktor = "2.3.10"
+ktor = "2.3.11"
 compose = "1.6.3"
 compose-compiler = "1.5.4"
 compose-material3 = "1.2.1"

--- a/codeSnippets/snippets/tutorial-http-api/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-http-api/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     application
     kotlin("jvm")
     kotlin("plugin.serialization") version "1.9.10"
-    id("io.ktor.plugin") version "2.3.10"
+    id("io.ktor.plugin") version "2.3.11"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-server-get-started-maven/pom.xml
+++ b/codeSnippets/snippets/tutorial-server-get-started-maven/pom.xml
@@ -8,7 +8,7 @@
     <name>tutorial-server-get-started-maven</name>
     <description>tutorial-server-get-started-maven</description>
     <properties>
-        <ktor_version>2.3.10</ktor_version>
+        <ktor_version>2.3.11</ktor_version>
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin_version>1.9.22</kotlin_version>
         <logback_version>1.5.3</logback_version>

--- a/codeSnippets/snippets/tutorial-server-get-started/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-get-started/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.10"
+    id("io.ktor.plugin") version "2.3.11"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-website-interactive-docker-compose/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-website-interactive-docker-compose/build.gradle.kts
@@ -7,7 +7,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.10"
+    id("io.ktor.plugin") version "2.3.11"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-website-interactive-persistence-advanced/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-website-interactive-persistence-advanced/build.gradle.kts
@@ -9,7 +9,7 @@ val ehcache_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.10"
+    id("io.ktor.plugin") version "2.3.11"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-website-interactive-persistence/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-website-interactive-persistence/build.gradle.kts
@@ -7,7 +7,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.10"
+    id("io.ktor.plugin") version "2.3.11"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-website-interactive/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-website-interactive/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.10"
+    id("io.ktor.plugin") version "2.3.11"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-website-static/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-website-static/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.10"
+    id("io.ktor.plugin") version "2.3.11"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-websockets-server/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-websockets-server/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.10"
+    id("io.ktor.plugin") version "2.3.11"
 }
 
 application {

--- a/help-versions.json
+++ b/help-versions.json
@@ -5,7 +5,7 @@
     "isCurrent": false
   },
   {
-    "version": "2.3.10",
+    "version": "2.3.11",
     "url": "/docs/",
     "isCurrent": false
   },

--- a/project.ihp
+++ b/project.ihp
@@ -14,7 +14,7 @@
     <categories src="c.list"/>
     <instance src="ktor.tree"
               web-path="/docs/"
-              version="2.3.10"
+              version="2.3.11"
               id="docs"
               keymaps-mode="none"/>
 

--- a/topics/client-timeout.md
+++ b/topics/client-timeout.md
@@ -68,4 +68,4 @@ supported by those engines:
 | [Darwin](client-engines.md#darwin) | ✅️              | ✖️              | ✅️             |
 | [JavaScript](client-engines.md#js) | ✅               | ✖️              | ✖️             |
 | [Curl](client-engines.md#curl)     | ✅               | ✅️              | ✖️             |
-| [MockEngine](client-testing.md)    | ✅               | ✖️              | ✖️             |
+| [MockEngine](client-testing.md)    | ✅               | ✖️              | ✅              |

--- a/topics/releases.md
+++ b/topics/releases.md
@@ -33,6 +33,12 @@ The following table lists details of the latest Ktor releases.
 
 <table>
 <tr><td>Version</td><td>Release Date</td><td>Highlights</td></tr>
+<tr><td>2.3.11</td><td>May 9, 2024</td><td><p>
+A patch release, including a bug fix for applying a socket timeout to the Test Client's engine.
+</p>
+<var name="version" value="2.3.11"/>
+<include from="lib.topic" element-id="release_details_link"/>
+</td></tr>
 <tr><td>2.3.10</td><td>April 8, 2024</td><td><p>
 A patch release including various bug fixes for the CallLogging and SSE server plugins, improved Android client logging, and more.
 </p>

--- a/v.list
+++ b/v.list
@@ -4,8 +4,8 @@
 
 <vars>
 
-    <var name="ktor_version" value="2.3.10"/>
-    <var name="kotlin_version" value="1.8.0"/>
+    <var name="ktor_version" value="2.3.11"/>
+    <var name="kotlin_version" value="1.9.10"/>
     <var name="coroutines_version" value="1.6.4"/>
     <var name="kotlin_css_version" value="1.0.0-pre.625"/>
     <var name="logback_version" value="1.2.11"/>


### PR DESCRIPTION
- update the Ktor version and plugins from 2.3.10 to 2.3.11
- add a [release](https://writerside.labs.jb.gg/staging/staging/ktor/2.3.11/releases.html#release-details) entry
- update MockEngine support for Socket timeout in the [client-timeout](https://writerside.labs.jb.gg/staging/staging/ktor/2.3.11/client-timeout.html#limitations) topic