### PR TITLE
doc: Fixed typos in shortcut keys.

### DIFF
--- a/topics/server-create-a-new-project.topic
+++ b/topics/server-create-a-new-project.topic
@@ -658,7 +658,7 @@
                     <p>In intelliJ IDEA, navigate to the <code>configureRouting()</code> function by placing the caret
                         over the function name
                         and pressing
-                        <shortcut>⌘Cmd+C</shortcut>
+                        <shortcut>⌘Cmd+B</shortcut>
                         .
                     </p>
                     <p>Alternatively, you can navigate to the function by opening the <code>Routing.kt</code> file.</p>


### PR DESCRIPTION
Go to declaration shortcut is Cmd+B