### PR TITLE
Clarify Google AppEngine docs, support java21 runtime

### DIFF
--- a/codeSnippets/snippets/google-appengine-standard/build.gradle.kts
+++ b/codeSnippets/snippets/google-appengine-standard/build.gradle.kts
@@ -7,7 +7,7 @@ val gce_logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("com.google.cloud.tools.appengine") version "2.4.2"
+    id("com.google.cloud.tools.appengine") version "2.8.0"
     id("com.github.johnrengelman.shadow") version "7.1.2"
 }
 

--- a/codeSnippets/snippets/google-appengine-standard/src/main/appengine/app.yaml
+++ b/codeSnippets/snippets/google-appengine-standard/src/main/appengine/app.yaml
@@ -1,2 +1,2 @@
-runtime: java11
+runtime: java21
 entrypoint: 'java -jar google-appengine-standard-1.0-SNAPSHOT-all.jar'

--- a/codeSnippets/snippets/google-appengine-standard/src/main/appengine/app.yaml
+++ b/codeSnippets/snippets/google-appengine-standard/src/main/appengine/app.yaml
@@ -1,2 +1,2 @@
 runtime: java21
-entrypoint: 'java -jar google-appengine-standard-1.0-SNAPSHOT-all.jar'
+entrypoint: 'java -jar google-appengine-standard-all.jar'

--- a/topics/google-app-engine.md
+++ b/topics/google-app-engine.md
@@ -67,14 +67,15 @@ The [Google App Engine Gradle plugin](https://github.com/GoogleCloudPlatform/app
 
 ### Step 3: Configure App Engine settings {id="configure-app-engine-settings"}
 You configure App Engine settings for your application in the [app.yaml](https://cloud.google.com/appengine/docs/standard/python/config/appref) file:
-1. Create the `appengine` directory inside `src/main/appengine`.
-2. Inside this directory, create the `app.yaml` file and add the following content:
+1. Create the `appengine` directory inside `src/main`.
+2. Inside this directory, create the `app.yaml` file and add the following content (replace `google-appengine-standard` with your project's name):
    ```yaml
    ```
    {src="snippets/google-appengine-standard/src/main/appengine/app.yaml"}
    
    The `entrypoint` option contains a command used to run a fat JAR generated for the application.
 
+   Further documentation on supported configuration options can be found from the [Google AppEngine documentation](https://cloud.google.com/appengine/docs/standard/reference/app-yaml?tab=java).
 
 ## Deploy an application {id="deploy-app"}
 


### PR DESCRIPTION
The docs and code examples for deploying a Ktor server project to Google AppEngine currently demonstrates use of the `java11` run time environment. The java11 runtime will reach end of support within a few weeks (31 October 2024). (See the [Support Schedule](https://cloud.google.com/appengine/docs/standard/lifecycle/support-schedule#java) as published by Google.)

I've updated the example project to use the most recent support Java runtime (`java21`). This also requires use of the latest AppEngine plugin for Gradle, version 2.8.0. 

I've also made a few small revisions to the associated documentation to clarify a few items which I found confusing when I worked through this for my own project.