### PR TITLE
Update Kotlin version to `2.0.0` and Ktor versions where applicable

### DIFF
--- a/codeSnippets/gradle.properties
+++ b/codeSnippets/gradle.properties
@@ -5,10 +5,10 @@ kotlin.native.binary.memoryModel = experimental
 # gradle configuration
 org.gradle.configureondemand = false
 # versions
-kotlin_version = 1.9.10
+kotlin_version = 2.0.0
 ktor_version = 2.3.12
-kotlinx_coroutines_version = 1.6.4
-kotlinx_serialization_version = 1.4.1
+kotlinx_coroutines_version = 2.0.0
+kotlinx_serialization_version = 2.0.0
 kotlin_css_version = 1.0.0-pre.721
 exposed_version = 0.41.1
 h2_version = 2.2.224

--- a/codeSnippets/snippets/auth-jwt-hs256/build.gradle.kts
+++ b/codeSnippets/snippets/auth-jwt-hs256/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    kotlin("plugin.serialization").version("1.9.10")
+    kotlin("plugin.serialization").version("2.0.0")
 }
 
 application {

--- a/codeSnippets/snippets/auth-jwt-rs256/build.gradle.kts
+++ b/codeSnippets/snippets/auth-jwt-rs256/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    kotlin("plugin.serialization").version("1.9.10")
+    kotlin("plugin.serialization").version("2.0.0")
 }
 
 application {

--- a/codeSnippets/snippets/auth-oauth-google/build.gradle.kts
+++ b/codeSnippets/snippets/auth-oauth-google/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    kotlin("plugin.serialization").version("1.9.10")
+    kotlin("plugin.serialization").version("2.0.0")
 }
 
 application {

--- a/codeSnippets/snippets/client-auth-oauth-google/build.gradle.kts
+++ b/codeSnippets/snippets/client-auth-oauth-google/build.gradle.kts
@@ -6,7 +6,7 @@ val hamcrest_version: String by project
 plugins {
     application
     kotlin("jvm")
-    kotlin("plugin.serialization").version("1.9.10")
+    kotlin("plugin.serialization").version("2.0.0")
 }
 
 application {

--- a/codeSnippets/snippets/client-engine-js/build.gradle.kts
+++ b/codeSnippets/snippets/client-engine-js/build.gradle.kts
@@ -3,7 +3,7 @@ val kotlinx_html_version: String by project
 
 plugins {
     kotlin("js")
-    kotlin("plugin.serialization").version("1.9.10")
+    kotlin("plugin.serialization").version("2.0.0")
 }
 
 repositories {

--- a/codeSnippets/snippets/client-json-kotlinx/build.gradle.kts
+++ b/codeSnippets/snippets/client-json-kotlinx/build.gradle.kts
@@ -6,7 +6,7 @@ val hamcrest_version: String by project
 plugins {
     application
     kotlin("jvm")
-    kotlin("plugin.serialization").version("1.9.10")
+    kotlin("plugin.serialization").version("2.0.0")
 }
 
 application {

--- a/codeSnippets/snippets/client-testing-mock/build.gradle.kts
+++ b/codeSnippets/snippets/client-testing-mock/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    kotlin("plugin.serialization").version("1.9.10")
+    kotlin("plugin.serialization").version("2.0.0")
 }
 
 application {

--- a/codeSnippets/snippets/client-type-safe-requests/build.gradle.kts
+++ b/codeSnippets/snippets/client-type-safe-requests/build.gradle.kts
@@ -6,7 +6,7 @@ val hamcrest_version: String by project
 plugins {
     application
     kotlin("jvm")
-    kotlin("plugin.serialization").version("1.9.10")
+    kotlin("plugin.serialization").version("2.0.0")
 }
 
 application {

--- a/codeSnippets/snippets/client-validate-2xx-response/build.gradle.kts
+++ b/codeSnippets/snippets/client-validate-2xx-response/build.gradle.kts
@@ -6,7 +6,7 @@ val hamcrest_version: String by project
 plugins {
     application
     kotlin("jvm")
-    kotlin("plugin.serialization").version("1.9.10")
+    kotlin("plugin.serialization").version("2.0.0")
 }
 
 application {

--- a/codeSnippets/snippets/client-websockets-serialization/build.gradle.kts
+++ b/codeSnippets/snippets/client-websockets-serialization/build.gradle.kts
@@ -6,7 +6,7 @@ val hamcrest_version: String by project
 plugins {
     application
     kotlin("jvm")
-    kotlin("plugin.serialization").version("1.9.10")
+    kotlin("plugin.serialization").version("2.0.0")
 }
 
 application {

--- a/codeSnippets/snippets/cors/build.gradle.kts
+++ b/codeSnippets/snippets/cors/build.gradle.kts
@@ -6,7 +6,7 @@ val junit_version: String by project
 plugins {
     application
     kotlin("jvm")
-    kotlin("plugin.serialization").version("1.9.10")
+    kotlin("plugin.serialization").version("2.0.0")
 }
 
 application {

--- a/codeSnippets/snippets/json-kotlinx-method-override/build.gradle.kts
+++ b/codeSnippets/snippets/json-kotlinx-method-override/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    kotlin("plugin.serialization").version("1.9.10")
+    kotlin("plugin.serialization").version("2.0.0")
 }
 
 application {

--- a/codeSnippets/snippets/json-kotlinx-openapi/build.gradle.kts
+++ b/codeSnippets/snippets/json-kotlinx-openapi/build.gradle.kts
@@ -6,7 +6,7 @@ val swagger_codegen_version: String by project
 plugins {
     application
     kotlin("jvm")
-    kotlin("plugin.serialization").version("1.9.10")
+    kotlin("plugin.serialization").version("2.0.0")
 }
 
 application {

--- a/codeSnippets/snippets/json-kotlinx/build.gradle.kts
+++ b/codeSnippets/snippets/json-kotlinx/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    kotlin("plugin.serialization").version("1.9.10")
+    kotlin("plugin.serialization").version("2.0.0")
 }
 
 application {

--- a/codeSnippets/snippets/migrating-express-ktor/5_send_response/build.gradle.kts
+++ b/codeSnippets/snippets/migrating-express-ktor/5_send_response/build.gradle.kts
@@ -4,8 +4,8 @@ val logback_version: String by project
 
 plugins {
     application
-    kotlin("jvm") version "1.8.0"
-    kotlin("plugin.serialization").version("1.9.10")
+    kotlin("jvm")
+    kotlin("plugin.serialization").version("2.0.0")
 }
 
 application {

--- a/codeSnippets/snippets/migrating-express-ktor/7_receive_request/build.gradle.kts
+++ b/codeSnippets/snippets/migrating-express-ktor/7_receive_request/build.gradle.kts
@@ -4,8 +4,8 @@ val logback_version: String by project
 
 plugins {
     application
-    kotlin("jvm") version "1.8.0"
-    kotlin("plugin.serialization").version("1.9.10")
+    kotlin("jvm")
+    kotlin("plugin.serialization").version("2.0.0")
 }
 
 application {

--- a/codeSnippets/snippets/migrating-express-ktor/gradle.properties
+++ b/codeSnippets/snippets/migrating-express-ktor/gradle.properties
@@ -1,4 +1,4 @@
 ktor_version=2.3.12
-kotlin_version=1.9.10
+kotlin_version=2.0.0
 logback_version=1.5.6
 kotlin.code.style=official

--- a/codeSnippets/snippets/request-validation/build.gradle.kts
+++ b/codeSnippets/snippets/request-validation/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    kotlin("plugin.serialization").version("1.9.10")
+    kotlin("plugin.serialization").version("2.0.0")
 }
 
 application {

--- a/codeSnippets/snippets/resource-routing/build.gradle.kts
+++ b/codeSnippets/snippets/resource-routing/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    kotlin("plugin.serialization").version("1.9.10")
+    kotlin("plugin.serialization").version("2.0.0")
 }
 
 application {

--- a/codeSnippets/snippets/server-websockets-serialization/build.gradle.kts
+++ b/codeSnippets/snippets/server-websockets-serialization/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    kotlin("plugin.serialization").version("1.9.10")
+    kotlin("plugin.serialization").version("2.0.0")
 }
 
 application {

--- a/codeSnippets/snippets/server-websockets-sharedflow/build.gradle.kts
+++ b/codeSnippets/snippets/server-websockets-sharedflow/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     application
     kotlin("jvm")
     id("io.ktor.plugin") version "2.3.12"
-    kotlin("plugin.serialization").version("1.9.10")
+    kotlin("plugin.serialization").version("2.0.0")
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-client-kmm/gradle/libs.versions.toml
+++ b/codeSnippets/snippets/tutorial-client-kmm/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.3.1"
-kotlin = "1.9.20"
-coroutines = "1.8.1"
+kotlin = "2.0.0"
+coroutines = "2.0.0"
 ktor = "2.3.12"
 compose = "1.6.8"
 compose-compiler = "1.5.4"

--- a/codeSnippets/snippets/tutorial-server-db-integration/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-db-integration/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     application
     kotlin("jvm")
     id("io.ktor.plugin") version "2.3.12"
-    id("org.jetbrains.kotlin.plugin.serialization") version "1.9.23"
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.0.0"
 }
 
 group = "com.example"
@@ -35,7 +35,7 @@ dependencies {
     implementation("com.h2database:h2:2.1.214")
     implementation("io.ktor:ktor-server-netty-jvm")
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    implementation("io.ktor:ktor-server-config-yaml:2.3.10")
+    implementation("io.ktor:ktor-server-config-yaml:$ktor_version")
     testImplementation("io.ktor:ktor-server-tests-jvm")
     testImplementation("io.ktor:ktor-client-content-negotiation-jvm:$ktor_version")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")

--- a/codeSnippets/snippets/tutorial-server-docker-compose/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-docker-compose/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     application
     kotlin("jvm")
     id("io.ktor.plugin") version "2.3.12"
-    id("org.jetbrains.kotlin.plugin.serialization") version "1.9.23"
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.0.0"
 }
 
 group = "com.example"
@@ -35,7 +35,7 @@ dependencies {
     implementation("com.h2database:h2:2.1.214")
     implementation("io.ktor:ktor-server-netty-jvm")
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    implementation("io.ktor:ktor-server-config-yaml:2.3.10")
+    implementation("io.ktor:ktor-server-config-yaml:$ktor_version")
     testImplementation("io.ktor:ktor-server-tests-jvm")
     testImplementation("io.ktor:ktor-client-content-negotiation-jvm:$ktor_version")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")

--- a/codeSnippets/snippets/tutorial-server-restful-api/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-restful-api/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.8"
+    id("io.ktor.plugin") version "2.3.12"
     id("org.jetbrains.kotlin.plugin.serialization") version "1.9.22"
 }
 
@@ -25,7 +25,7 @@ dependencies {
     implementation("io.ktor:ktor-serialization-kotlinx-json-jvm")
     implementation("io.ktor:ktor-server-netty-jvm")
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    implementation("io.ktor:ktor-server-config-yaml:2.3.8")
+    implementation("io.ktor:ktor-server-config-yaml:$ktor_version")
     testImplementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
     testImplementation("io.ktor:ktor-server-tests-jvm")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")

--- a/codeSnippets/snippets/tutorial-server-routing-and-requests/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-routing-and-requests/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.8"
+    id("io.ktor.plugin") version "2.3.12"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-server-web-application/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-web-application/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "2.3.9"
+    id("io.ktor.plugin") version "2.3.12"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-server-websockets/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-websockets/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     kotlin("jvm")
     id("io.ktor.plugin") version "2.3.12"
-    id("org.jetbrains.kotlin.plugin.serialization") version "1.9.23"
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.0.0"
 }
 
 group = "com.example"

--- a/v.list
+++ b/v.list
@@ -5,10 +5,10 @@
 <vars>
 
     <var name="ktor_version" value="2.3.12"/>
-    <var name="kotlin_version" value="1.9.10"/>
-    <var name="coroutines_version" value="1.6.4"/>
+    <var name="kotlin_version" value="2.0.0"/>
+    <var name="coroutines_version" value="2.0.0"/>
     <var name="kotlin_css_version" value="1.0.0-pre.625"/>
-    <var name="logback_version" value="1.5.3"/>
+    <var name="logback_version" value="1.5.6"/>
     <var name="prometheus_version" value="1.10.3"/>
     <var name="dropwizard_version" value="4.2.15"/>
     <var name="shadow_version" value="7.1.2"/>


### PR DESCRIPTION
In some examples we are still using old versions of Ktor, so I've updated them to use the latest one.
Also updated Kotlin versions to `2.0.0` so they match the versions used in the project generator.