### PR TITLE
fix(deps): downgrade coroutines to 1.9.0

### DIFF
--- a/codeSnippets/snippets/tutorial-client-kmm/gradle/libs.versions.toml
+++ b/codeSnippets/snippets/tutorial-client-kmm/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.3.1"
 kotlin = "2.0.0"
-coroutines = "2.0.0"
+coroutines = "1.9.0"
 ktor = "2.3.12"
 compose = "1.6.8"
 compose-compiler = "1.5.4"


### PR DESCRIPTION
The latest version of coroutines is 1.9.0.
Currently the version in the sample is 2.0.0 which is not existing yet