### PR TITLE
KTOR-5759 add missing imports in the plugin installation snippet for embeddedServer

### DIFF
--- a/topics/lib.topic
+++ b/topics/lib.topic
@@ -23,9 +23,11 @@
         <tabs>
             <tab title="embeddedServer">
                 <code-block lang="kotlin">
+                    import io.ktor.server.engine.*
+                    import io.ktor.server.netty.*
                     import io.ktor.server.application.*
                     import %package_name%.*
-                    // ...
+
                     fun main() {
                         embeddedServer(Netty, port = 8080) {
                             install(%plugin_name%)


### PR DESCRIPTION
[KTOR-5759](https://youtrack.jetbrains.com/issue/KTOR-5759) Sessions: documentation snippet lacks import statement