### PR TITLE
Update the `migrating-express-ktor` sample and relevant topic

### DIFF
--- a/codeSnippets/snippets/migrating-express-ktor/1_hello/README.md
+++ b/codeSnippets/snippets/migrating-express-ktor/1_hello/README.md
@@ -1,0 +1,24 @@
+# Hello World
+
+An application that accepts `GET` requests and responds with predefined plain text.
+
+>The application is used to demonstrate the content described in the [Hello World chapter](https://ktor.io/docs/migration-from-express-js.html#hello)
+>from the "Migrating from Express to Ktor" article.
+
+## Build
+
+To build the application, run the following command from the project's root directory:
+
+```shell
+./gradlew build
+```
+
+## Run
+
+To run the application, run the following command from the project's root directory:
+
+```shell
+./gradlew run
+```
+
+The application will be running at [http://0.0.0.0:8080](http://0.0.0.0:8080)

--- a/codeSnippets/snippets/migrating-express-ktor/1_hello/build.gradle.kts
+++ b/codeSnippets/snippets/migrating-express-ktor/1_hello/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 
 plugins {
     application
-    kotlin("jvm") version "1.8.0"
+    kotlin("jvm") version "2.0.0"
 }
 
 group = "com.example"

--- a/codeSnippets/snippets/migrating-express-ktor/1_hello_config/build.gradle.kts
+++ b/codeSnippets/snippets/migrating-express-ktor/1_hello_config/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 
 plugins {
     application
-    kotlin("jvm") version "1.8.0"
+    kotlin("jvm") version "2.0.0"
 }
 
 application {

--- a/codeSnippets/snippets/migrating-express-ktor/2_static/README.md
+++ b/codeSnippets/snippets/migrating-express-ktor/2_static/README.md
@@ -1,0 +1,24 @@
+# Serving static content
+
+An application that serves static files such as images, CSS files, and JavaScript files.
+
+>The application is used to demonstrate the content described in the [Serving static content chapter](https://ktor.io/docs/migration-from-express-js.html#static)
+>from the "Migrating from Express to Ktor" article.
+
+## Build
+
+To build the application, run the following command from the project's root directory:
+
+```shell
+./gradlew build
+```
+
+## Run
+
+To run the application, run the following command from the project's root directory:
+
+```shell
+./gradlew run
+```
+
+The application will be running at [http://0.0.0.0:8080](http://0.0.0.0:8080)

--- a/codeSnippets/snippets/migrating-express-ktor/2_static/build.gradle.kts
+++ b/codeSnippets/snippets/migrating-express-ktor/2_static/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 
 plugins {
     application
-    kotlin("jvm") version "1.8.0"
+    kotlin("jvm") version "2.0.0"
 }
 
 application {

--- a/codeSnippets/snippets/migrating-express-ktor/2_static/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/migrating-express-ktor/2_static/src/main/kotlin/com/example/Application.kt
@@ -10,10 +10,6 @@ fun main(args: Array<String>): Unit =
 
 fun Application.module() {
     routing {
-        static("/") {
-            staticRootFolder = File("public")
-            files(".")
-            default("index.html")
-        }
+        staticFiles("", File("public"), "index.html")
     }
 }

--- a/codeSnippets/snippets/migrating-express-ktor/3_router/README.md
+++ b/codeSnippets/snippets/migrating-express-ktor/3_router/README.md
@@ -1,0 +1,28 @@
+# Routing
+
+An application that handles `GET` and `POST` requests made to the `/` path.
+
+>The application is used to demonstrate the content described in the [Routing chapter](https://ktor.io/docs/migration-from-express-js.html#routing)
+>from the "Migrating from Express to Ktor" article.
+
+## Build
+
+To build the application, run the following command from the project's root directory:
+
+```shell
+./gradlew build
+```
+
+## Run
+
+To run the application, run the following command from the project's root directory:
+
+```shell
+./gradlew run
+```
+
+The application will be running at [http://0.0.0.0:8080](http://0.0.0.0:8080)
+
+## Test
+
+Use the [request.http](request.http) file to manually test the HTTP endpoints directly from the IDE.

--- a/codeSnippets/snippets/migrating-express-ktor/3_router/build.gradle.kts
+++ b/codeSnippets/snippets/migrating-express-ktor/3_router/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 
 plugins {
     application
-    kotlin("jvm") version "1.8.0"
+    kotlin("jvm") version "2.0.0"
 }
 
 application {

--- a/codeSnippets/snippets/migrating-express-ktor/3_router/request.http
+++ b/codeSnippets/snippets/migrating-express-ktor/3_router/request.http
@@ -1,16 +1,32 @@
 GET http://0.0.0.0:8080/book
 Content-Type: text/plain
 
+Get a random book
+
 ###
 
 POST http://0.0.0.0:8080/book
 Content-Type: text/plain
 
-Hello, world!
+Add a book
 
 ###
 
 PUT http://0.0.0.0:8080/book
 Content-Type: text/plain
 
-Hello, world!
+Update a book
+
+###
+
+GET http://0.0.0.0:8080/birds
+Content-Type: text/plain
+
+Birds home page
+
+###
+
+GET http://0.0.0.0:8080/birds/about
+Content-Type: text/plain
+
+About birds

--- a/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/routes/Birds.kt
+++ b/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/routes/Birds.kt
@@ -1,10 +1,9 @@
 package com.example.routes
 
-import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 
-fun Route.birdsRoutes() {
+fun Routing.birdsRoutes() {
     route("/birds") {
         get {
             call.respondText("Birds home page")

--- a/codeSnippets/snippets/migrating-express-ktor/4_parameters/README.md
+++ b/codeSnippets/snippets/migrating-express-ktor/4_parameters/README.md
@@ -1,0 +1,24 @@
+# Route and query parameters
+
+An application that shows how to access route and query parameters.
+
+>The application is used to demonstrate the content described in the [Route and query parameters chapter](https://ktor.io/docs/migration-from-express-js.html#route-query-param)
+>from the "Migrating from Express to Ktor" article.
+
+## Build
+
+To build the application, run the following command from the project's root directory:
+
+```shell
+./gradlew build
+```
+
+## Run
+
+To run the application, run the following command from the project's root directory:
+
+```shell
+./gradlew run
+```
+
+The application will be running at [http://0.0.0.0:8080](http://0.0.0.0:8080)

--- a/codeSnippets/snippets/migrating-express-ktor/4_parameters/build.gradle.kts
+++ b/codeSnippets/snippets/migrating-express-ktor/4_parameters/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 
 plugins {
     application
-    kotlin("jvm") version "1.8.0"
+    kotlin("jvm") version "2.0.0"
 }
 
 application {

--- a/codeSnippets/snippets/migrating-express-ktor/5_send_response/README.md
+++ b/codeSnippets/snippets/migrating-express-ktor/5_send_response/README.md
@@ -1,0 +1,32 @@
+# Sending responses
+
+An application that shows how to access route and query parameters.
+
+>The application is used to demonstrate the content described in the [Sending responses chapter](https://ktor.io/docs/migration-from-express-js.html#send-json)
+>from the "Migrating from Express to Ktor" article.
+
+## Build
+
+To build the application, run the following command from the project's root directory:
+
+```shell
+./gradlew build
+```
+
+## Run
+
+To run the application, run the following command from the project's root directory:
+
+```shell
+./gradlew run
+```
+The application will be running at [http://0.0.0.0:8080](http://0.0.0.0:8080)
+
+## Test
+
+Test the application by navigating to the following URLs:
+
+- [http://0.0.0.0:8080/old](http://0.0.0.0:8080/old) redirects to `/moved`.
+- [http://0.0.0.0:8080/json](http://0.0.0.0:8080/json) returns data displayed in a JSON format.
+- [http://0.0.0.0:8080/file](http://0.0.0.0:8080/file) returns a file.
+- [http://0.0.0.0:8080/file-attachment](http://0.0.0.0:8080/file-attachment) downloads a file.

--- a/codeSnippets/snippets/migrating-express-ktor/5_send_response/build.gradle.kts
+++ b/codeSnippets/snippets/migrating-express-ktor/5_send_response/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 
 plugins {
     application
-    kotlin("jvm")
+    kotlin("jvm") version "2.0.0"
     kotlin("plugin.serialization").version("2.0.0")
 }
 

--- a/codeSnippets/snippets/migrating-express-ktor/6_templates/README.md
+++ b/codeSnippets/snippets/migrating-express-ktor/6_templates/README.md
@@ -1,0 +1,24 @@
+# Templates
+
+An application that responds with a FreeMarker template.
+
+>The application is used to demonstrate the content described in the [Templates chapter](https://ktor.io/docs/migration-from-express-js.html#templates)
+>from the "Migrating from Express to Ktor" article.
+
+## Build
+
+To build the application, run the following command from the project's root directory:
+
+```shell
+./gradlew build
+```
+
+## Run
+
+To run the application, run the following command from the project's root directory:
+
+```shell
+./gradlew run
+```
+
+The application will be running at [http://0.0.0.0:8080](http://0.0.0.0:8080)

--- a/codeSnippets/snippets/migrating-express-ktor/6_templates/build.gradle.kts
+++ b/codeSnippets/snippets/migrating-express-ktor/6_templates/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 
 plugins {
     application
-    kotlin("jvm") version "1.8.0"
+    kotlin("jvm") version "2.0.0"
 }
 
 application {

--- a/codeSnippets/snippets/migrating-express-ktor/7_receive_request/README.md
+++ b/codeSnippets/snippets/migrating-express-ktor/7_receive_request/README.md
@@ -1,0 +1,28 @@
+# Receiving requests
+
+An application that receives request bodies in different formats.
+
+>The application is used to demonstrate the content described in the [Receiving requests chapter](https://ktor.io/docs/migration-from-express-js.html#receive-request)
+>from the "Migrating from Express to Ktor" article.
+
+## Build
+
+To build the application, run the following command from the project's root directory:
+
+```shell
+./gradlew build
+```
+
+## Run
+
+To run the application, run the following command from the project's root directory:
+
+```shell
+./gradlew run
+```
+
+The application will be running at [http://0.0.0.0:8080](http://0.0.0.0:8080)
+
+## Test
+
+Use the [post.http](post.http) file to manually test the `HTTP` endpoints directly from the IDE.

--- a/codeSnippets/snippets/migrating-express-ktor/7_receive_request/build.gradle.kts
+++ b/codeSnippets/snippets/migrating-express-ktor/7_receive_request/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 
 plugins {
     application
-    kotlin("jvm")
+    kotlin("jvm") version "2.0.0"
     kotlin("plugin.serialization").version("2.0.0")
 }
 

--- a/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt
@@ -9,6 +9,7 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.util.cio.*
 import io.ktor.utils.io.*
+import kotlinx.io.readByteArray
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.*
 import java.io.*
@@ -57,12 +58,13 @@ fun Application.module() {
 
                     is PartData.FileItem -> {
                         fileName = part.originalFileName as String
-                        var fileBytes = part.streamProvider().readBytes()
+                        val fileBytes = part.provider().readRemaining().readByteArray()
                         File("uploads/$fileName").writeBytes(fileBytes)
                     }
 
                     else -> {}
                 }
+                part.dispose()
             }
             call.respondText("$fileDescription is uploaded to 'uploads/$fileName'")
         }

--- a/codeSnippets/snippets/migrating-express-ktor/8_middleware/README.md
+++ b/codeSnippets/snippets/migrating-express-ktor/8_middleware/README.md
@@ -1,0 +1,24 @@
+# Creating middleware
+
+An application that extends the server functionality by implementing request logging as a custom plugin.
+
+>The application is used to demonstrate the content described in the [Creating middleware chapter](https://ktor.io/docs/migration-from-express-js.html#middleware)
+>from the "Migrating from Express to Ktor" article.
+
+## Build
+
+To build the application, run the following command from the project's root directory:
+
+```shell
+./gradlew build
+```
+
+## Run
+
+To run the application, run the following command from the project's root directory:
+
+```shell
+./gradlew run
+```
+
+The application will be running at [http://0.0.0.0:8080](http://0.0.0.0:8080)

--- a/codeSnippets/snippets/migrating-express-ktor/8_middleware/build.gradle.kts
+++ b/codeSnippets/snippets/migrating-express-ktor/8_middleware/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 
 plugins {
     application
-    kotlin("jvm") version "1.8.0"
+    kotlin("jvm") version "2.0.0"
 }
 
 application {

--- a/codeSnippets/snippets/migrating-express-ktor/README.md
+++ b/codeSnippets/snippets/migrating-express-ktor/README.md
@@ -1,3 +1,19 @@
 # Migrating from Express to Ktor (Ktor project)
 
 The Ktor project that complements the [Migrating from Express to Ktor](https://ktor.io/docs/express-js.html) guide.
+
+# Build 
+
+To build all projects, run the following command from the project's root directory:
+
+```shell
+./gradlew build
+```
+
+# Run
+
+The project consists of 8 subprojects you can run individually, by using the project name and the `run` Gradle command.
+```shell
+./gradlew :1_hello:run
+```
+For further instructions, refer to each project's `README.md` file.

--- a/topics/migration-from-express-js.topic
+++ b/topics/migration-from-express-js.topic
@@ -10,25 +10,18 @@
 
     <link-summary>This guide shows how to create, run, and test a simple Ktor application.</link-summary>
 
+    <tldr>
+        <p>
+            <b>Code examples</b>:
+            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express">migrating-express</a>
+            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor">migrating-express-ktor</a>
+        </p>
+    </tldr>
     <p>
         In this guide, we'll take a look at how to migrate an Express application to Ktor in basic scenarios:
-        from generating an application and writing your first application to creating middleware for extending application functionality.
+        from generating an application and writing your first application to creating middleware for extending
+        application functionality.
     </p>
-
-    <tip>
-        <p>
-            The sample projects used in this guide are available here:
-        </p>
-        <list>
-            <li>
-                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express">Express</a>
-            </li>
-            <li>
-                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor">Ktor</a>
-            </li>
-        </list>
-    </tip>
-
 
     <chapter title="Generate an app" id="generate">
         <table style="header-column">
@@ -75,7 +68,8 @@
                                 <a href="https://github.com/ktorio/ktor-cli">Native Command Line Tool</a> (beta)
                             </p>
                             <p>
-                                To create a new Ktor project, you need to pass a project name to the <code>ktor generate</code> command:
+                                To create a new Ktor project, you need to pass a project name to the <code>ktor
+                                generate</code> command:
                             </p>
                             <code-block lang="shell">
                                 ktor generate ktor-sample
@@ -94,7 +88,8 @@
 
     <chapter title="Hello world" id="hello">
         <p>
-            In this section, we'll look at how to create the simplest server application that accepts <code>GET</code> requests and responds with predefined plain text.
+            In this section, we'll look at how to create the simplest server application that accepts <code>GET</code>
+            requests and responds with predefined plain text.
         </p>
 
         <table style="header-column">
@@ -105,13 +100,14 @@
                 <td>
                     <p>
                         The example below shows the Express application that starts a server and listens on port
-                        <control>3000</control> for connections.
+                        <control>3000</control>
+                        for connections.
                     </p>
                     <code-block lang="javascript" src="snippets/migrating-express/1_hello/app.js"/>
                     <p>
-                        <emphasis>
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/1_hello/app.js">View sample on GitHub</a>
-                        </emphasis>
+                        For the full example, see the
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/1_hello/app.js">1_hello</a>
+                        project.
                     </p>
                 </td>
             </tr>
@@ -121,24 +117,34 @@
                 </td>
                 <td>
                     <p>
-                        In Ktor, you can use the <a href="server-create-and-configure.topic" anchor="embedded-server">embeddedServer</a> function to configure server parameters in code and quickly run an application.
+                        In Ktor, you can use the <a href="server-create-and-configure.topic" anchor="embedded-server">embeddedServer</a>
+                        function to configure server parameters in code and quickly run an application.
                     </p>
-                    <code-block lang="kotlin" src="snippets/migrating-express-ktor/1_hello/src/main/kotlin/com/example/Application.kt" include-lines="3-17"/>
+                    <code-block lang="kotlin"
+                                src="snippets/migrating-express-ktor/1_hello/src/main/kotlin/com/example/Application.kt"
+                                include-lines="3-17"/>
                     <p>
-                        <emphasis>
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/1_hello/src/main/kotlin/com/example/Application.kt">View sample on GitHub</a>
-                        </emphasis>
+                        For the full example, see the
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/1_hello/src/main/kotlin/com/example/Application.kt">1_hello</a>
+                        project.
                     </p>
                     <p>
-                        You can also specify server settings in an <a href="server-create-and-configure.topic" anchor="engine-main">external configuration file</a> that uses the HOCON or YAML format.
+                        You can also specify server settings in an <a href="server-create-and-configure.topic"
+                                                                      anchor="engine-main">external configuration
+                        file</a> that uses the HOCON or YAML format.
                     </p>
                 </td>
             </tr>
         </table>
 
         <p>
-            Note that the Express application above adds the <control>Date</control>,
-            <control>X-Powered-By</control>, and <control>ETag</control> response headers that might look as follows:
+            Note that the Express application above adds the
+            <control>Date</control>
+            ,
+            <control>X-Powered-By</control>
+            , and
+            <control>ETag</control>
+            response headers that might look as follows:
         </p>
         <code-block>
             Date: Fri, 05 Aug 2022 06:30:48 GMT
@@ -146,10 +152,15 @@
             ETag: W/"c-Lve95gjOVATpfV8EL5X4nxwjKHE"
         </code-block>
         <p>
-            To add the default <control>Server</control> and <control>Date</control> headers into each response in Ktor,
+            To add the default
+            <control>Server</control>
+            and
+            <control>Date</control>
+            headers into each response in Ktor,
             you need to install the <a href="server-default-headers.md">DefaultHeaders</a> plugin.
             The <a href="server-conditional-headers.md">ConditionalHeaders</a> plugin can be used to configure the
-            <control>Etag</control> response header.
+            <control>Etag</control>
+            response header.
         </p>
     </chapter>
 
@@ -158,7 +169,11 @@
         <p>
             In this section, we'll see how to serve static files such as images, CSS files,
             and JavaScript files in Express and Ktor.
-            Suppose we have the <path>public</path> folder with the main <path>index.html</path> page
+            Suppose we have the
+            <path>public</path>
+            folder with the main
+            <path>index.html</path>
+            page
             and a set of linked assets.
         </p>
         <code-block>
@@ -178,13 +193,15 @@
                 </td>
                 <td>
                     <p>
-                        In Express, pass the folder name to the <control>express.static</control> function.
+                        In Express, pass the folder name to the
+                        <control>express.static</control>
+                        function.
                     </p>
                     <code-block lang="javascript" src="snippets/migrating-express/2_static/app.js"/>
                     <p>
-                        <emphasis>
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/2_static/app.js">View sample on GitHub</a>
-                        </emphasis>
+                        For the full example, see the
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/2_static/app.js">2_static</a>
+                        project.
                     </p>
                 </td>
             </tr>
@@ -194,16 +211,23 @@
                 </td>
                 <td>
                     <p>
-                        In Ktor, use the <a href="server-static-content.md">static</a> function to map any
-                        request made to the <path>/</path> path to the <path>public</path> physical folder. 
-                        The <code>files(".")</code> function enables serving all files from the
-                        <path>public</path> folder recursively.
+                        In Ktor, use the <a href="server-static-content.md" anchor="folders"><code>staticFiles()</code></a>
+                        function to map any request made to the
+                        <path>/</path>
+                        path to the
+                        <path>public</path>
+                        physical folder.
+                        This function enables serving all files from the
+                        <path>public</path>
+                        folder recursively.
                     </p>
-                    <code-block lang="javascript" src="snippets/migrating-express-ktor/2_static/src/main/kotlin/com/example/Application.kt" include-lines="3-19"/>
+                    <code-block lang="kotlin"
+                                src="snippets/migrating-express-ktor/2_static/src/main/kotlin/com/example/Application.kt"
+                                include-lines="3-15"/>
                     <p>
-                        <emphasis>
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/2_static/src/main/kotlin/com/example/Application.kt">View sample on GitHub</a>
-                        </emphasis>
+                        For the full example, see the <a
+                            href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/2_static/src/main/kotlin/com/example/Application.kt">2_static</a>
+                        project.
                     </p>
                 </td>
             </tr>
@@ -223,17 +247,22 @@
         <list>
             <li>
                 <p>
-                    <control>Accept-Ranges</control>: <a href="server-partial-content.md">PartialContent</a>
+                    <control>Accept-Ranges</control>
+                    : <a href="server-partial-content.md">PartialContent</a>
                 </p>
             </li>
             <li>
                 <p>
-                    <control>Cache-Control</control>: <a href="server-caching-headers.md">CachingHeaders</a>
+                    <control>Cache-Control</control>
+                    : <a href="server-caching-headers.md">CachingHeaders</a>
                 </p>
             </li>
             <li>
                 <p>
-                    <control>ETag</control> and <control>Last-Modified</control>:
+                    <control>ETag</control>
+                    and
+                    <control>Last-Modified</control>
+                    :
                     <a href="server-conditional-headers.md">ConditionalHeaders</a>
                 </p>
             </li>
@@ -244,9 +273,12 @@
     <chapter title="Routing" id="routing">
         <p>
             <a href="server-routing.md">Routing</a> allows handling incoming requests made to a particular endpoint,
-            which is defined by a specific HTTP request method (<code>GET</code>, <code>POST</code>, and so on) and a path.
+            which is defined by a specific HTTP request method (<code>GET</code>, <code>POST</code>, and so on) and a
+            path.
             The examples below show how to handle <code>GET</code> and
-            <code>POST</code> requests made to the <path>/</path> path.
+            <code>POST</code> requests made to the
+            <path>/</path>
+            path.
         </p>
         <table style="header-column">
             <tr>
@@ -254,11 +286,12 @@
                     <control>Express</control>
                 </td>
                 <td>
-                    <code-block lang="javascript" src="snippets/migrating-express/3_router/app.js" include-lines="7-13"/>
+                    <code-block lang="javascript" src="snippets/migrating-express/3_router/app.js"
+                                include-lines="7-13"/>
                     <p>
-                        <emphasis>
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/3_router/app.js">View sample on GitHub</a>
-                        </emphasis>
+                        For the full example, see the
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
+                        project.
                     </p>
                 </td>
             </tr>
@@ -267,17 +300,20 @@
                     <control>Ktor</control>
                 </td>
                 <td>
-                    <code-block lang="kotlin" src="snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt" include-lines="12,14-19,36"/>
+                    <code-block lang="kotlin"
+                                src="snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt"
+                                include-lines="12,14-19,36"/>
                     <tip>
                         <p>
-                            See <a anchor="receive-request"/> to learn how to receive request bodies for <code>POST</code>, <code>PUT</code>, or
+                            See <a anchor="receive-request"/> to learn how to receive request bodies for
+                            <code>POST</code>, <code>PUT</code>, or
                             <code>PATCH</code> requests.
                         </p>
                     </tip>
                     <p>
-                        <emphasis>
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">View sample on GitHub</a>
-                        </emphasis>
+                        For the full example, see the
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
+                        project.
                     </p>
                 </td>
             </tr>
@@ -298,11 +334,12 @@
                         In Express, you can create chainable route handlers for a route path by using
                         <code>app.route()</code>.
                     </p>
-                    <code-block lang="javascript" src="snippets/migrating-express/3_router/app.js" include-lines="16-25"/>
+                    <code-block lang="javascript" src="snippets/migrating-express/3_router/app.js"
+                                include-lines="16-25"/>
                     <p>
-                        <emphasis>
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/3_router/app.js">View sample on GitHub</a>
-                        </emphasis>
+                        For the full example, see the
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
+                        project.
                     </p>
                 </td>
             </tr>
@@ -315,11 +352,13 @@
                         Ktor provides a <code>route</code> function,
                         whereby you define the path and then place the verbs for that path as nested functions.
                     </p>
-                    <code-block lang="kotlin" src="snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt" include-lines="12,22-32,36"/>
+                    <code-block lang="kotlin"
+                                src="snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt"
+                                include-lines="12,22-32,36"/>
                     <p>
-                        <emphasis>
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">View sample on GitHub</a>
-                        </emphasis>
+                        For the full example, see the
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
+                        project.
                     </p>
                 </td>
             </tr>
@@ -336,21 +375,26 @@
                 <td>
                     <p>
                         Express provides the <code>express.Router</code> class to create mountable route handlers.
-                        Suppose we have the <path>birds.js</path> router file in the application's directory.
-                        This router module can be loaded in the application as shown in <path>app.js</path>:
+                        Suppose we have the
+                        <path>birds.js</path>
+                        router file in the application's directory.
+                        This router module can be loaded in the application as shown in
+                        <path>app.js</path>
+                        :
                     </p>
                     <tabs>
                         <tab title="birds.js">
                             <code-block lang="javascript" src="snippets/migrating-express/3_router/birds.js"/>
                         </tab>
                         <tab title="app.js">
-                            <code-block lang="javascript" src="snippets/migrating-express/3_router/app.js" include-lines="1-5,28-32"/>
+                            <code-block lang="javascript" src="snippets/migrating-express/3_router/app.js"
+                                        include-lines="1-5,28-32"/>
                         </tab>
                     </tabs>
                     <p>
-                        <emphasis>
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/3_router/app.js">View sample on GitHub</a>
-                        </emphasis>
+                        For the full example, see the
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
+                        project.
                     </p>
                 </td>
             </tr>
@@ -360,24 +404,32 @@
                 </td>
                 <td>
                     <p>
-                        In Ktor, a common pattern is to use extension functions on the <code>Route</code> type
+                        In Ktor, a common pattern is to use extension functions on the <code>Routing</code> type
                         to define the actual routes.
-                        The sample below (<path>Birds.kt</path>) defines the <code>birdsRoutes</code> extension function.
-                        You can include corresponding routes in the application (<path>Application.kt</path>)
+                        The sample below (
+                        <path>Birds.kt</path>
+                        ) defines the <code>birdsRoutes</code> extension function.
+                        You can include corresponding routes in the application (
+                        <path>Application.kt</path>
+                        )
                         by calling this function inside the <code>routing</code> block:
                     </p>
                     <tabs>
-                        <tab title="Birds.kt">
-                            <code-block lang="kotlin" src="snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/routes/Birds.kt" include-lines="3-16"/>
+                        <tab title="Birds.kt" id="birds-kt">
+                            <code-block lang="kotlin"
+                                        src="snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/routes/Birds.kt"
+                                        include-lines="3-15"/>
                         </tab>
-                        <tab title="Application.kt">
-                            <code-block lang="kotlin" src="snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt" include-lines="3-12,35-37"/>
+                        <tab title="Application.kt" id="application-kt">
+                            <code-block lang="kotlin"
+                                        src="snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt"
+                                        include-lines="3-12,35-37"/>
                         </tab>
                     </tabs>
                     <p>
-                        <emphasis>
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">View sample on GitHub</a>
-                        </emphasis>
+                        For the full example, see the
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
+                        project.
                     </p>
                 </td>
             </tr>
@@ -394,7 +446,8 @@
             This section will show us how to access route and query parameters.
         </p>
         <p>
-            A route (or path) parameter is a named URL segment used to capture the value specified at its position in the URL.
+            A route (or path) parameter is a named URL segment used to capture the value specified at its position in
+            the URL.
         </p>
         <table style="header-column">
             <tr>
@@ -405,13 +458,18 @@
                     <p>
                         To access route parameters in Express, you can use <code>Request.params</code>.
                         For example, <code>req.parameters["login"]</code> in the code snippet below will
-                        return <emphasis>admin</emphasis> for the <path>/user/admin</path> path:
+                        return
+                        <emphasis>admin</emphasis>
+                        for the
+                        <path>/user/admin</path>
+                        path:
                     </p>
-                    <code-block lang="javascript" src="snippets/migrating-express/4_parameters/app.js" include-lines="6-12"/>
+                    <code-block lang="javascript" src="snippets/migrating-express/4_parameters/app.js"
+                                include-lines="6-12"/>
                     <p>
-                        <emphasis>
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/4_parameters/app.js">View sample on GitHub</a>
-                        </emphasis>
+                        For the full example, see the
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a>
+                        project.
                     </p>
                 </td>
             </tr>
@@ -424,11 +482,13 @@
                         In Ktor, route parameters are defined using the <code>{param}</code> syntax.
                         You can use <code>call.parameters</code> to access route parameters in route handlers:
                     </p>
-                    <code-block lang="kotlin" src="snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt" include-lines="11-18,24"/>
+                    <code-block lang="kotlin"
+                                src="snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt"
+                                include-lines="11-18,24"/>
                     <p>
-                        <emphasis>
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">View sample on GitHub</a>
-                        </emphasis>
+                        For the full example, see the
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a>
+                        project.
                     </p>
                 </td>
             </tr>
@@ -447,13 +507,18 @@
                     <p>
                         To access route parameters in Express, you can use <code>Request.params</code>.
                         For example, <code>req.parameters["login"]</code> in the code snippet below will
-                        return <emphasis>admin</emphasis> for the <path>/user/admin</path> path:
+                        return
+                        <emphasis>admin</emphasis>
+                        for the
+                        <path>/user/admin</path>
+                        path:
                     </p>
-                    <code-block lang="javascript" src="snippets/migrating-express/4_parameters/app.js" include-lines="14-18"/>
+                    <code-block lang="javascript" src="snippets/migrating-express/4_parameters/app.js"
+                                include-lines="14-18"/>
                     <p>
-                        <emphasis>
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/4_parameters/app.js">View sample on GitHub</a>
-                        </emphasis>
+                        For the full example, see the
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a>
+                        project.
                     </p>
                 </td>
             </tr>
@@ -466,17 +531,18 @@
                         In Ktor, route parameters are defined using the <code>{param}</code> syntax.
                         You can use <code>call.parameters</code> to access route parameters in route handlers:
                     </p>
-                    <code-block lang="kotlin" src="snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt" include-lines="11,19-24"/>
+                    <code-block lang="kotlin"
+                                src="snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt"
+                                include-lines="11,19-24"/>
                     <p>
-                        <emphasis>
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">View sample on GitHub</a>
-                        </emphasis>
+                        For the full example, see the
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a>
+                        project.
                     </p>
                 </td>
             </tr>
         </table>
     </chapter>
-
 
 
     <chapter title="Sending responses" id="send-response">
@@ -496,11 +562,12 @@
                             To send a JSON response with the appropriate content type in Express,
                             call the <code>res.json</code> function:
                         </p>
-                        <code-block lang="javascript" src="snippets/migrating-express/5_send_response/app.js" include-lines="6-9"/>
+                        <code-block lang="javascript" src="snippets/migrating-express/5_send_response/app.js"
+                                    include-lines="6-9"/>
                         <p>
-                            <emphasis>
-                                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/5_send_response/app.js">View sample on GitHub</a>
-                            </emphasis>
+                            For the full example, see the
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
+                            project.
                         </p>
                     </td>
                 </tr>
@@ -510,22 +577,30 @@
                     </td>
                     <td>
                         <p>
-                            In Ktor, you need to install the <a href="server-serialization.md">ContentNegotiation</a> plugin and
+                            In Ktor, you need to install the <a href="server-serialization.md">ContentNegotiation</a>
+                            plugin and
                             configure the JSON serializer:
                         </p>
-                        <code-block lang="kotlin" src="snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt" include-lines="19-21"/>
+                        <code-block lang="kotlin"
+                                    src="snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt"
+                                    include-lines="19-21"/>
                         <p>
-                            To serialize data into JSON, you need to create a data class with the <code>@Serializable</code> annotation:
+                            To serialize data into JSON, you need to create a data class with the
+                            <code>@Serializable</code> annotation:
                         </p>
-                        <code-block lang="kotlin" src="snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt" include-lines="15-16"/>
+                        <code-block lang="kotlin"
+                                    src="snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt"
+                                    include-lines="15-16"/>
                         <p>
                             Then, you can use <code>call.respond</code> to send an object of this class in a response:
                         </p>
-                        <code-block lang="kotlin" src="snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt" include-lines="23-25"/>
+                        <code-block lang="kotlin"
+                                    src="snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt"
+                                    include-lines="23-25"/>
                         <p>
-                            <emphasis>
-                                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">View sample on GitHub</a>
-                            </emphasis>
+                            For the full example, see the
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
+                            project.
                         </p>
                     </td>
                 </tr>
@@ -542,11 +617,12 @@
                         <p>
                             To respond with a file in Express, use <code>res.sendFile</code>:
                         </p>
-                        <code-block lang="javascript" src="snippets/migrating-express/5_send_response/app.js" include-lines="2,10-13"/>
+                        <code-block lang="javascript" src="snippets/migrating-express/5_send_response/app.js"
+                                    include-lines="2,10-13"/>
                         <p>
-                            <emphasis>
-                                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/5_send_response/app.js">View sample on GitHub</a>
-                            </emphasis>
+                            For the full example, see the
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
+                            project.
                         </p>
                     </td>
                 </tr>
@@ -558,21 +634,27 @@
                         <p>
                             Ktor provides the <code>call.respondFile</code> function for sending files to the client:
                         </p>
-                        <code-block lang="kotlin" src="snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt" include-lines="26-29"/>
+                        <code-block lang="kotlin"
+                                    src="snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt"
+                                    include-lines="26-29"/>
                         <p>
-                            <emphasis>
-                                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">View sample on GitHub</a>
-                            </emphasis>
+                            For the full example, see the
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
+                            project.
                         </p>
                     </td>
                 </tr>
             </table>
 
             <p>
-                The Express application adds the <control>Accept-Ranges</control> HTTP response header
+                The Express application adds the
+                <control>Accept-Ranges</control>
+                HTTP response header
                 when responding with a file.
-                The server uses this header for advertising its support for partial requests from the client for file downloads.
-                In Ktor, you need to install the <a href="server-partial-content.md">PartialContent</a> plugin to support partial requests.
+                The server uses this header for advertising its support for partial requests from the client for file
+                downloads.
+                In Ktor, you need to install the <a href="server-partial-content.md">PartialContent</a> plugin to
+                support partial requests.
             </p>
         </chapter>
 
@@ -586,11 +668,12 @@
                         <p>
                             The <code>res.download</code> function transfers the specified file as an attachment:
                         </p>
-                        <code-block lang="javascript" src="snippets/migrating-express/5_send_response/app.js" include-lines="15-17"/>
+                        <code-block lang="javascript" src="snippets/migrating-express/5_send_response/app.js"
+                                    include-lines="15-17"/>
                         <p>
-                            <emphasis>
-                                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/5_send_response/app.js">View sample on GitHub</a>
-                            </emphasis>
+                            For the full example, see the
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
+                            project.
                         </p>
                     </td>
                 </tr>
@@ -601,13 +684,16 @@
                     <td>
                         <p>
                             In Ktor, you need to configure the
-                            <control>Content-Disposition</control> header manually to transfer the file as the attachment:
+                            <control>Content-Disposition</control>
+                            header manually to transfer the file as the attachment:
                         </p>
-                        <code-block lang="kotlin" src="snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt" include-lines="30-38"/>
+                        <code-block lang="kotlin"
+                                    src="snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt"
+                                    include-lines="30-38"/>
                         <p>
-                            <emphasis>
-                                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">View sample on GitHub</a>
-                            </emphasis>
+                            For the full example, see the
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
+                            project.
                         </p>
                     </td>
                 </tr>
@@ -624,11 +710,12 @@
                         <p>
                             To generate a redirection response in Express, call the <code>redirect</code> function:
                         </p>
-                        <code-block lang="javascript" src="snippets/migrating-express/5_send_response/app.js" include-lines="19-25"/>
+                        <code-block lang="javascript" src="snippets/migrating-express/5_send_response/app.js"
+                                    include-lines="19-25"/>
                         <p>
-                            <emphasis>
-                                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/5_send_response/app.js">View sample on GitHub</a>
-                            </emphasis>
+                            For the full example, see the
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
+                            project.
                         </p>
                     </td>
                 </tr>
@@ -640,11 +727,13 @@
                         <p>
                             In Ktor, use <code>respondRedirect</code> to send a redirection response:
                         </p>
-                        <code-block lang="kotlin" src="snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt" include-lines="39-44"/>
+                        <code-block lang="kotlin"
+                                    src="snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt"
+                                    include-lines="39-44"/>
                         <p>
-                            <emphasis>
-                                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">View sample on GitHub</a>
-                            </emphasis>
+                            For the full example, see the
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
+                            project.
                         </p>
                     </td>
                 </tr>
@@ -664,17 +753,20 @@
                 </td>
                 <td>
                     <p>
-                        Suppose we have the following Pug template in the <path>views</path> folder:
+                        Suppose we have the following Pug template in the
+                        <path>views</path>
+                        folder:
                     </p>
                     <code-block src="snippets/migrating-express/6_templates/views/index.pug"/>
                     <p>
                         To respond with this template, call <code>res.render</code>:
                     </p>
-                    <code-block lang="javascript" src="snippets/migrating-express/6_templates/app.js" include-lines="5-10"/>
+                    <code-block lang="javascript" src="snippets/migrating-express/6_templates/app.js"
+                                include-lines="5-10"/>
                     <p>
-                        <emphasis>
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/6_templates/app.js">View sample on GitHub</a>
-                        </emphasis>
+                        For the full example, see the
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/6_templates/app.js">6_templates</a>
+                        project.
                     </p>
                 </td>
             </tr>
@@ -690,17 +782,18 @@
                         install and configure the <code>FreeMarker</code> plugin and
                         then send a template using <code>call.respond</code>:
                     </p>
-                    <code-block lang="kotlin" src="snippets/migrating-express-ktor/6_templates/src/main/kotlin/com/example/Application.kt" include-lines="11-23"/>
+                    <code-block lang="kotlin"
+                                src="snippets/migrating-express-ktor/6_templates/src/main/kotlin/com/example/Application.kt"
+                                include-lines="11-23"/>
                     <p>
-                        <emphasis>
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/6_templates/src/main/kotlin/com/example/Application.kt">View sample on GitHub</a>
-                        </emphasis>
+                        For the full example, see the
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/6_templates/src/main/kotlin/com/example/Application.kt">6_templates</a>
+                        project.
                     </p>
                 </td>
             </tr>
         </table>
     </chapter>
-
 
 
     <chapter title="Receiving requests" id="receive-request">
@@ -724,17 +817,19 @@
                         <p>
                             To parse an incoming request body in Express, you need to add <code>body-parser</code>:
                         </p>
-                        <code-block lang="javascript" src="snippets/migrating-express/7_receive_request/app.js" include-lines="2"/>
+                        <code-block lang="javascript" src="snippets/migrating-express/7_receive_request/app.js"
+                                    include-lines="2"/>
                         <p>
                             In the <code>post</code> handler,
                             you need to pass the text parser (<code>bodyParser.text</code>).
                             A request body will be available under the <code>req.body</code> property:
                         </p>
-                        <code-block lang="javascript" src="snippets/migrating-express/7_receive_request/app.js" include-lines="8-11"/>
+                        <code-block lang="javascript" src="snippets/migrating-express/7_receive_request/app.js"
+                                    include-lines="8-11"/>
                         <p>
-                            <emphasis>
-                                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/7_receive_request/app.js">View sample on GitHub</a>
-                            </emphasis>
+                            For the full example, see the
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                            project.
                         </p>
                     </td>
                 </tr>
@@ -746,11 +841,13 @@
                         <p>
                             In Ktor, you can receive a body as a text using <code>call.receiveText</code>:
                         </p>
-                        <code-block lang="kotlin" src="snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt" include-lines="30-33"/>
+                        <code-block lang="kotlin"
+                                    src="snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt"
+                                    include-lines="30-33"/>
                         <p>
-                            <emphasis>
-                                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">View sample on GitHub</a>
-                            </emphasis>
+                            For the full example, see the
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
+                            project.
                         </p>
                     </td>
                 </tr>
@@ -774,11 +871,12 @@
                         <p>
                             To receive JSON in Express, use <code>bodyParser.json</code>:
                         </p>
-                        <code-block lang="javascript" src="snippets/migrating-express/7_receive_request/app.js" include-lines="2,12-16"/>
+                        <code-block lang="javascript" src="snippets/migrating-express/7_receive_request/app.js"
+                                    include-lines="2,12-16"/>
                         <p>
-                            <emphasis>
-                                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/7_receive_request/app.js">View sample on GitHub</a>
-                            </emphasis>
+                            For the full example, see the
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                            project.
                         </p>
                     </td>
                 </tr>
@@ -788,22 +886,29 @@
                     </td>
                     <td>
                         <p>
-                            In Ktor, you need to install the <a href="server-serialization.md">ContentNegotiation</a> plugin
+                            In Ktor, you need to install the <a href="server-serialization.md">ContentNegotiation</a>
+                            plugin
                             and configure the <code>Json</code> serializer:
                         </p>
-                        <code-block lang="kotlin" src="snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt" include-lines="23-28"/>
+                        <code-block lang="kotlin"
+                                    src="snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt"
+                                    include-lines="23-28"/>
                         <p>
                             To deserialize received data into an object, you need to create a data class:
                         </p>
-                        <code-block lang="kotlin" src="snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt" include-lines="19-20"/>
+                        <code-block lang="kotlin"
+                                    src="snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt"
+                                    include-lines="19-20"/>
                         <p>
                             Then, use the <code>receive</code> method that accepts this data class as a parameter:
                         </p>
-                        <code-block lang="kotlin" src="snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt" include-lines="34-37"/>
+                        <code-block lang="kotlin"
+                                    src="snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt"
+                                    include-lines="34-37"/>
                         <p>
-                            <emphasis>
-                                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">View sample on GitHub</a>
-                            </emphasis>
+                            For the full example, see the
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
+                            project.
                         </p>
                     </td>
                 </tr>
@@ -814,7 +919,8 @@
         <chapter title="URL-encoded" id="receive-url-encoded">
             <p>
                 Now let's see how to receive form data sent using the
-                <control>application/x-www-form-urlencoded</control> type.
+                <control>application/x-www-form-urlencoded</control>
+                type.
                 The code snippet below shows a sample <code>POST</code> request with form data:
             </p>
             <code-block lang="http" src="snippets/migrating-express/7_receive_request/post.http" include-lines="19-22"/>
@@ -828,11 +934,12 @@
                             As for plain text and JSON, Express requires <code>body-parser</code>.
                             You need to set the parser type to <code>bodyParser.urlencoded</code>:
                         </p>
-                        <code-block lang="javascript" src="snippets/migrating-express/7_receive_request/app.js" include-lines="2,17-21"/>
+                        <code-block lang="javascript" src="snippets/migrating-express/7_receive_request/app.js"
+                                    include-lines="2,17-21"/>
                         <p>
-                            <emphasis>
-                                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/7_receive_request/app.js">View sample on GitHub</a>
-                            </emphasis>
+                            For the full example, see the
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                            project.
                         </p>
                     </td>
                 </tr>
@@ -844,11 +951,13 @@
                         <p>
                             In Ktor, use the <code>call.receiveParameters</code> function:
                         </p>
-                        <code-block lang="kotlin" src="snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt" include-lines="38-42"/>
+                        <code-block lang="kotlin"
+                                    src="snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt"
+                                    include-lines="38-42"/>
                         <p>
-                            <emphasis>
-                                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">View sample on GitHub</a>
-                            </emphasis>
+                            For the full example, see the
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
+                            project.
                         </p>
                     </td>
                 </tr>
@@ -860,7 +969,8 @@
             <p>
                 The next use case is handling binary data.
                 The request below sends a PNG image with the
-                <control>application/octet-stream</control> to the server:
+                <control>application/octet-stream</control>
+                to the server:
             </p>
             <code-block lang="http" src="snippets/migrating-express/7_receive_request/post.http" include-lines="26-29"/>
             <table style="header-column">
@@ -872,11 +982,12 @@
                         <p>
                             To handle binary data in Express, set the parser type to <code>raw</code>:
                         </p>
-                        <code-block lang="javascript" src="snippets/migrating-express/7_receive_request/app.js" include-lines="2-3,22-27"/>
+                        <code-block lang="javascript" src="snippets/migrating-express/7_receive_request/app.js"
+                                    include-lines="2-3,22-27"/>
                         <p>
-                            <emphasis>
-                                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/7_receive_request/app.js">View sample on GitHub</a>
-                            </emphasis>
+                            For the full example, see the
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                            project.
                         </p>
                     </td>
                 </tr>
@@ -889,11 +1000,14 @@
                             Ktor provides <code>ByteReadChannel</code> and <code>ByteWriteChannel</code>
                             for asynchronous reading/writing sequences of bytes:
                         </p>
-                        <code-block lang="kotlin" src="snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt" include-lines="43-47"/>
+                        <code-block lang="kotlin"
+                                    src="snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt"
+                                    include-lines="43-47"/>
                         <p>
-                            <emphasis>
-                                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">View sample on GitHub</a>
-                            </emphasis>
+                            For the full example, see the
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive
+                                request</a>
+                            project.
                         </p>
                     </td>
                 </tr>
@@ -903,9 +1017,12 @@
 
         <chapter title="Multipart" id="receive-multipart">
             <p>
-                In the final section, let's look at how to handle <emphasis>multipart</emphasis> bodies.
+                In the final section, let's look at how to handle
+                <emphasis>multipart</emphasis>
+                bodies.
                 The <code>POST</code> request below sends a PNG image with a description using the
-                <control>multipart/form-data</control> type:
+                <control>multipart/form-data</control>
+                type:
             </p>
             <code-block lang="http" src="snippets/migrating-express/7_receive_request/post.http" include-lines="33-46"/>
             <table style="header-column">
@@ -916,13 +1033,16 @@
                     <td>
                         <p>
                             Express requires a separate module to parse multipart data.
-                            In the example below, <control>multer</control> is used to upload a file to the server:
+                            In the example below,
+                            <control>multer</control>
+                            is used to upload a file to the server:
                         </p>
-                        <code-block lang="javascript" src="snippets/migrating-express/7_receive_request/app.js" include-lines="4,28-40"/>
+                        <code-block lang="javascript" src="snippets/migrating-express/7_receive_request/app.js"
+                                    include-lines="4,28-40"/>
                         <p>
-                            <emphasis>
-                                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/7_receive_request/app.js">View sample on GitHub</a>
-                            </emphasis>
+                            For the full example, see the
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                            project.
                         </p>
                     </td>
                 </tr>
@@ -934,13 +1054,16 @@
                         <p>
                             In Ktor, if you need to receive a file sent as a part of a multipart request,
                             call the <code>receiveMultipart</code> function and then loop over each part as required.
-                            In the example below, <code>PartData.FileItem</code> is used to receive a file as a byte stream:
+                            In the example below, <code>PartData.FileItem</code> is used to receive a file as a byte
+                            stream:
                         </p>
-                        <code-block lang="kotlin" src="snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt" include-lines="48-68"/>
+                        <code-block lang="kotlin"
+                                    src="snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt"
+                                    include-lines="48-68"/>
                         <p>
-                            <emphasis>
-                                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">View sample on GitHub</a>
-                            </emphasis>
+                            For the full example, see the
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
+                            project.
                         </p>
                     </td>
                 </tr>
@@ -949,10 +1072,10 @@
     </chapter>
 
 
-
     <chapter title="Creating middleware" id="middleware">
         <p>
-            The final thing we'll look at is how to create middleware that allows you to extend the server functionality.
+            The final thing we'll look at is how to create middleware that allows you to extend the server
+            functionality.
             The examples below show how to implement request logging using Express and Ktor.
         </p>
         <table style="header-column">
@@ -964,11 +1087,12 @@
                     <p>
                         In Express, middleware is a function bound to the application using <code>app.use</code>:
                     </p>
-                    <code-block lang="javascript" src="snippets/migrating-express/8_middleware/app.js" include-lines="1-13"/>
+                    <code-block lang="javascript" src="snippets/migrating-express/8_middleware/app.js"
+                                include-lines="1-13"/>
                     <p>
-                        <emphasis>
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/8_middleware/app.js">View sample on GitHub</a>
-                        </emphasis>
+                        For the full example, see the
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/8_middleware/app.js">8_middleware</a>
+                        project.
                     </p>
                 </td>
             </tr>
@@ -982,11 +1106,13 @@
                         using <a href="server-custom-plugins.md">custom plugins</a>.
                         The code example below shows how to handle <code>onCall</code> to implement request logging:
                     </p>
-                    <code-block lang="kotlin" src="snippets/migrating-express-ktor/8_middleware/src/main/kotlin/com/example/Application.kt" include-lines="23-29"/>
+                    <code-block lang="kotlin"
+                                src="snippets/migrating-express-ktor/8_middleware/src/main/kotlin/com/example/Application.kt"
+                                include-lines="23-29"/>
                     <p>
-                        <emphasis>
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/8_middleware/src/main/kotlin/com/example/Application.kt">View sample on GitHub</a>
-                        </emphasis>
+                        For the full example, see the
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/8_middleware/src/main/kotlin/com/example/Application.kt">8_middleware</a>
+                        project.
                     </p>
                 </td>
             </tr>
@@ -1000,8 +1126,9 @@
             For most of these functionalities, Ktor provides dedicated plugins
             that can be installed in the application and configured as required.
             To continue your journey with Ktor,
-            visit the <control><a href="https://ktor.io/learn/">Learn page</a></control>,
-            which provides a set of step-by-step guides and ready-to-use samples.
+            visit the
+            <control><a href="https://ktor.io/learn/">Learn page</a></control>
+            ,which provides a set of step-by-step guides and ready-to-use samples.
         </p>
     </chapter>
 </topic>


### PR DESCRIPTION
Made the following changes to the sample project:
- Updated `kotlin(jvm)` version to `2.0.0`
- Replaced `static` with `staticFiles`
- Replaced `Route` with `Routing`
- Added `README.md` files in the root and sub-projects.

Changes to the "Migrating from Express to Ktor" topic:

- Replaced `static` with `staticFiles`
- Replaced `Route` with `Routing`
- Formatted file to fix project warnings
- Edited Github links to include the project name and not use `<emphasis>`
- Used the `<tldr>` element to the top of the topic for code examples