### PR TITLE
Update the version switcher to show docs for `3.0.0-beta-2` instead of `3.0.0-beta-1`

### DIFF
--- a/help-versions.json
+++ b/help-versions.json
@@ -10,8 +10,8 @@
     "isCurrent": false
   },
   {
-    "version": "3.0.0-beta-1",
-    "url": "/docs/3.0.0-beta-1/",
+    "version": "3.0.0-beta-2",
+    "url": "/docs/3.0.0-beta-2/",
     "isCurrent": true
   }
 ]


### PR DESCRIPTION
The docs are already published at [https://ktor.io/docs/3.0.0-beta-2/welcome.html]( https://ktor.io/docs/3.0.0-beta-2/welcome.html) from the `3.0.0-beta-2` branch.
