### PR TITLE
KTOR-2866 Replace deprecated `static` function with `staticFiles` or `staticResources`

### DIFF
--- a/codeSnippets/snippets/auth-jwt-rs256/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/auth-jwt-rs256/src/main/kotlin/com/example/Application.kt
@@ -79,9 +79,6 @@ fun Application.main() {
                 call.respondText("Hello, $username! Token is expired at $expiresAt ms.")
             }
         }
-        static(".well-known") {
-            staticRootFolder = File("certs")
-            file("jwks.json")
-        }
+        staticFiles(".well-known", File("certs"), "jwks.json")
     }
 }

--- a/codeSnippets/snippets/tutorial-server-db-integration/src/main/kotlin/com/example/plugins/Routing.kt
+++ b/codeSnippets/snippets/tutorial-server-db-integration/src/main/kotlin/com/example/plugins/Routing.kt
@@ -18,8 +18,6 @@ fun Application.configureRouting() {
             call.respondText("Hello World!")
         }
         // Static plugin. Try to access `/static/index.html`
-        static("/static") {
-            resources("static")
-        }
+        staticResources("/static", "static")
     }
 }

--- a/codeSnippets/snippets/tutorial-server-docker-compose/src/main/kotlin/com/example/plugins/Routing.kt
+++ b/codeSnippets/snippets/tutorial-server-docker-compose/src/main/kotlin/com/example/plugins/Routing.kt
@@ -18,8 +18,6 @@ fun Application.configureRouting() {
             call.respondText("Hello World!")
         }
         // Static plugin. Try to access `/static/index.html`
-        static("/static") {
-            resources("static")
-        }
+        staticResources("/static", "static")
     }
 }

--- a/codeSnippets/snippets/tutorial-server-web-application/src/main/kotlin/com/example/plugins/Routing.kt
+++ b/codeSnippets/snippets/tutorial-server-web-application/src/main/kotlin/com/example/plugins/Routing.kt
@@ -11,8 +11,6 @@ fun Application.configureRouting() {
             call.respondText("Hello World!")
         }
         // Static plugin. Try to access `/static/index.html`
-        static("/static") {
-            resources("static")
-        }
+        staticResources("/static", "static")
     }
 }

--- a/codeSnippets/snippets/tutorial-server-websockets/src/main/kotlin/com/example/plugins/Routing.kt
+++ b/codeSnippets/snippets/tutorial-server-websockets/src/main/kotlin/com/example/plugins/Routing.kt
@@ -11,8 +11,6 @@ fun Application.configureRouting() {
             call.respondText("Hello World!")
         }
         // Static plugin. Try to access `/static/index.html`
-        static("/static") {
-            resources("static")
-        }
+        staticResources("/static", "static")
     }
 }

--- a/codeSnippets/snippets/webjars/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/webjars/src/main/kotlin/com/example/Application.kt
@@ -12,8 +12,6 @@ fun Application.module() {
         path = "assets"
     }
     routing {
-        static("/static") {
-            resources("files")
-        }
+        staticResources("/static", "files")
     }
 }

--- a/topics/server-create-website.topic
+++ b/topics/server-create-website.topic
@@ -280,9 +280,7 @@ fun Application.configureTemplating() {
             file:
         </p>
         <code-block lang="kotlin"><![CDATA[
-            static("/static") {
-                resources("static")
-            }
+            staticResources("/static", "static")
             ]]>
         </code-block>
         <p>

--- a/topics/server-webjars.md
+++ b/topics/server-webjars.md
@@ -46,7 +46,7 @@ By default, `%plugin_name%` serves WebJars assets on the `/webjars` path. The ex
 
 ```kotlin
 ```
-{src="snippets/webjars/src/main/kotlin/com/example/Application.kt" include-lines="3,6-7,10-13,19"}
+{src="snippets/webjars/src/main/kotlin/com/example/Application.kt" include-lines="3,6-7,10-13,17"}
 
 For instance, if you've installed the `org.webjars:bootstrap` dependency, you can add `bootstrap.css` as follows:
 


### PR DESCRIPTION
[KTOR-2866](https://youtrack.jetbrains.com/issue/KTOR-2866)

In tutorial code examples, the `static` function was automatically created by the Ktor generator. The generator no longer uses the deprecated function, so the samples have been updated to reflect this change.