### PR TITLE
Fixed getting a non-existent parameter

### DIFF
--- a/codeSnippets/snippets/tutorial-server-web-application/src/main/kotlin/com/example/plugins/Templating.kt
+++ b/codeSnippets/snippets/tutorial-server-web-application/src/main/kotlin/com/example/plugins/Templating.kt
@@ -27,7 +27,7 @@ fun Application.configureTemplating() {
                 )
             }
             get("/byName") {
-                val name = call.request.queryParameters["taskName"]
+                val name = call.request.queryParameters["name"]
                 if (name == null) {
                     call.respond(HttpStatusCode.BadRequest)
                     return@get


### PR DESCRIPTION
The form on the page `resources/static/index.html` designed to search for a task by name sends a GET request to the endpoint `/tasks/byName` with the name of the task in the `name` parameter. The endpoint, in turn, tries to get the value of the name by the `taskName` parameter. Now the GET method of the `/tasks/byName` endpoint tries to get the task name parameter by the name `name` instead of `taskName`.