### PR TITLE
chore: replace com.github.johnrengelman.shadow with com.gradleup.shadow

### DIFF
--- a/codeSnippets/snippets/google-appengine-standard/build.gradle.kts
+++ b/codeSnippets/snippets/google-appengine-standard/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     application
     kotlin("jvm")
     id("com.google.cloud.tools.appengine") version "2.8.0"
-    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.gradleup.shadow") version "8.3.1"
 }
 
 application {


### PR DESCRIPTION
com.github.johnrengelman.shadow plugin has changed the core maintainer and has new coordinates: https://plugins.gradle.org/plugin/com.gradleup.shadow

for more info se: https://plugins.gradle.org/plugin/com.github.johnrengelman.shadow