### PR TITLE
Chore/proguard server simple minor change

### DIFF
--- a/codeSnippets/snippets/proguard/build.gradle.kts
+++ b/codeSnippets/snippets/proguard/build.gradle.kts
@@ -1,4 +1,5 @@
 import java.io.FileNotFoundException
+import java.nio.file.Files
 import java.nio.file.Paths
 
 val ktor_version: String by project
@@ -75,9 +76,8 @@ val buildMinimizedJar = tasks.register<proguard.gradle.ProGuardTask>("buildMinim
     } else {
         // Starting from Java 9, runtime classes are packaged in modular JMOD files.
         fun includeJavaModuleFromJdk(jModFileNameWithoutExtension: String) {
-            val jModFilePath = Paths.get(javaHome, "jmods", "$jModFileNameWithoutExtension.jmod").toString()
-            val jModFile = File(jModFilePath)
-            if (!jModFile.exists()) {
+            val jModFilePath = Paths.get(javaHome, "jmods", "$jModFileNameWithoutExtension.jmod")
+            if (!Files.exists(jModFilePath)) {
                 throw FileNotFoundException("The Java module '$jModFileNameWithoutExtension' at '$jModFilePath' doesn't exist.")
             }
             libraryjars(

--- a/codeSnippets/snippets/proguard/build.gradle.kts
+++ b/codeSnippets/snippets/proguard/build.gradle.kts
@@ -112,7 +112,7 @@ val buildMinimizedJar = tasks.register<proguard.gradle.ProGuardTask>("buildMinim
     // is essential for resolving Kotlin and other library warnings without using '-dontwarn kotlin.**'
     injars(sourceSets.main.get().compileClasspath)
 
-    printmapping(fatJarDestinationDirectory.file("$fatJarFileNameWithoutExtension.map"))
+    printmapping(fatJarDestinationDirectory.file("${minimizedJarFile.get().asFile.nameWithoutExtension}.map"))
     // Disabling obfuscation makes the JAR file size a bit larger and the debugging process a bit less easy
     dontobfuscate()
     // Kotlinx serialization breaks when using optimizations

--- a/codeSnippets/snippets/proguard/build.gradle.kts
+++ b/codeSnippets/snippets/proguard/build.gradle.kts
@@ -1,5 +1,5 @@
-import java.io.FileNotFoundException
 import java.nio.file.Files
+import java.nio.file.NoSuchFileException
 import java.nio.file.Paths
 
 val ktor_version: String by project
@@ -78,7 +78,7 @@ val buildMinimizedJar = tasks.register<proguard.gradle.ProGuardTask>("buildMinim
         fun includeJavaModuleFromJdk(jModFileNameWithoutExtension: String) {
             val jModFilePath = Paths.get(javaHome, "jmods", "$jModFileNameWithoutExtension.jmod")
             if (!Files.exists(jModFilePath)) {
-                throw FileNotFoundException("The Java module '$jModFileNameWithoutExtension' at '$jModFilePath' doesn't exist.")
+                throw NoSuchFileException("The Java module '$jModFileNameWithoutExtension' at '$jModFilePath' doesn't exist.")
             }
             libraryjars(
                 mapOf("jarfilter" to "!**.jar", "filter" to "!module-info.class"),


### PR DESCRIPTION
While working on a side project that has similar changes sent in #481, noticed that I'm using `java.nio.file.Paths` to build the path as String and `java.io.File` to check if the file exists which is a bit inconsistent, sending this change here as well, this PR has two minor changes

1. Avoid converting the path of the `Path` class to a `String` to create the `File`, instead use the `Files` class directly to check if the file exists, throw `java.nio.file.NoSuchFileException` as an alternative of `java.io.FileNotFoundException`.
While this code doesn't import `java.io.File` as it still uses `org.gradle.api.file.RegularFile` which uses the `File` class. We could also use `file` function from Gradle which return `File`
2. If the developer removed the line `dontobfuscate()`, Progaurd will generate a map file using `printmapping` function that can be used with [Proguard Retrace](https://www.guardsquare.com/manual/tools/retrace) to get a readable stack trace that makes the debugging process easier for development, previously the file will be `my-application.map`, now `my-application.min.map` since this map file is specific to the Proguard minimized JAR file

**Side note**:
If you want a readable stack trace with the source file and line number, in addition to using **Proguard Retrace**, you need to include the following in `proguard.pro`:

```
-keepattributes SourceFile,LineNumberTable
```

This will increase the Minimized JAR size a bit and you still need to use Proguard Retrace.

We could provide a link to Proguard Retrace in the README.md of this simple.