### PR TITLE
Fix code example name and add a missing README

### DIFF
--- a/codeSnippets/snippets/tutorial-server-web-application/README.md
+++ b/codeSnippets/snippets/tutorial-server-web-application/README.md
@@ -1,0 +1,18 @@
+# An interactive website for task management
+
+A web application built with Ktor and Thymeleaf templates by following the steps explained in
+the [Create a website](https://ktor.io/docs/server-create-website.html) tutorial.
+> This sample is a part of the [codeSnippets](../../README.md) Gradle project.
+
+## Run
+
+To run the application, execute the following command in the repository's root directory:
+
+```bash
+./gradlew :tutorial-server-web-application:run
+```
+
+Then, you can navigate to the following URLs:
+
+- [http://0.0.0.0:8080/tasks](http://0.0.0.0:8080/tasks) to see all tasks displayed in a table.
+- [http://0.0.0.0:8080/static/index.html](http://0.0.0.0:8080/static/index.html) to filer and create tasks.

--- a/topics/server-integrate-database.topic
+++ b/topics/server-integrate-database.topic
@@ -6,7 +6,7 @@
        title="Integrate a database with Kotlin, Ktor, and Exposed" id="server-integrate-database">
     <show-structure for="chapter" depth="2"/>
     <tldr>
-        <var name="example_name" value="tutorial-server-database-integration"/>
+        <var name="example_name" value="tutorial-server-db-integration"/>
         <include from="lib.topic" element-id="download_example"/>
         <p>
             <b>Used plugins</b>: <a href="server-routing.md"/>,<a href="server-static-content.md">Static Content</a>,


### PR DESCRIPTION
1. Fix the name of the code example for the "Integrate a database" tutorial.
2. Add a README.md file in the code example for the "Create a website" tutorial.