### PR TITLE
Add release details for 3.0.0-rc-1

### DIFF
--- a/topics/releases.md
+++ b/topics/releases.md
@@ -36,6 +36,7 @@ The following table lists details of the latest Ktor releases.
 <tr><td>3.0.0-rc-1</td><td>September 9, 2024</td><td><p>
 A major release candidate containing significant improvements and bug fixes. This update enhances backward compatibility
 and features extended <code>staticZip</code> support.
+For more information on breaking changes, see <a href="https://ktor.io/docs/eap/migrating-3.html">the migration guide</a>.
 </p>
 <var name="version" value="3.0.0-rc-1"/>
 <include from="lib.topic" element-id="release_details_link"/>

--- a/topics/releases.md
+++ b/topics/releases.md
@@ -33,8 +33,16 @@ The following table lists details of the latest Ktor releases.
 
 <table>
 <tr><td>Version</td><td>Release Date</td><td>Highlights</td></tr>
+<tr><td>3.0.0-rc-1</td><td>September 9, 2024</td><td><p>
+A major release candidate containing significant improvements and bug fixes. This update enhances backward compatibility
+and features extended <code>staticZip</code> support.
+</p>
+<var name="version" value="3.0.0-rc-1"/>
+<include from="lib.topic" element-id="release_details_link"/>
+</td></tr>
 <tr><td>3.0.0-beta-2</td><td>July 15, 2024</td><td><p>
 A major pre-release version with various improvements and bug fixes, including SSE support improvements and a Ktor client for Kotlin/Wasm.
+For more information on breaking changes, see <a href="https://ktor.io/docs/3.0.0-beta-2/migrating-3.html">the migration guide</a>.
 </p>
 <var name="version" value="3.0.0-beta-2"/>
 <include from="lib.topic" element-id="release_details_link"/>


### PR DESCRIPTION
- Listed `3.0.0-rc-1` to the Releases page.
- Included a link to the  migration guide for  both `3.0.0-rc-1` and `3.0.0-beta-2`.