### PR TITLE
Refactor/update ktor server proguard simple

### DIFF
--- a/codeSnippets/snippets/proguard/README.md
+++ b/codeSnippets/snippets/proguard/README.md
@@ -22,11 +22,15 @@ this example:
 3. [Proguard](https://github.com/Guardsquare/proguard) Kotlin Example: https://github.com/Guardsquare/proguard/blob/master/examples/application-kotlin/proguard.pro
 4. [Google Guava](https://github.com/google/guava): https://github.com/google/guava/wiki/UsingProGuardWithGuava
 
-This example is configured to work with Kotlinx coroutines and serialization, required modules that are part of the JDK
+This example is already configured to work the libraries mentioned above, required modules that are part of the JDK
 and some libraries that Ktor server depends on.
 
+> If you're using Ktor Client with OkHttp as an engine in Ktor Server, you need to include
+> [OkHttp Proguard](https://square.github.io/okhttp/features/r8_proguard/) Rules, otherwise you will get warnings that
+> cause the proguard task build to fail.
+
 If you're using additional libraries that use features such as 
-reflections or dynamic class loading, You will get a warning that needs to be solved, some common ways to solve this:
+reflections or dynamic class loading, You will usually get warnings that need to be solved, some common ways to solve this:
 
 1. You can see if the library supports Proguard, take a look at the docs, resources of the module you want to include.
 `README.md` file, or some common folders such as `proguard` or `rules`, also in `META-INF/proguard` in the JAR file, which

--- a/codeSnippets/snippets/proguard/README.md
+++ b/codeSnippets/snippets/proguard/README.md
@@ -3,12 +3,30 @@
 A sample project packed as a JAR using the [Ktor Gradle plugin](https://ktor.io/docs/fatjar.html) and minimized using [ProGuard](https://www.guardsquare.com/manual/home).
 > This sample is a part of the [codeSnippets](../../README.md) Gradle project.
 
+This example is configured to work with Kotlinx coroutines and serialization, required modules that are part of the JDK
+and some libraries that Ktor server depends on.
+
+if you're using additional libraries that use features such as 
+reflections or dynamic class loading, You will get a warning that needs to be solved.
+
+For this example, the Fat JAR size is (15.2 MB) and the minimized JAR (9 MB). This will
+be different depending on your project, dependencies, and Proguard configurations.
+
 ## Running
 
 To build a minimized JAR and run the application, execute the following commands:
+
 ```bash
-./gradlew :proguard:minimizedJar
+./gradlew :proguard:buildMinimizedJar
 java -jar snippets/proguard/build/libs/my-application.min.jar
 ```
 
+or run the JAR directly using a Gradle task:
+
+```bash
+./gradlew :proguard:runMinimizedJar
+```
+
 Then, navigate to [http://localhost:8080/](http://localhost:8080/) to see the sample home page.
+
+> Replace `gradlew` with `gradlew.bat` if you're using **Microsoft Windows**

--- a/codeSnippets/snippets/proguard/README.md
+++ b/codeSnippets/snippets/proguard/README.md
@@ -3,14 +3,52 @@
 A sample project packed as a JAR using the [Ktor Gradle plugin](https://ktor.io/docs/fatjar.html) and minimized using [ProGuard](https://www.guardsquare.com/manual/home).
 > This sample is a part of the [codeSnippets](../../README.md) Gradle project.
 
+**Proguard** is a tool to shrink, obfuscate, and optimizer for Java bytecode and Android apps, it's the default solution
+used in frameworks and projects
+like [Compose Desktop](https://github.com/JetBrains/compose-multiplatform/blob/master/tutorials/Native_distributions_and_local_execution/README.md#minification--obfuscation).
+
+Proguard will need rules to keep some classes that use **reflection** and **dynamic access
+(dynamic class loading)** to work correctly.
+
+Proguard will give you **warnings** that need to be **either solved or suppressed**. 
+This is usually caused by missing class references, Java module that's used yet not included, or when it detects usages
+that can't be automated.
+
+Libraries and frameworks might have rules that need to be included to work properly, the following rules are included in
+this example:
+
+1. [Kotlinx Coroutines](https://github.com/Kotlin/kotlinx.coroutines): https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro
+2. [Kotlinx Serialization](https://github.com/Kotlin/kotlinx.serialization): https://github.com/Kotlin/kotlinx.serialization/blob/master/rules/common.pro
+3. [Proguard](https://github.com/Guardsquare/proguard) Kotlin Example: https://github.com/Guardsquare/proguard/blob/master/examples/application-kotlin/proguard.pro
+4. [Google Guava](https://github.com/google/guava): https://github.com/google/guava/wiki/UsingProGuardWithGuava
+
 This example is configured to work with Kotlinx coroutines and serialization, required modules that are part of the JDK
 and some libraries that Ktor server depends on.
 
-if you're using additional libraries that use features such as 
-reflections or dynamic class loading, You will get a warning that needs to be solved.
+If you're using additional libraries that use features such as 
+reflections or dynamic class loading, You will get a warning that needs to be solved, some common ways to solve this:
 
-For this example, the Fat JAR size is (15.2 MB) and the minimized JAR (9 MB). This will
-be different depending on your project, dependencies, and Proguard configurations.
+1. You can see if the library supports Proguard, take a look at the docs, resources of the module you want to include.
+`README.md` file, or some common folders such as `proguard` or `rules`, also in `META-INF/proguard` in the JAR file, which
+will be included even when not using Proguard if the library has Proguard rules.
+2. If the warning says, it can't find a certain class or package from Java,
+   you need to update your Proguard configurations
+   to either include the required modules or include them all.
+   Proguard will need access to the JDK even if your application
+   requires installing of JRE to minimize, shrink correctly.
+3. You can try to write custom rules, see [Proguard Configurations Usage](https://www.guardsquare.com/manual/configuration/usage)
+4. Or you can exclude the library from minimization if it heavily depends on reflections,
+   or ignore all the warnings from it, notice it'd not recommended to use `ignorewarnings` as the warnings will catch many common bugs and runtime 
+   errors, instead, ignore warnings from a certain package if it doesn't cause any issues
+
+For this example:
+- **Fat JAR**: 15.2 MB
+- **Minimized JAR with obfuscation disabled**: 9 MB (reduced by 40.79%)
+
+This will be different depending on your project, dependencies, and Proguard configurations.<br>
+Generally, you can reduce the size of an application by anything between **20%** and **90%**
+
+For more details on how Proguard works, see [Proguard Manual](https://www.guardsquare.com/manual/home).
 
 ## Running
 

--- a/codeSnippets/snippets/proguard/README.md
+++ b/codeSnippets/snippets/proguard/README.md
@@ -1,58 +1,75 @@
 # ProGuard
 
-A sample project packed as a JAR using the [Ktor Gradle plugin](https://ktor.io/docs/fatjar.html) and minimized using [ProGuard](https://www.guardsquare.com/manual/home).
+A sample project packed as a JAR using the [Ktor Gradle plugin](https://ktor.io/docs/fatjar.html) and minimized
+using [ProGuard](https://www.guardsquare.com/manual/home).
 > This sample is a part of the [codeSnippets](../../README.md) Gradle project.
 
-**Proguard** is a tool to shrink, obfuscate, and optimizer for Java bytecode and Android apps, it's the default solution
-used in frameworks and projects
-like [Compose Desktop](https://github.com/JetBrains/compose-multiplatform/blob/master/tutorials/Native_distributions_and_local_execution/README.md#minification--obfuscation).
+ProGuard is a tool used to shrink, obfuscate, and optimize Java bytecode and Android applications. It's the default
+solution in frameworks and projects such
+as [Compose Desktop](https://github.com/JetBrains/compose-multiplatform/blob/master/tutorials/Native_distributions_and_local_execution/README.md#minification--obfuscation).
 
-Proguard will need rules to keep some classes that use **reflection** and **dynamic access
-(dynamic class loading)** to work correctly.
+## Configuration
 
-Proguard will give you **warnings** that need to be **either solved or suppressed**. 
-This is usually caused by missing class references, Java module that's used yet not included, or when it detects usages
-that can't be automated.
+Certain libraries and frameworks require specific ProGuard rules to function properly. The following rules are included
+in this example:
 
-Libraries and frameworks might have rules that need to be included to work properly, the following rules are included in
-this example:
+1. [Kotlinx Coroutines](https://github.com/Kotlin/kotlinx.coroutines): [ProGuard rules](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro)
+2. [Kotlinx Serialization](https://github.com/Kotlin/kotlinx.serialization): [ProGuard rules](https://github.com/Kotlin/kotlinx.serialization/blob/master/rules/common.pro)
+3. [Proguard Kotlin Example](https://github.com/Guardsquare/proguard): [ProGuard rules](https://github.com/Guardsquare/proguard/blob/master/examples/application-kotlin/proguard.pro)
+4. [Google Guava](https://github.com/google/guava): [ProGuard rules](https://github.com/google/guava/wiki/UsingProGuardWithGuava)
 
-1. [Kotlinx Coroutines](https://github.com/Kotlin/kotlinx.coroutines): https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro
-2. [Kotlinx Serialization](https://github.com/Kotlin/kotlinx.serialization): https://github.com/Kotlin/kotlinx.serialization/blob/master/rules/common.pro
-3. [Proguard](https://github.com/Guardsquare/proguard) Kotlin Example: https://github.com/Guardsquare/proguard/blob/master/examples/application-kotlin/proguard.pro
-4. [Google Guava](https://github.com/google/guava): https://github.com/google/guava/wiki/UsingProGuardWithGuava
-
-This example is already configured to work the libraries mentioned above, required modules that are part of the JDK
-and some libraries that Ktor server depends on.
+This example is already configured to work the libraries mentioned above, required JDK modules,
+and some dependencies of Ktor Server.
 
 > If you're using Ktor Client with OkHttp as an engine in Ktor Server, you need to include
-> [OkHttp Proguard](https://square.github.io/okhttp/features/r8_proguard/) Rules, otherwise you will get warnings that
+> [OkHttp ProGuard rules](https://square.github.io/okhttp/features/r8_proguard/), otherwise you will get warnings that
 > cause the proguard task build to fail.
 
-If you're using additional libraries that use features such as 
-reflections or dynamic class loading, You will usually get warnings that need to be solved, some common ways to solve this:
+## Reflection and dynamic access
 
-1. You can see if the library supports Proguard, take a look at the docs, resources of the module you want to include.
-`README.md` file, or some common folders such as `proguard` or `rules`, also in `META-INF/proguard` in the JAR file, which
-will be included even when not using Proguard if the library has Proguard rules.
-2. If the warning says, it can't find a certain class or package from Java,
-   you need to update your Proguard configurations
-   to either include the required modules or include them all.
-   Proguard will need access to the JDK even if your application
-   requires installing of JRE to minimize, shrink correctly.
-3. You can try to write custom rules, see [Proguard Configurations Usage](https://www.guardsquare.com/manual/configuration/usage)
-4. Or you can exclude the library from minimization if it heavily depends on reflections,
-   or ignore all the warnings from it, notice it'd not recommended to use `ignorewarnings` as the warnings will catch many common bugs and runtime 
-   errors, instead, ignore warnings from a certain package if it doesn't cause any issues
+ProGuard requires specific rules to preserve classes that use reflection and dynamic access (dynamic class loading) to
+ensure these features work correctly.
+
+## Handling warnings
+
+ProGuard will generate warnings that are usually caused by missing class references, Java modules being used but not
+included, or usages that can't be automated. They must either be resolved or suppressed to maintain proper
+functionality.
+
+The following are common ways to solve some warnings:
+
+1. **Check library ProGuard support**
+
+   Verify if the library supports ProGuard by checking in the documentation, resources of the module you want to
+   include, the `README.md` file, or common folders such as `proguard` or `rules`. Look in `META-INF/proguard` within
+   the JAR file, which will be included if the library has Proguard rules.
+2. **Update ProGuard configurations**
+
+   If the warning indicates a missing class or package from Java,
+   update your ProGuard configurations to include the required modules or all modules.
+   ProGuard will need access to the JDK to minimize and shrink correctly, even if your application only
+   requires installing of JRE.
+3. **Write custom rules**
+
+   Consider writing custom rules. For more information, refer to
+   the [Proguard Configurations Usage](https://www.guardsquare.com/manual/configuration/usage).
+4. **Exclude libraries or ignore warnings**
+
+   You can exclude the library from minimization if it heavily depends on reflections,
+   or ignore all the warnings specific to it. Avoid using `ignorewarnings`, as warnings often catch
+   common bugs and runtime errors. Instead, ignore warnings from certain packages if they don't cause issues.
+
+## JAR size reduction
 
 For this example:
+
 - **Fat JAR**: 15.2 MB
 - **Minimized JAR with obfuscation disabled**: 9 MB (reduced by 40.79%)
 
-This will be different depending on your project, dependencies, and Proguard configurations.<br>
-Generally, you can reduce the size of an application by anything between **20%** and **90%**
+This reduction will vary depending on your project, dependencies, and ProGuard configurations.
+Typically, you can reduce the size of an application by anywhere between **20%** and **90%**.
 
-For more details on how Proguard works, see [Proguard Manual](https://www.guardsquare.com/manual/home).
+For more details on how ProGuard works, see the [Proguard Manual](https://www.guardsquare.com/manual/home).
 
 ## Running
 
@@ -69,6 +86,7 @@ or run the JAR directly using a Gradle task:
 ./gradlew :proguard:runMinimizedJar
 ```
 
+> On **Microsoft Windows**, replace `gradlew` with `gradlew.bat`.
+
 Then, navigate to [http://localhost:8080/](http://localhost:8080/) to see the sample home page.
 
-> Replace `gradlew` with `gradlew.bat` if you're using **Microsoft Windows**

--- a/codeSnippets/snippets/proguard/build.gradle.kts
+++ b/codeSnippets/snippets/proguard/build.gradle.kts
@@ -42,6 +42,13 @@ ktor {
     }
 }
 
+fun getMinimizedJarFile(
+    fatJarFileNameWithoutExtension: String,
+    fatJarDestinationDirectory: DirectoryProperty
+): Provider<RegularFile> {
+    return fatJarDestinationDirectory.file("$fatJarFileNameWithoutExtension.min.jar")
+}
+
 val buildMinimizedJar = tasks.register<proguard.gradle.ProGuardTask>("buildMinimizedJar") {
     group = "ktor"
 
@@ -51,7 +58,10 @@ val buildMinimizedJar = tasks.register<proguard.gradle.ProGuardTask>("buildMinim
     val fatJarFileNameWithoutExtension = fatJarFile.get().asFile.nameWithoutExtension
     val fatJarDestinationDirectory = tasks.shadowJar.get().destinationDirectory
 
-    val minimizedJarFile = fatJarDestinationDirectory.get().file("$fatJarFileNameWithoutExtension-min.jar")
+    val minimizedJarFile = getMinimizedJarFile(
+        fatJarFileNameWithoutExtension = fatJarFileNameWithoutExtension,
+        fatJarDestinationDirectory = fatJarDestinationDirectory
+    )
 
     injars(fatJarFile)
     outjars(minimizedJarFile)
@@ -115,5 +125,13 @@ tasks.register<JavaExec>("runMinimizedJar") {
     group = "ktor"
 
     dependsOn(buildMinimizedJar)
-    classpath = files(tasks.shadowJar.get().archiveFile)
+
+    val fatJarFileNameWithoutExtension = tasks.shadowJar.get().archiveFile.get().asFile.nameWithoutExtension
+    val fatJarDestinationDirectory = tasks.shadowJar.get().destinationDirectory
+
+    val minimizedJarFile = getMinimizedJarFile(
+        fatJarFileNameWithoutExtension = fatJarFileNameWithoutExtension,
+        fatJarDestinationDirectory = fatJarDestinationDirectory
+    )
+    classpath = files(minimizedJarFile)
 }

--- a/codeSnippets/snippets/proguard/build.gradle.kts
+++ b/codeSnippets/snippets/proguard/build.gradle.kts
@@ -1,4 +1,4 @@
-import proguard.gradle.*
+import java.io.FileNotFoundException
 
 val ktor_version: String by project
 val kotlin_version: String by project
@@ -9,7 +9,7 @@ buildscript {
         maven("https://plugins.gradle.org/m2")
     }
     dependencies {
-        classpath("com.guardsquare:proguard-gradle:7.4.2")
+        classpath("com.guardsquare:proguard-gradle:7.5.0")
     }
 }
 
@@ -41,25 +41,74 @@ ktor {
     }
 }
 
-task(name = "minimizedJar", type = ProGuardTask::class) {
-    dependsOn("buildFatJar")
-    injars("build/libs/my-application.jar")
-    outjars("build/libs/my-application.min.jar")
+val buildMinimizedJar = tasks.register<proguard.gradle.ProGuardTask>("buildMinimizedJar") {
+    group = "ktor"
+
+    dependsOn(tasks.buildFatJar)
+
+    val fatJarFile = tasks.shadowJar.flatMap { it.archiveFile }
+    val fatJarFileNameWithoutExtension = fatJarFile.get().asFile.nameWithoutExtension
+    val fatJarDestinationDirectory = tasks.shadowJar.get().destinationDirectory
+    injars(fatJarFile)
+    outjars(
+        fatJarDestinationDirectory.file("${fatJarFileNameWithoutExtension}.min.jar")
+    )
+
+    // Automatically handle the Java version of this build.
     val javaHome = System.getProperty("java.home")
     if (System.getProperty("java.version").startsWith("1.")) {
         // Before Java 9, runtime classes are packaged in a single JAR file.
         libraryjars("$javaHome/lib/rt.jar")
     } else {
         // Starting from Java 9, runtime classes are packaged in modular JMOD files.
-        libraryjars(
-            mapOf("jarfilter" to "!**.jar", "filter" to "!module-info.class"),
-            "$javaHome/jmods/java.base.jmod"
+        fun includeJavaModuleFromJDK(jModFileName: String) {
+            val jModFilePath = "$javaHome/jmods/$jModFileName"
+            val jModFile = File(jModFilePath)
+            if (!jModFile.exists()) {
+                throw FileNotFoundException("The '$jModFile' at '$jModFilePath' doesn't exist.")
+            }
+            libraryjars(
+                mapOf("jarfilter" to "!**.jar", "filter" to "!module-info.class"),
+                jModFilePath,
+            )
+        }
+        val javaModules = listOf(
+            "java.base.jmod",
+            // All imports from "org.mozilla.javascript.tools.debugger" use Java Swing/Desktop imports
+            "java.desktop.jmod",
+            // Some libraries depends on Java logging
+            "java.logging.jmod",
+            // Some libraries depends on Java xml
+            "java.xml.jmod",
+            // Needed by some Ktor modules such as "ktor-server-auth-jvm"
+            "java.naming.jmod",
+            // Needed by some Ktor packages such as "io.ktor.util.debug"
+            "java.management.jmod",
+            // Needed by some libraries such as "com.github.fge.jsonschema"
+            "java.scripting.jmod",
+            // All classes in "com.fasterxml.jackson.databind" need this
+            "java.sql.jmod",
+            // Might be needed when using Java engine in Ktor Client
+            "java.net.http.jmod"
         )
+        javaModules.forEach { includeJavaModuleFromJDK(it) }
     }
-    printmapping("build/libs/my-application.map")
-    ignorewarnings()
+
+    // This will include the Kotlin library jars, it will be needed even though Shadow JAR already includes it
+    // to solve all warnings that are related to Kotlin without '-dontwarn kotlin.**'
+    // this will also solve warnings that are coming from some libraries
+    injars(sourceSets.main.get().compileClasspath)
+
+    printmapping(fatJarDestinationDirectory.file("$fatJarFileNameWithoutExtension.map"))
     dontobfuscate()
     dontoptimize()
-    dontwarn()
-    configuration("proguard.pro")
+
+    configuration(file("proguard.pro"))
+}
+
+tasks.register<JavaExec>("runMinimizedJar") {
+    group = "ktor"
+
+    dependsOn(buildMinimizedJar)
+    classpath = files(tasks.shadowJar.get().archiveFile)
 }

--- a/codeSnippets/snippets/proguard/proguard.pro
+++ b/codeSnippets/snippets/proguard/proguard.pro
@@ -1,6 +1,251 @@
--keep class io.ktor.server.netty.EngineMain { *; }
--keep class io.ktor.server.config.HoconConfigLoader { *; }
--keep class com.example.ApplicationKt { *; }
+# Proguard Kotlin Example https://github.com/Guardsquare/proguard/blob/master/examples/application-kotlin/proguard.pro
+
+-keepattributes *Annotation*
+
+-keep class kotlin.Metadata { *; }
+
+# Kotlin
+
 -keep class kotlin.reflect.jvm.internal.** { *; }
 -keep class kotlin.text.RegexOption { *; }
+
+# Kotlinx Coroutines https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro
+
+# ServiceLoader support
+-keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}
+-keepnames class kotlinx.coroutines.CoroutineExceptionHandler {}
+
+# Most of volatile fields are updated with AFU and should not be mangled
+-keepclassmembers class kotlinx.coroutines.** {
+    volatile <fields>;
+}
+
+# Same story for the standard library's SafeContinuation that also uses AtomicReferenceFieldUpdater
+-keepclassmembers class kotlin.coroutines.SafeContinuation {
+    volatile <fields>;
+}
+
+# These classes are only required by kotlinx.coroutines.debug.AgentPremain, which is only loaded when
+# kotlinx-coroutines-core is used as a Java agent, so these are not needed in contexts where ProGuard is used.
+-dontwarn java.lang.instrument.ClassFileTransformer
+-dontwarn sun.misc.SignalHandler
+-dontwarn java.lang.instrument.Instrumentation
+-dontwarn sun.misc.Signal
+
+# Only used in `kotlinx.coroutines.internal.ExceptionsConstructor`.
+# The case when it is not available is hidden in a `try`-`catch`, as well as a check for Android.
+-dontwarn java.lang.ClassValue
+
+# An annotation used for build tooling, won't be directly accessed.
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+# Kotlinx Serialization https://github.com/Kotlin/kotlinx.serialization/blob/master/rules/common.pro
+
+# Keep `Companion` object fields of serializable classes.
+# This avoids serializer lookup through `getDeclaredClasses` as done for named companion objects.
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1> {
+    static <1>$Companion Companion;
+}
+
+# Keep `serializer()` on companion objects (both default and named) of serializable classes.
+-if @kotlinx.serialization.Serializable class ** {
+    static **$* *;
+}
+-keepclassmembers class <2>$<3> {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# Keep `INSTANCE.serializer()` of serializable objects.
+-if @kotlinx.serialization.Serializable class ** {
+    public static ** INSTANCE;
+}
+-keepclassmembers class <1> {
+    public static <1> INSTANCE;
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# @Serializable and @Polymorphic are used at runtime for polymorphic serialization.
+-keepattributes RuntimeVisibleAnnotations,AnnotationDefault
+
+# Don't print notes about potential mistakes or omissions in the configuration for kotlinx-serialization classes
+# See also https://github.com/Kotlin/kotlinx.serialization/issues/1900
+-dontnote kotlinx.serialization.**
+
+# Serialization core uses `java.lang.ClassValue` for caching inside these specified classes.
+# If there is no `java.lang.ClassValue` (for example, in Android), then R8/ProGuard will print a warning.
+# However, since in this case they will not be used, we can disable these warnings
+-dontwarn kotlinx.serialization.internal.ClassValueReferences
+
+# Ktor Server
+
+-keep class io.ktor.server.netty.EngineMain { *; }
+-keep class io.ktor.server.config.HoconConfigLoader { *; }
 -keep class io.ktor.serialization.kotlinx.json.KotlinxSerializationJsonExtensionProvider { *; }
+
+# Logback (Custom rules, see https://github.com/krschultz/android-proguard-snippets/blob/master/libraries/proguard-logback-android.pro)
+# to ignore warnings coming from slf4j and logback
+
+-keep class ch.qos.** { *; }
+-dontwarn ch.qos.**
+
+-keep class org.slf4j.** { *; }
+-dontwarn org.slf4j.**
+
+-dontwarn ch.qos.logback.core.net.*
+
+# Joda-Time Library
+-keep class org.joda.time.** { *; }
+-dontwarn org.joda.time.**
+
+# Google Guava (https://github.com/google/guava/wiki/UsingProGuardWithGuava)
+
+-dontwarn javax.lang.model.element.Modifier
+
+# Note: We intentionally don't add the flags we'd need to make Enums work.
+# That's because the Proguard configuration required to make it work on
+# optimized code would preclude lots of optimization, like converting enums
+# into ints.
+
+# Throwables uses internal APIs for lazy stack trace resolution
+-dontnote sun.misc.SharedSecrets
+-keep class sun.misc.SharedSecrets {
+  *** getJavaLangAccess(...);
+}
+-dontnote sun.misc.JavaLangAccess
+-keep class sun.misc.JavaLangAccess {
+  *** getStackTraceElement(...);
+  *** getStackTraceDepth(...);
+}
+
+# FinalizableReferenceQueue calls this reflectively
+# Proguard is intelligent enough to spot the use of reflection onto this, so we
+# only need to keep the names, and allow it to be stripped out if
+# FinalizableReferenceQueue is unused.
+-keepnames class com.google.common.base.internal.Finalizer {
+  *** startFinalizer(...);
+}
+# However, it cannot "spot" that this method needs to be kept IF the class is.
+-keepclassmembers class com.google.common.base.internal.Finalizer {
+  *** startFinalizer(...);
+}
+-keepnames class com.google.common.base.FinalizableReference {
+  void finalizeReferent();
+}
+-keepclassmembers class com.google.common.base.FinalizableReference {
+  void finalizeReferent();
+}
+
+# Striped64, LittleEndianByteArray, UnsignedBytes, AbstractFuture
+-dontwarn sun.misc.Unsafe
+
+# Striped64 appears to make some assumptions about object layout that
+# really might not be safe. This should be investigated.
+-keepclassmembers class com.google.common.cache.Striped64 {
+  *** base;
+  *** busy;
+}
+-keepclassmembers class com.google.common.cache.Striped64$Cell {
+  <fields>;
+}
+
+-dontwarn java.lang.SafeVarargs
+
+-keep class java.lang.Throwable {
+  *** addSuppressed(...);
+}
+
+# Futures.getChecked, in both of its variants, is incompatible with proguard.
+
+# Used by AtomicReferenceFieldUpdater and sun.misc.Unsafe
+-keepclassmembers class com.google.common.util.concurrent.AbstractFuture** {
+  *** waiters;
+  *** value;
+  *** listeners;
+  *** thread;
+  *** next;
+}
+-keepclassmembers class com.google.common.util.concurrent.AtomicDouble {
+  *** value;
+}
+-keepclassmembers class com.google.common.util.concurrent.AggregateFutureState {
+  *** remaining;
+  *** seenExceptions;
+}
+
+# Since Unsafe is using the field offsets of these inner classes, we don't want
+# to have class merging or similar tricks applied to these classes and their
+# fields. It's safe to allow obfuscation, since the by-name references are
+# already preserved in the -keep statement above.
+-keep,allowshrinking,allowobfuscation class com.google.common.util.concurrent.AbstractFuture** {
+  <fields>;
+}
+
+# Futures.getChecked (which often won't work with Proguard anyway) uses this. It
+# has a fallback, but again, don't use Futures.getChecked on Android regardless.
+-dontwarn java.lang.ClassValue
+
+# MoreExecutors references AppEngine
+-dontnote com.google.appengine.api.ThreadManager
+-keep class com.google.appengine.api.ThreadManager {
+  static *** currentRequestThreadFactory(...);
+}
+-dontnote com.google.apphosting.api.ApiProxy
+-keep class com.google.apphosting.api.ApiProxy {
+  static *** getCurrentEnvironment (...);
+}
+
+# Project specific
+
+# Custom rules to ignore warnings from Google Guava
+-dontwarn com.google.common.collect.**
+-dontwarn com.google.common.base.Converter
+-dontwarn com.google.common.cache.**
+-dontwarn com.google.common.util.concurrent.**
+-dontwarn com.google.common.eventbus.Subscriber
+-dontwarn com.google.common.eventbus.SubscriberRegistry
+-dontwarn com.google.common.hash.**
+
+# Ignore warnings from Kotlinx Coroutines
+-dontwarn kotlinx.coroutines.**
+
+# Ignore warnings from Netty
+-dontwarn io.netty.**
+
+# Ignore warnings from Javax Activation
+-dontwarn javax.activation.**
+
+# Ignore warrnings from Javax mail
+-dontwarn javax.mail.**
+
+# Ignore warnings from Apache
+-dontwarn org.apache.commons.**
+-dontwarn org.apache.http.**
+
+# Fix runtime error when using io.github.classgraph
+-keep class io.github.classgraph.** { *; }
+-keep class nonapi.** { *; }
+-keepclassmembers class nonapi.io.github.classgraph.classloaderhandler.* {
+    boolean canHandle(java.lang.Class, nonapi.io.github.classgraph.utils.LogNode);
+}
+
+# Keep all classes and methods in com.fasterxml.jackson package
+-keep class com.fasterxml.jackson.** { *; }
+
+# Keep all classes and methods in com.fasterxml.jackson.databind package
+-keep class com.fasterxml.jackson.databind.** { *; }
+
+# Keep all classes and methods in com.fasterxml.jackson.module.kotlin package
+-keep class com.fasterxml.jackson.module.kotlin.** { *; }
+
+# Keep all classes and methods in com.fasterxml.jackson.databind.cfg package
+-keep class com.fasterxml.jackson.databind.cfg.** { *; }
+
+# Keep all classes and methods in com.github.victools.jsonschema.generator package
+-keep class com.github.victools.jsonschema.generator.** { *; }
+
+# Keep all classes and methods in com.github.victools.jsonschema.generator.Option
+-keep class com.github.victools.jsonschema.generator.Option { *; }
+
+# Entry point to the app.
+-keep class com.example.ApplicationKt { *; }


### PR DESCRIPTION
Update the Ktor Server Proguard example:

1. Avoid using `ignorewarnings` and `dontwarn`, instead fix the warnings by configuring the Kotlin standard library and the required Java modules in Proguard configurations, this will not only fix warnings but avoid many bugs and issues that are hard to debug as the message and errors can become quite unclear because Proguard doesn't have access to the used Java modules that are part of the JDK, for more details, see this [comment](https://github.com/square/okio/issues/1298#issuecomment-1652182091)
2. Include the official rules of Kotlinx serialization (https://github.com/Kotlin/kotlinx.serialization/blob/master/rules/common.pro) and coroutines (https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro)
3. Update the Proguard rules to get the example working without using `ignorewarnings` to fix many bugs. This new version of Proguard rules can still be improved further. The rules are configured to build the project without any issues for the following libraries:
    ```kotlin
    implementation("io.ktor:ktor-server-auth-jvm")
        implementation("io.ktor:ktor-server-core-jvm")
        implementation("io.ktor:ktor-server-webjars-jvm")
        implementation("org.webjars:jquery:3.2.1")
        implementation("io.github.smiley4:ktor-swagger-ui:2.9.0")
        implementation("io.ktor:ktor-server-resources-jvm")
        implementation("io.ktor:ktor-server-host-common-jvm")
        implementation("io.ktor:ktor-server-status-pages-jvm")
        implementation("io.ktor:ktor-server-cors-jvm")
        implementation("io.ktor:ktor-server-caching-headers-jvm")
        implementation("io.ktor:ktor-server-compression-jvm")
        implementation("io.ktor:ktor-server-call-logging-jvm")
        implementation("io.ktor:ktor-server-content-negotiation-jvm")
        implementation("io.ktor:ktor-serialization-kotlinx-json-jvm")
        implementation("io.ktor:ktor-server-websockets-jvm")
        implementation("io.ktor:ktor-server-auth-ldap-jvm")
        implementation("io.ktor:ktor-server-netty-jvm")
        implementation("ch.qos.logback:logback-classic:$logback_version")
    ```
    I haven't tested all the functionality for each one though, fixing the warnings can catch some common bugs though.
5. Update Proguard to `7.5.0` to support Java 22, We could update the Gradle wrapper, Kotlin, also the versions are hardcoded for all used tools like Ktor Gradle Plugin, I suggest using Gradle version catalogs `gradle/libs.versions.toml`
6. Use the official Proguard [https://github.com/Guardsquare/proguard/blob/master/examples/application-kotlin/proguard.pro](application-kotlin) example as a reference
7. Create a new task called `runMinimizedJar` and replace `minimizedJar` with `buildMinimizedJar` to maintain consistency with `buildFatJar` and `runFatJar`
8. Avoid hardcoding the name of the minimized JAR file
9. Tested with Java 11, 17, 21, and Kotlin 2.0.0, Gradle 8.8, and tested with the version tool versions in this code snippet.
10. Group both `buildMinimizedJar` and `runMinimizedJar` in `ktor`:
![image](https://github.com/ktorio/ktor-documentation/assets/73608287/5f253d5e-d7eb-4b07-be31-95808e2caefa)
to be along with `buildFatJar` and `runFatJar`

I suggest renaming the `proguard` module to `ktor-server-proguard` or `server-proguard` or something similar for clarity as this is for the Ktor server and won't work directly for Ktor Client, notice that you will need to include more rules depending on the engine and the libraries, for example If you're using OkHttp as the engine in Ktor client, you will need to include the rules from (https://square.github.io/okhttp/features/r8_proguard/) and Okio, as well as OkHttp, depends on it.

**Not related**:
I noticed Ktor somehow depends on Java Swing/Desktop, all imports from `org.mozilla.javascript.tools.debugger` use it, while this may sound not an issue, it could cause some issues, like making the bundle size bigger when using `jlink` to include the required Java modules only in the application instead of fully installing Java on the machine, an easy solution is to split this functionality into a different module and make it optional to use.

While this example is referenced in Ktor docs, it's also applicable in the [ktor-samples](https://github.com/ktorio/ktor-samples) repository.

Feel free to share your suggestions or request any changes.