### PR TITLE
Included the helper function in the WebSocket configuration snippet.

### DIFF
--- a/topics/server-create-websocket-application.topic
+++ b/topics/server-create-websocket-application.topic
@@ -379,7 +379,7 @@
                 </p>
                 <code-block src="snippets/tutorial-server-websockets/src/main/kotlin/com/example/plugins/Sockets.kt"
                             lang="kotlin"
-                            include-lines="16-46"
+                            include-lines="16-53"
                 />
                 <p>With this code you have done the following:</p>
                 <list>


### PR DESCRIPTION
The `DefaultWebSocketServerSession.sendAllTasks` helper function is used in the code of the `Application.configureSockets` function, but it was not included in the topic. Because of its absence on the user side, the program code cannot even be compiled.

Before: 
![Screenshot from 2024-09-05 16-23-02](https://github.com/user-attachments/assets/651d2ac6-31f7-4c26-b7d3-810f8be72ce4)

After:
![Screenshot from 2024-09-05 16-23-23](https://github.com/user-attachments/assets/eefdb41c-4525-476d-97c1-9bf7650aefef)