### PR TITLE
Fix ref to code on client-create-and-configure.md

### DIFF
--- a/topics/client-create-and-configure.md
+++ b/topics/client-create-and-configure.md
@@ -50,7 +50,7 @@ To install a plugin, you need to pass it to the `install` function inside a [cli
 You can also configure a plugin inside the `install` block. For example, for the [Logging](client-logging.md) plugin, you can specify the logger, logging level, and condition for filtering log messages:
 ```kotlin
 ```
-{src="snippets/client-logging/src/main/kotlin/com/example/Application.kt" include-lines="12-20"}
+{src="snippets/client-logging/src/main/kotlin/com/example/Application.kt" include-lines="13-22"}
 
 Note that a specific plugin might require a separate [dependency](client-dependencies.md).
 


### PR DESCRIPTION
https://ktor.io/docs/client-create-and-configure.html#plugins

The code in the example in this section of the documentation is non-working - there are no closing brackets. I have corrected the link to the lines so that the code is correct.