### PR TITLE
Fixed build issues related to directly set kotlin version

### DIFF
--- a/codeSnippets/snippets/client-engine-winhttp/build.gradle.kts
+++ b/codeSnippets/snippets/client-engine-winhttp/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 
 plugins {
     application
-    kotlin("multiplatform") version "2.0.0"
+    kotlin("multiplatform")
 }
 
 repositories {


### PR DESCRIPTION
Hi! I had issues with launching ./gradlew :tutorial-client-get-started:run and ./gradlew :tutorial-server-get-started:run 
the issue was: 
> FAILURE: Build failed with an exception.

> * Where:
Build file 'C:\Repositories\IdeaProjects\ktor-documentation\codeSnippets\snippets\client-engine-winhttp\build.gradle.kts' line: 5

> * What went wrong:
Error resolving plugin [id: 'org.jetbrains.kotlin.multiplatform', version: '2.0.0']
> The request for this plugin could not be satisfied because the plugin is already on the classpath with an unknown version, so compatibility cannot be checked.

Sorry, this is my first attempt "contibution like" but i felt that it's weird that the project cannot be used out of box.
If i'm mistaken here just recent this merge :D 
