### PR TITLE
KTOR-5085 Remove note about JVM-only support for XML serialization

### DIFF
--- a/topics/server-serialization.md
+++ b/topics/server-serialization.md
@@ -81,7 +81,8 @@ To serialize/deserialize XML, add the `ktor-serialization-kotlinx-xml` in the bu
 <var name="artifact_name" value="ktor-serialization-kotlinx-xml"/>
 <include from="lib.topic" element-id="add_ktor_artifact"/>
 
-Note that XML serialization is supported on JVM only.
+> Note that XML serialization [is not supported on `jsNode` target](https://github.com/pdvrieze/xmlutil/issues/83).
+{style="note"}
 
 #### CBOR {id="add_cbor_dependency"}
 


### PR DESCRIPTION
Documentation change to reflect changes from https://github.com/ktorio/ktor/pull/4225