### PR TITLE
KTOR-7313: Dockerfile in sample Docker Compose is based on deprecated and old OpenJDK.

### DIFF
--- a/codeSnippets/snippets/forwarded-header/Dockerfile
+++ b/codeSnippets/snippets/forwarded-header/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.16
+FROM amazoncorretto:22
 EXPOSE 8080:8080
 RUN mkdir /app
 COPY ./build/libs/*-all.jar /app/ktor-docker-sample.jar

--- a/codeSnippets/snippets/tutorial-server-docker-compose/Dockerfile
+++ b/codeSnippets/snippets/tutorial-server-docker-compose/Dockerfile
@@ -1,5 +1,25 @@
-FROM openjdk:11.0.16
+# Stage 1: Cache Gradle dependencies
+FROM gradle:latest AS cache
+RUN mkdir -p /home/gradle/cache_home
+ENV GRADLE_USER_HOME /home/gradle/cache_home
+COPY build.gradle.* gradle.properties /home/gradle/java-code/
+WORKDIR /home/gradle/java-code
+RUN gradle clean build -i --stacktrace
+
+# Stage 2: Build Application
+FROM gradle:latest AS build
+COPY --from=cache /home/gradle/cache_home /home/gradle/.gradle
+COPY . /usr/src/java-code/
+WORKDIR /usr/src/java-code
+COPY --chown=gradle:gradle . /home/gradle/src
+WORKDIR /home/gradle/src
+# Build the fat JAR, Gradle also supports shadow
+# and boot JAR by default.
+RUN gradle buildFatJar --no-daemon
+
+# Stage 3: Create the Runtime Image
+FROM openjdk:22 AS runtime
 EXPOSE 8080:8080
 RUN mkdir /app
-COPY ./build/libs/*-all.jar /app/ktor-docker-sample.jar
+COPY --from=build /home/gradle/src/build/libs/*.jar /app/ktor-docker-sample.jar
 ENTRYPOINT ["java","-jar","/app/ktor-docker-sample.jar"]

--- a/codeSnippets/snippets/tutorial-server-docker-compose/Dockerfile
+++ b/codeSnippets/snippets/tutorial-server-docker-compose/Dockerfile
@@ -2,15 +2,15 @@
 FROM gradle:latest AS cache
 RUN mkdir -p /home/gradle/cache_home
 ENV GRADLE_USER_HOME /home/gradle/cache_home
-COPY build.gradle.* gradle.properties /home/gradle/java-code/
-WORKDIR /home/gradle/java-code
+COPY build.gradle.* gradle.properties /home/gradle/app/
+WORKDIR /home/gradle/app
 RUN gradle clean build -i --stacktrace
 
 # Stage 2: Build Application
 FROM gradle:latest AS build
 COPY --from=cache /home/gradle/cache_home /home/gradle/.gradle
-COPY . /usr/src/java-code/
-WORKDIR /usr/src/java-code
+COPY . /usr/src/app/
+WORKDIR /usr/src/app
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
 # Build the fat JAR, Gradle also supports shadow
@@ -18,7 +18,7 @@ WORKDIR /home/gradle/src
 RUN gradle buildFatJar --no-daemon
 
 # Stage 3: Create the Runtime Image
-FROM openjdk:22 AS runtime
+FROM amazoncorretto:22 AS runtime
 EXPOSE 8080:8080
 RUN mkdir /app
 COPY --from=build /home/gradle/src/build/libs/*.jar /app/ktor-docker-sample.jar

--- a/topics/docker-compose.topic
+++ b/topics/docker-compose.topic
@@ -110,7 +110,7 @@
                 For more information on how this multi-stage build works, see <a href="docker.md"
                                                                                  anchor="prepare-docker"/>.
             </tip>
-            <include from="docker.md" element-id="openjdk_deprecation_warning"/>
+            <include from="docker.md" element-id="jdk_image_replacement_tip"/>
         </chapter>
         <chapter title="Configure Docker Compose" id="configure-docker-compose">
             <p>In the root directory of the project, create a new

--- a/topics/docker-compose.topic
+++ b/topics/docker-compose.topic
@@ -106,12 +106,6 @@
                 the following content:
             </p>
             <code-block lang="Docker" src="snippets/tutorial-server-docker-compose/Dockerfile"/>
-            <p>
-                Note that this
-                <path>Dockerfile</path>
-                requires creating a fat JAR before running <code>docker compose
-                up</code>.
-            </p>
             <tip>
                 To learn how to use multi-stage builds to generate an application distribution using Docker, see
                 <a href="docker.md" anchor="prepare-docker"/>.

--- a/topics/docker-compose.topic
+++ b/topics/docker-compose.topic
@@ -107,13 +107,10 @@
             </p>
             <code-block lang="Docker" src="snippets/tutorial-server-docker-compose/Dockerfile"/>
             <tip>
-                To learn how to use multi-stage builds to generate an application distribution using Docker, see
-                <a href="docker.md" anchor="prepare-docker"/>.
+                For more information on how this multi-stage build works, see <a href="docker.md"
+                                                                                 anchor="prepare-docker"/>.
             </tip>
-            <tip>
-                OpenJDK is deprecated and disrecommended to use, refer to <a href="docker.md" anchor="prepare-docker"/>
-                for finding a suitable replacement.
-            </tip>
+            <include from="docker.md" element-id="openjdk_deprecation_warning"/>
         </chapter>
         <chapter title="Configure Docker Compose" id="configure-docker-compose">
             <p>In the root directory of the project, create a new
@@ -155,8 +152,8 @@
             </step>
             <step>
                 <p>
-                    Navigate to <a href="http://localhost:8080/">http://localhost:8080/</a> to
-                    open the web application. You should see the Task Manager Client page displaying three forms for
+                    Navigate to <a href="http://localhost:8080/static/index.html">http://localhost:8080/static/index.html</a>
+                    to open the web application. You should see the Task Manager Client page displaying three forms for
                     filtering and adding new tasks,as well as a table of tasks.
                 </p>
                 <img src="tutorial_server_db_integration_manual_test.gif"

--- a/topics/docker-compose.topic
+++ b/topics/docker-compose.topic
@@ -116,6 +116,10 @@
                 To learn how to use multi-stage builds to generate an application distribution using Docker, see
                 <a href="docker.md" anchor="prepare-docker"/>.
             </tip>
+            <tip>
+                OpenJDK is deprecated and disrecommended to use, refer to <a href="docker.md" anchor="prepare-docker"/>
+                for finding a suitable replacement.
+            </tip>
         </chapter>
         <chapter title="Configure Docker Compose" id="configure-docker-compose">
             <p>In the root directory of the project, create a new

--- a/topics/docker.md
+++ b/topics/docker.md
@@ -161,7 +161,6 @@ In the root folder of the project, create a file named `Dockerfile` with the fol
 <tabs group="languages">
 <tab title="Gradle" group-key="kotlin">
 
-<tip>
 First stage of Dockerfile is optional, but recommended due to
 improvement for overall build speed.
 
@@ -170,17 +169,13 @@ dependencies declared in ``build.gradle.kts`` will be installed in every build.
 
 If first stage is used, dependencies will be re-downloaded only when there is a change to
 build related files, such as ``gradle.properties``, ``build.gradle.kts``, and so on.
-</tip>
 
 
 ```Docker
-# Stage 1: Cache Maven dependencies
+# Stage 1: Cache Gradle dependencies
 FROM gradle:latest AS cache
-# Create a directory for Gradle cache
 RUN mkdir -p /home/gradle/cache_home
 ENV GRADLE_USER_HOME /home/gradle/cache_home
-# Only dependency-related files are copied, and 
-# this stage is cached as long as build files are not changed.
 COPY build.gradle.* gradle.properties /home/gradle/java-code/
 WORKDIR /home/gradle/java-code
 RUN gradle clean build -i --stacktrace
@@ -207,7 +202,6 @@ ENTRYPOINT ["java","-jar","/app/ktor-docker-sample.jar"]
 </tab>
 <tab title="Maven" group-key="maven">
 
-<tip>
 First stage of Dockerfile is optional, but recommended due to
 improvement for overall build speed.
 
@@ -216,7 +210,6 @@ dependencies declared in ``pom.xml`` will be installed in every build.
 
 If first stage is used, dependencies will be re-downloaded only when there is a change to
 ``pom.xml``.
-</tip>
 
 <warning>
 OpenJDK version in build stage is 18, and official Maven image dropped support for

--- a/topics/docker.md
+++ b/topics/docker.md
@@ -15,9 +15,8 @@ Learn how to deploy a Ktor application to a Docker container, which can then be 
 Learn how to deploy your application to a Docker container.
 </link-summary>
 
-In this section, we'll see how to use the [Ktor Gradle plugin](https://github.com/ktorio/ktor-build-plugins) for packaging, running, and deploying applications using [Docker](https://www.docker.com).
-
-
+In this section, we'll see how to use the [Ktor Gradle plugin](https://github.com/ktorio/ktor-build-plugins) for
+packaging, running, and deploying applications using [Docker](https://www.docker.com).
 
 ## Install the Ktor plugin {id="install-plugin"}
 
@@ -31,6 +30,7 @@ plugins {
     id("io.ktor.plugin") version "%ktor_version%"
 }
 ```
+
 {interpolate-variables="true"}
 
 </tab>
@@ -41,30 +41,39 @@ plugins {
     id "io.ktor.plugin" version "%ktor_version%"
 }
 ```
+
 {interpolate-variables="true"}
 
 </tab>
 </tabs>
 
-
 ## Plugin tasks {id="tasks"}
 
-After [installing](#install-plugin) the plugin, the following tasks are available for packaging, running, and deploying applications:
+After [installing](#install-plugin) the plugin, the following tasks are available for packaging, running, and deploying
+applications:
 
-- `buildImage`: builds a project's Docker image to a tarball. This task generates a `jib-image.tar` file in the `build` directory. You can load this image to a Docker daemon using the [docker load](https://docs.docker.com/engine/reference/commandline/load/) command:
+- `buildImage`: builds a project's Docker image to a tarball. This task generates a `jib-image.tar` file in the `build`
+  directory. You can load this image to a Docker daemon using
+  the [docker load](https://docs.docker.com/engine/reference/commandline/load/) command:
    ```Bash
    docker load < build/jib-image.tar
    ```
 - `publishImageToLocalRegistry`: builds and publishes a project's Docker image to a local registry.
-- `runDocker`: builds a project's image to a Docker daemon and runs it. Executing this task will launch the Ktor server, responding on `http://0.0.0.0:8080` by default. If your server is configured to use another port, you can adjust [port mapping](#port-mapping).
-- `publishImage`: builds and publishes a project's Docker image to an external registry such as [Docker Hub](https://hub.docker.com/) or [Google Container Registry](https://cloud.google.com/container-registry). Note that you need to configure the external registry using the **[ktor.docker.externalRegistry](#external-registry)** property for this task.
+- `runDocker`: builds a project's image to a Docker daemon and runs it. Executing this task will launch the Ktor server,
+  responding on `http://0.0.0.0:8080` by default. If your server is configured to use another port, you can
+  adjust [port mapping](#port-mapping).
+- `publishImage`: builds and publishes a project's Docker image to an external registry such
+  as [Docker Hub](https://hub.docker.com/) or [Google Container Registry](https://cloud.google.com/container-registry).
+  Note that you need to configure the external registry using the **[ktor.docker.externalRegistry](#external-registry)**
+  property for this task.
 
-Note that by default, these tasks build the image with the `ktor-docker-image` name and `latest` tag. 
+Note that by default, these tasks build the image with the `ktor-docker-image` name and `latest` tag.
 You can customize these values in the [plugin configuration](#name-tag).
 
 ## Configure the Ktor plugin {id="configure-plugin"}
 
-To configure the Ktor plugin settings related to Docker tasks, use the `ktor.docker` extension in your `build.gradle.(kts)` file:
+To configure the Ktor plugin settings related to Docker tasks, use the `ktor.docker` extension in
+your `build.gradle.(kts)` file:
 
 ```kotlin
 ktor {
@@ -80,6 +89,7 @@ The `jreVersion` property specifies the JRE version to use in the image:
 
 ```kotlin
 ```
+
 {src="snippets/deployment-ktor-plugin/build.gradle.kts" include-lines="29,34-35,53-54"}
 
 ### Image name and tag {id="name-tag"}
@@ -88,37 +98,44 @@ If you need to customize the image name and tag, use the `localImageName` and `i
 
 ```kotlin
 ```
+
 {src="snippets/deployment-ktor-plugin/build.gradle.kts" include-lines="29,34,36-37,53-54"}
 
 ### Port mapping {id="port-mapping"}
 
 By default, the [runDocker](#tasks) task publishes the `8080` container port to the `8080` Docker host port.
 If required, you can change these ports using the `portMappings` property.
-This might be useful if your server is [configured](server-configuration-file.topic#predefined-properties) to use another port. 
+This might be useful if your server is [configured](server-configuration-file.topic#predefined-properties) to use
+another port.
 
 The example below shows how to map the `8080` container port to the `80` Docker host port.
 
 ```kotlin
 ```
+
 {src="snippets/deployment-ktor-plugin/build.gradle.kts" include-lines="29,34,38-44,53-54"}
 
 In this case, you can access the server on `http://0.0.0.0:80`.
 
-
 ### External registry {id="external-registry"}
 
-Before publishing a project's Docker image to an external registry using the **[publishImage](#tasks)** task, you need to configure the external registry using the `ktor.docker.externalRegistry` property. This property accepts the `DockerImageRegistry` instance, which provides configuration for the required registry type:
+Before publishing a project's Docker image to an external registry using the **[publishImage](#tasks)** task, you need
+to configure the external registry using the `ktor.docker.externalRegistry` property. This property accepts
+the `DockerImageRegistry` instance, which provides configuration for the required registry type:
 
 - `DockerImageRegistry.dockerHub`: creates a `DockerImageRegistry` for [Docker Hub](https://hub.docker.com/).
-- `DockerImageRegistry.googleContainerRegistry`: creates a `DockerImageRegistry` for [Google Container Registry](https://cloud.google.com/container-registry).
+- `DockerImageRegistry.googleContainerRegistry`: creates a `DockerImageRegistry`
+  for [Google Container Registry](https://cloud.google.com/container-registry).
 
 The example below shows how to configure the Docker Hub registry:
 
 ```kotlin
 ```
+
 {src="snippets/deployment-ktor-plugin/build.gradle.kts" include-lines="29,34,46-54"}
 
-Note that the Docker Hub name and password are fetched from the environment variables, so you need to set these values before running the `publishImage` task:
+Note that the Docker Hub name and password are fetched from the environment variables, so you need to set these values
+before running the `publishImage` task:
 
 <tabs group="os">
 <tab title="Linux/macOS" group-key="unix">
@@ -139,37 +156,29 @@ setx DOCKER_HUB_PASSWORD yourHubPassword
 </tab>
 </tabs>
 
-
 ## Manual image configuration {id="manual"}
 
 If required, you can provide your own `Dockerfile` to assemble an image with a Ktor application.
 
 ### Package the application {id="packagea-pp"}
-As a first step, you need to package your application along with its dependencies. 
-For example, this might be a [fat JAR](server-fatjar.md) or an [executable JVM application](server-packaging.md).
 
+As a first step, you need to package your application along with its dependencies.
+For example, this might be a [fat JAR](server-fatjar.md) or an [executable JVM application](server-packaging.md).
 
 ### Prepare Docker image {id="prepare-docker"}
 
-To dockerize the application, we'll use [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/):
-- First, we'll use the `gradle`/`maven` image to generate a fat JAR with the application.
-- Then, the generated distribution will be run in the environment created based on the `openjdk` image.
+To dockerize the application, we'll
+use [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/):
+
+1. First, we'll set up caching for Gradle/Maven dependencies. This step is optional, but recommended as it improves the
+   overall build speed.
+2. Then, we'll use the `gradle`/`maven` image to generate a fat JAR with the application.
+3. Finally, the generated distribution will be run in the environment created based on the `openjdk` image.
 
 In the root folder of the project, create a file named `Dockerfile` with the following contents:
 
-
 <tabs group="languages">
 <tab title="Gradle" group-key="kotlin">
-
-First stage of Dockerfile is optional, but recommended due to
-improvement for overall build speed.
-
-If first stage is not used, or dependencies are not cached in other stages,
-dependencies declared in ``build.gradle.kts`` will be installed in every build.
-
-If first stage is used, dependencies will be re-downloaded only when there is a change to
-build related files, such as ``gradle.properties``, ``build.gradle.kts``, and so on.
-
 
 ```Docker
 # Stage 1: Cache Gradle dependencies
@@ -187,8 +196,6 @@ COPY . /usr/src/java-code/
 WORKDIR /usr/src/java-code
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
-# Build the fat JAR, Gradle also supports shadow 
-# and boot JAR by default.
 RUN gradle buildFatJar --no-daemon
 
 # Stage 3: Create the Runtime Image
@@ -201,21 +208,6 @@ ENTRYPOINT ["java","-jar","/app/ktor-docker-sample.jar"]
 
 </tab>
 <tab title="Maven" group-key="maven">
-
-First stage of Dockerfile is optional, but recommended due to
-improvement for overall build speed.
-
-If first stage is not used, or dependencies are not cached in other stages,
-dependencies declared in ``pom.xml`` will be installed in every build.
-
-If first stage is used, dependencies will be re-downloaded only when there is a change to
-``pom.xml``.
-
-<warning>
-OpenJDK version in build stage is 18, and official Maven image dropped support for
-OpenJDK after version 18. Please refer to the information below the Dockerfile for replacements
-to OpenJDK.
-</warning>
 
 ```Docker
 # Stage 1: Cache Maven dependencies
@@ -242,23 +234,32 @@ ENTRYPOINT ["java", "-jar", "app.jar"]
 </tab>
 </tabs>
 
+The first stage ensures dependencies will be re-downloaded only when there is a change to the
+build related files. If the first stage is not used, or dependencies are not cached in other stages,
+dependencies will be installed in every build.
 
-The second stage of the build works in the following way:
+In the second stage the fat JAR is built. Note that Gradle also supports shadow and boot JAR by default.
+
+The third stage of the build works in the following way:
 
 * Indicates what image is going to be used.
-  * Official Maven image for Docker is no longer supporting OpenJDK,
-    and for build and run stages, using OpenJDK is strongly disrecommended.
-  * After initial testing, it is highly recommended to replace OpenJDK with a suitable replacement, some examples of other official JDK's:
-    * [Amazon Corretto](https://hub.docker.com/_/amazoncorretto)
-    * [Eclipse Temurin](https://hub.docker.com/_/eclipse-temurin)
-    * [IBM Semeru](https://hub.docker.com/_/ibm-semeru-runtimes)
-    * [IBM Java](https://hub.docker.com/_/ibmjava)
-    * [SAP Machine JDK](https://hub.docker.com/_/sapmachine)
 * Specifies the exposed port (this does not automatically expose the port, which is done when running the container).
 * Copies the contents from the build output to the folder.
 * Runs the application (`ENTRYPOINT`).
 
-
+<warning id="openjdk_deprecation_warning">
+  <p>
+   The OpenJDK Docker Image is <a href="https://hub.docker.com/_/openjdk">officially deprecated</a>.
+  We highly recommend replacing OpenJDK with a suitable alternative, such as one of the follwing:
+  </p>
+  <list>
+    <li><a href="https://hub.docker.com/_/amazoncorretto">Amazon Corretto</a></li>
+    <li><a href="https://hub.docker.com/_/eclipse-temurin">Eclipse Temurin</a></li>
+    <li><a href="https://hub.docker.com/_/ibm-semeru-runtimes">IBM Semeru</a></li>
+    <li><a href="https://hub.docker.com/_/ibmjava">IBM Java</a></li>
+    <li><a href="https://hub.docker.com/_/sapmachine">SAP Machine JDK</a></li>
+  </list>
+</warning>
 
 ### Build and run the Docker image {id="build-run"}
 


### PR DESCRIPTION
Added disclaimer text for OpenJDK being deprecated, and added another stage to the Dockerfile for caching dependencies. Two stage Dockerfile is too slow to build, as we are downloading dependencies each time.

also please warn me if my english is too shit for this type of contribution

smooch