### PR TITLE
KTOR-7495 Document removal of `withTestApplication`

### DIFF
--- a/codeSnippets/snippets/json-kotlinx/src/test/kotlin/jsonkotlinx/ApplicationTest.kt
+++ b/codeSnippets/snippets/json-kotlinx/src/test/kotlin/jsonkotlinx/ApplicationTest.kt
@@ -5,10 +5,7 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
-import io.ktor.server.application.*
 import io.ktor.server.testing.*
-import kotlinx.serialization.*
-import kotlinx.serialization.json.*
 import kotlin.test.*
 
 class CustomerTests {

--- a/codeSnippets/snippets/upload-file/src/test/kotlin/uploadfile/UploadFileTest.kt
+++ b/codeSnippets/snippets/upload-file/src/test/kotlin/uploadfile/UploadFileTest.kt
@@ -4,14 +4,10 @@ import io.ktor.client.request.*
 import io.ktor.client.request.forms.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
-import io.ktor.http.content.*
-import io.ktor.server.application.*
 import io.ktor.server.testing.*
-import io.ktor.utils.io.*
 import org.junit.*
 import java.io.*
 import kotlin.test.*
-import kotlin.test.Ignore
 import kotlin.test.Test
 
 class ApplicationTest {

--- a/topics/migrating-3.md
+++ b/topics/migrating-3.md
@@ -127,13 +127,41 @@ function.
 For more details about the model change,
 see [issue KTOR-3857 on YouTrack](https://youtrack.jetbrains.com/issue/KTOR-3857/Environment-Engine-Application-Design).
 
-### `TestApplication` explicit loading of modules
+### Testing
+
+##### `withTestApplication` and `withApplication` have been removed
+
+The `withTestApplication` and `withApplication` functions, [previously deprecated in the
+`2.0.0` release](migration-to-20x.md#testing-api), have now been removed from the `ktor-server-test-host` package.
+
+Instead, use the `testApplication` function with the existing [Ktor client](client-create-and-configure.md)
+instance to make requests to your server and verify the results.
+
+In the test below, the `handleRequest` function is replaced with the `client.get` request:
+
+<compare first-title="1.x.x" second-title="3.0.x">
+
+```kotlin
+```
+{src="https://raw.githubusercontent.com/ktorio/ktor-documentation/refs/heads/2.3.12/codeSnippets/snippets/engine-main/src/test/kotlin/EngineMainTest.kt"
+include-lines="18-26"}
+
+```kotlin
+```
+{src="https://raw.githubusercontent.com/ktorio/ktor-documentation/refs/heads/2.3.12/codeSnippets/snippets/engine-main/src/test/kotlin/EngineMainTest.kt"
+include-lines="11-16"}
+
+</compare>
+
+For more information, see [](server-testing.md).
+
+#### `TestApplication` module loading {id="test-module-loading"}
 
 `TestApplication` no longer automatically loads modules from a configuration file (
 e.g. `application.conf`). Instead, you must [explicitly load your modules](#explicit-module-loading) within the
 `testApplication` function or [load the configuration file](#configure-env) manually.
 
-#### Explicit module loading {id="explicit-module-loading"}
+##### Explicit module loading {id="explicit-module-loading"}
 
 To explicitly load modules, use the `application` function within `testApplication`. This approach allows you to
 manually specify which modules to load, providing greater control over your test setup.
@@ -188,7 +216,7 @@ class ApplicationTest {
 
 </compare>
 
-#### Load modules from a configuration file {id="configure-env"}
+##### Load modules from a configuration file {id="configure-env"}
 
 If you want to load modules from a configuration file, use the `environment` function to specify the configuration
 file for your test.

--- a/topics/migration-to-20x.md
+++ b/topics/migration-to-20x.md
@@ -197,14 +197,16 @@ In the test below, the `handleRequest` function is replaced with the `client.get
 
 ```kotlin
 ```
-{src="snippets/engine-main/src/test/kotlin/EngineMainTest.kt" include-lines="18-26"}
+{src="https://raw.githubusercontent.com/ktorio/ktor-documentation/refs/heads/2.3.12/codeSnippets/snippets/engine-main/src/test/kotlin/EngineMainTest.kt"
+include-lines="18-26"}
 
 </tab>
 <tab title="2.0.0" group-key="2_0">
 
 ```kotlin
 ```
-{src="snippets/engine-main/src/test/kotlin/EngineMainTest.kt" include-lines="11-16"}
+{src="https://raw.githubusercontent.com/ktorio/ktor-documentation/refs/heads/2.3.12/codeSnippets/snippets/engine-main/src/test/kotlin/EngineMainTest.kt"
+include-lines="11-16"}
 
 </tab>
 </tabs>
@@ -219,14 +221,16 @@ In the test below, the `handleRequest` function is replaced with the `client.pos
 
 ```kotlin
 ```
-{src="snippets/post-form-parameters/src/test/kotlin/formparameters/ApplicationTest.kt" include-lines="20-28"}
+{src="https://raw.githubusercontent.com/ktorio/ktor-documentation/refs/heads/2.3.12/codeSnippets/snippets/post-form-parameters/src/test/kotlin/formparameters/ApplicationTest.kt"
+include-lines="20-28"}
 
 </tab>
 <tab title="2.0.0" group-key="2_0">
 
 ```kotlin
 ```
-{src="snippets/post-form-parameters/src/test/kotlin/formparameters/ApplicationTest.kt" include-lines="11-18"}
+{src="https://raw.githubusercontent.com/ktorio/ktor-documentation/refs/heads/2.3.12/codeSnippets/snippets/post-form-parameters/src/test/kotlin/formparameters/ApplicationTest.kt"
+include-lines="11-18"}
 
 </tab>
 </tabs>
@@ -242,14 +246,14 @@ To build `multipart/form-data` in v2.0.0, you need to pass `MultiPartFormDataCon
 
 ```kotlin
 ```
-{src="snippets/upload-file/src/test/kotlin/uploadfile/UploadFileTest.kt" include-lines="38-63"}
+{src="https://raw.githubusercontent.com/ktorio/ktor-documentation/refs/heads/2.3.12/codeSnippets/snippets/upload-file/src/test/kotlin/uploadfile/UploadFileTest.kt" include-lines="38-63"}
 
 </tab>
 <tab title="2.0.0" group-key="2_0">
 
 ```kotlin
 ```
-{src="snippets/upload-file/src/test/kotlin/uploadfile/UploadFileTest.kt" include-lines="17-36"}
+{src="https://raw.githubusercontent.com/ktorio/ktor-documentation/refs/heads/2.3.12/codeSnippets/snippets/upload-file/src/test/kotlin/uploadfile/UploadFileTest.kt" include-lines="17-36"}
 
 </tab>
 </tabs>
@@ -266,14 +270,16 @@ With v2.0.0, you need to create a new client instance and install the [ContentNe
 
 ```kotlin
 ```
-{src="snippets/json-kotlinx/src/test/kotlin/jsonkotlinx/ApplicationTest.kt" include-lines="46-55"}
+{src="https://raw.githubusercontent.com/ktorio/ktor-documentation/refs/heads/2.3.12/codeSnippets/snippets/json-kotlinx/src/test/kotlin/jsonkotlinx/ApplicationTest.kt"
+include-lines="46-55"}
 
 </tab>
 <tab title="2.0.0" group-key="2_0">
 
 ```kotlin
 ```
-{src="snippets/json-kotlinx/src/test/kotlin/jsonkotlinx/ApplicationTest.kt" include-lines="31-44"}
+{src="https://raw.githubusercontent.com/ktorio/ktor-documentation/refs/heads/2.3.12/codeSnippets/snippets/json-kotlinx/src/test/kotlin/jsonkotlinx/ApplicationTest.kt"
+include-lines="31-44"}
 
 </tab>
 </tabs>
@@ -288,14 +294,14 @@ In v1.6.x, `cookiesSession` is used to preserve cookies between requests when te
 
 ```kotlin
 ```
-{src="snippets/session-cookie-client/src/test/kotlin/cookieclient/ApplicationTest.kt" include-lines="29-46"}
+{src="https://raw.githubusercontent.com/ktorio/ktor-documentation/refs/heads/2.3.12/codeSnippets/snippets/session-cookie-client/src/test/kotlin/cookieclient/ApplicationTest.kt" include-lines="29-46"}
 
 </tab>
 <tab title="2.0.0" group-key="2_0">
 
 ```kotlin
 ```
-{src="snippets/session-cookie-client/src/test/kotlin/cookieclient/ApplicationTest.kt" include-lines="12-27"}
+{src="https://raw.githubusercontent.com/ktorio/ktor-documentation/refs/heads/2.3.12/codeSnippets/snippets/session-cookie-client/src/test/kotlin/cookieclient/ApplicationTest.kt" include-lines="12-27"}
 
 </tab>
 </tabs>
@@ -309,14 +315,16 @@ In the old API, `handleWebSocketConversation` is used to test [WebSocket convers
 
 ```kotlin
 ```
-{src="snippets/server-websockets/src/test/kotlin/com/example/ModuleTest.kt" include-lines="28-40"}
+{src="https://raw.githubusercontent.com/ktorio/ktor-documentation/refs/heads/2.3.12/codeSnippets/snippets/server-websockets/src/test/kotlin/com/example/ModuleTest.kt"
+include-lines="28-40"}
 
 </tab>
 <tab title="2.0.0" group-key="2_0">
 
 ```kotlin
 ```
-{src="snippets/server-websockets/src/test/kotlin/com/example/ModuleTest.kt" include-lines="10-26"}
+{src="https://raw.githubusercontent.com/ktorio/ktor-documentation/refs/heads/2.3.12/codeSnippets/snippets/server-websockets/src/test/kotlin/com/example/ModuleTest.kt"
+include-lines="10-26"}
 
 </tab>
 </tabs>

--- a/topics/server-testing.md
+++ b/topics/server-testing.md
@@ -47,7 +47,7 @@ The code below demonstrates how to test the most simple Ktor application that ac
 
 ```kotlin
 ```
-{src="snippets/engine-main/src/test/kotlin/EngineMainTest.kt" include-lines="3-19,30"}
+{src="snippets/engine-main/src/test/kotlin/EngineMainTest.kt"}
 
 </tab>
 
@@ -55,7 +55,7 @@ The code below demonstrates how to test the most simple Ktor application that ac
 
 ```kotlin
 ```
-{src="snippets/engine-main/src/main/kotlin/com/example/Application.kt" include-lines="3-15"}
+{src="snippets/engine-main/src/main/kotlin/com/example/Application.kt"}
 
 </tab>
 </tabs>
@@ -88,7 +88,7 @@ To add modules to a test application manually, use the `application` function:
 
 ```kotlin
 ```
-{src="snippets/embedded-server-modules/src/test/kotlin/EmbeddedServerTest.kt" include-lines="11-15,19"}
+{src="snippets/embedded-server-modules/src/test/kotlin/EmbeddedServerTest.kt" include-symbol="testModule1"}
 
 #### Load modules from a configuration file {id="configure-env"}
 
@@ -153,7 +153,7 @@ The `testApplication` provides access to an HTTP client with default configurati
 If you need to customize the client and install additional plugins, you can use the `createClient` function. For example, to [send JSON data](#json-data) in a test POST/PUT request, you can install the [ContentNegotiation](client-serialization.md) plugin:
 ```kotlin
 ```
-{src="snippets/json-kotlinx/src/test/kotlin/jsonkotlinx/ApplicationTest.kt" include-lines="33-43,50"}
+{src="snippets/json-kotlinx/src/test/kotlin/jsonkotlinx/ApplicationTest.kt" include-lines="31-40,48"}
 
 
 ### Step 3: Make a request {id="make-request"}
@@ -162,7 +162,7 @@ To test your application, use the [configured client](#configure-client) to make
 
 ```kotlin
 ```
-{src="snippets/json-kotlinx/src/test/kotlin/jsonkotlinx/ApplicationTest.kt" include-lines="33-47,50"}
+{src="snippets/json-kotlinx/src/test/kotlin/jsonkotlinx/ApplicationTest.kt" include-lines="31-44,48"}
 
 
 
@@ -172,7 +172,7 @@ After receiving a [response](#make-request), you can verify the results by makin
 
 ```kotlin
 ```
-{src="snippets/json-kotlinx/src/test/kotlin/jsonkotlinx/ApplicationTest.kt" include-lines="33-50"}
+{src="snippets/json-kotlinx/src/test/kotlin/jsonkotlinx/ApplicationTest.kt" include-lines="31-48"}
 
 
 ## Test POST/PUT requests {id="test-post-put"}
@@ -191,7 +191,7 @@ A test below from the [post-form-parameters](https://github.com/ktorio/ktor-docu
 
 ```kotlin
 ```
-{src="snippets/post-form-parameters/src/test/kotlin/formparameters/ApplicationTest.kt" include-lines="3-21,32"}
+{src="snippets/post-form-parameters/src/test/kotlin/formparameters/ApplicationTest.kt"}
 
 </tab>
 
@@ -214,7 +214,7 @@ The code below demonstrates how to build `multipart/form-data` and test file upl
 
 ```kotlin
 ```
-{src="snippets/upload-file/src/test/kotlin/uploadfile/UploadFileTest.kt" include-lines="3-40,75"}
+{src="snippets/upload-file/src/test/kotlin/uploadfile/UploadFileTest.kt"}
 
 </tab>
 
@@ -222,7 +222,7 @@ The code below demonstrates how to build `multipart/form-data` and test file upl
 
 ```kotlin
 ```
-{src="snippets/upload-file/src/main/kotlin/uploadfile/UploadFile.kt" include-lines="3-40"}
+{src="snippets/upload-file/src/main/kotlin/uploadfile/UploadFile.kt"}
 
 </tab>
 </tabs>
@@ -237,7 +237,7 @@ To send JSON data in a test POST/PUT request, you need to create a new client an
 
 ```kotlin
 ```
-{src="snippets/json-kotlinx/src/test/kotlin/jsonkotlinx/ApplicationTest.kt" include-lines="3-14,34-50,62"}
+{src="snippets/json-kotlinx/src/test/kotlin/jsonkotlinx/ApplicationTest.kt" include-lines="3-11,31-48"}
 
 </tab>
 
@@ -262,7 +262,7 @@ If you need to preserve cookies between requests when testing, you need to creat
 
 ```kotlin
 ```
-{src="snippets/session-cookie-client/src/test/kotlin/cookieclient/ApplicationTest.kt" include-lines="3-30,50"}
+{src="snippets/session-cookie-client/src/test/kotlin/cookieclient/ApplicationTest.kt"}
 
 </tab>
 
@@ -293,7 +293,7 @@ You can test [WebSocket conversations](server-websockets.md) by using the [WebSo
 
 ```kotlin
 ```
-{src="snippets/server-websockets/src/test/kotlin/com/example/ModuleTest.kt" include-lines="3-29,44"}
+{src="snippets/server-websockets/src/test/kotlin/com/example/ModuleTest.kt"}
 
 
 ## End-to-end testing with HttpClient {id="end-to-end"}


### PR DESCRIPTION
[KTOR-7495](https://youtrack.jetbrains.com/issue/KTOR-7495)

- Document the removal of `withTestApplication` and `withApplication` in the Migration guide.
- Update source in code blocks to point to the `snippets` folder on github `2.3.12` branch where the legacy testing API has been used. (Due to the removal of test functions that use the legacy testing API in the `3.0.0-rc-2` release.)

[Preview Migration Guide on Staging](https://ktor.shared.aws.intellij.net/docs/3.0.0-rc-2/migrating-3.html#withtestapplication-and-withapplication-have-been-removed)