### PR TITLE
Fix: Remove duplicate catch block IllegalArgumentException - code snippet

### DIFF
--- a/codeSnippets/snippets/tutorial-server-routing-and-requests/src/main/kotlin/com/example/plugins/Routing.kt
+++ b/codeSnippets/snippets/tutorial-server-routing-and-requests/src/main/kotlin/com/example/plugins/Routing.kt
@@ -82,8 +82,6 @@ fun Application.configureRouting() {
                     call.respond(HttpStatusCode.NoContent)
                 } catch (ex: IllegalArgumentException) {
                     call.respond(HttpStatusCode.BadRequest)
-                } catch (ex: IllegalStateException) {
-                    call.respond(HttpStatusCode.BadRequest)
                 }
             }
         }


### PR DESCRIPTION
Remove the suspected redundant catch block in the tutorial code snippet.

Note: New to open source contribution and Kotlin/Ktor, please forgive potential misunderstanding here. Any feedback is welcomed.