### PR TITLE
Fix typo in 3.0.x migration guide

### DIFF
--- a/topics/migrating-3.md
+++ b/topics/migrating-3.md
@@ -50,7 +50,7 @@ and their current corresponding ownership:
 
 | 2.x.x                                           | 3.0.x                                        |
 |-------------------------------------------------|----------------------------------------------|
-| `ApplicationEngineEnvironment.connectors`       | `ApplciationEngine.Configuration.connectors` |
+| `ApplicationEngineEnvironment.connectors`       | `ApplicationEngine.Configuration.connectors` |
 | `ApplicationEnvironment.developmentMode`        | `Application.developmentMode`                |
 | `ApplicationEnvironment.monitor`                | `Application.monitor`                        |
 | `ApplicationEnvironment.parentCoroutineContext` | `Application.parentCoroutineContext`         |


### PR DESCRIPTION
I noticed a very small typo when reading the migration guide.

`ApplciationEngine` should be `ApplicationEngine`.