### PR TITLE
Update Ktor version from 3.0.0 to 3.0.1 

### DIFF
--- a/codeSnippets/gradle.properties
+++ b/codeSnippets/gradle.properties
@@ -6,7 +6,7 @@ kotlin.native.binary.memoryModel = experimental
 org.gradle.configureondemand = false
 # versions
 kotlin_version = 2.0.20
-ktor_version = 3.0.0
+ktor_version = 3.0.1
 kotlinx_coroutines_version = 1.9.0
 kotlinx_serialization_version = 1.7.2
 kotlin_css_version = 1.0.0-pre.721

--- a/codeSnippets/snippets/aws-elastic-beanstalk/build.gradle.kts
+++ b/codeSnippets/snippets/aws-elastic-beanstalk/build.gradle.kts
@@ -3,7 +3,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.0"
+    id("io.ktor.plugin") version "3.0.1"
 }
 
 application {

--- a/codeSnippets/snippets/deployment-ktor-plugin/build.gradle.kts
+++ b/codeSnippets/snippets/deployment-ktor-plugin/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.0"
+    id("io.ktor.plugin") version "3.0.1"
 }
 
 application {

--- a/codeSnippets/snippets/engine-main-custom-environment/build.gradle.kts
+++ b/codeSnippets/snippets/engine-main-custom-environment/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.0"
+    id("io.ktor.plugin") version "3.0.1"
 }
 
 application {

--- a/codeSnippets/snippets/forwarded-header/build.gradle.kts
+++ b/codeSnippets/snippets/forwarded-header/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.0"
+    id("io.ktor.plugin") version "3.0.1"
 }
 
 application {

--- a/codeSnippets/snippets/legacy-interactive-website/build.gradle.kts
+++ b/codeSnippets/snippets/legacy-interactive-website/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.0"
+    id("io.ktor.plugin") version "3.0.1"
 }
 
 application {

--- a/codeSnippets/snippets/migrating-express-ktor/gradle.properties
+++ b/codeSnippets/snippets/migrating-express-ktor/gradle.properties
@@ -1,4 +1,4 @@
-ktor_version=3.0.0
+ktor_version=3.0.1
 kotlin_version=2.0.0
 logback_version=1.5.6
 kotlin.code.style=official

--- a/codeSnippets/snippets/proguard/build.gradle.kts
+++ b/codeSnippets/snippets/proguard/build.gradle.kts
@@ -17,7 +17,7 @@ buildscript {
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.0"
+    id("io.ktor.plugin") version "3.0.1"
 }
 
 application {

--- a/codeSnippets/snippets/server-websockets-sharedflow/build.gradle.kts
+++ b/codeSnippets/snippets/server-websockets-sharedflow/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.0"
+    id("io.ktor.plugin") version "3.0.1"
     kotlin("plugin.serialization").version("2.0.0")
 }
 

--- a/codeSnippets/snippets/tutorial-client-kmm/gradle/libs.versions.toml
+++ b/codeSnippets/snippets/tutorial-client-kmm/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.3.1"
 kotlin = "2.0.0"
 coroutines = "1.9.0"
-ktor = "3.0.0"
+ktor = "3.0.1"
 compose = "1.6.8"
 compose-compiler = "1.5.4"
 compose-material3 = "1.2.1"

--- a/codeSnippets/snippets/tutorial-server-db-integration/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-db-integration/build.gradle.kts
@@ -8,7 +8,7 @@ val exposed_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.0"
+    id("io.ktor.plugin") version "3.0.1"
     id("org.jetbrains.kotlin.plugin.serialization") version "2.0.0"
 }
 

--- a/codeSnippets/snippets/tutorial-server-docker-compose/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-docker-compose/build.gradle.kts
@@ -8,7 +8,7 @@ val h2_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.0"
+    id("io.ktor.plugin") version "3.0.1"
     id("org.jetbrains.kotlin.plugin.serialization") version "2.0.0"
 }
 

--- a/codeSnippets/snippets/tutorial-server-get-started/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-get-started/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.0"
+    id("io.ktor.plugin") version "3.0.1"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-server-restful-api/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-restful-api/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.0"
+    id("io.ktor.plugin") version "3.0.1"
     id("org.jetbrains.kotlin.plugin.serialization") version "2.0.0"
 }
 

--- a/codeSnippets/snippets/tutorial-server-routing-and-requests/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-routing-and-requests/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.0"
+    id("io.ktor.plugin") version "3.0.1"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-server-web-application/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-web-application/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.0"
+    id("io.ktor.plugin") version "3.0.1"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-server-websockets/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-websockets/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 
 plugins {
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.0"
+    id("io.ktor.plugin") version "3.0.1"
     id("org.jetbrains.kotlin.plugin.serialization") version "2.0.0"
 }
 

--- a/codeSnippets/snippets/tutorial-website-static/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-website-static/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.0"
+    id("io.ktor.plugin") version "3.0.1"
 }
 
 application {

--- a/help-versions.json
+++ b/help-versions.json
@@ -10,7 +10,7 @@
     "isCurrent": false
   },
   {
-    "version": "3.0.0",
+    "version": "3.0.1",
     "url": "/docs/",
     "isCurrent": true
   }

--- a/project.ihp
+++ b/project.ihp
@@ -14,7 +14,7 @@
     <categories src="c.list"/>
     <instance src="ktor.tree"
               web-path="/docs/"
-              version="3.0.0"
+              version="3.0.1"
               id="docs"
               keymaps-mode="none"/>
 

--- a/topics/releases.md
+++ b/topics/releases.md
@@ -33,6 +33,12 @@ The following table lists details of the latest Ktor releases.
 
 <table>
 <tr><td>Version</td><td>Release Date</td><td>Highlights</td></tr>
+<tr><td>3.0.1</td><td>October 29, 2024</td><td><p>
+A patch release including improvements in client and server logging, and various bug fixes.  
+</p>
+<var name="version" value="3.0.1"/>
+<include from="lib.topic" element-id="release_details_link"/>
+</td></tr>
 <tr><td>3.0.0</td><td>October 9, 2024</td><td><p>
 A major release containing improvements and bug fixes, including added support for Android Native targets.
 For more information on breaking changes, see <a href="https://ktor.io/docs/migrating-3.html">the migration guide</a>.

--- a/v.list
+++ b/v.list
@@ -4,7 +4,7 @@
 
 <vars>
 
-    <var name="ktor_version" value="3.0.0"/>
+    <var name="ktor_version" value="3.0.1"/>
     <var name="kotlin_version" value="2.0.20"/>
     <var name="coroutines_version" value="1.9.0"/>
     <var name="kotlin_css_version" value="1.0.0-pre.625"/>


### PR DESCRIPTION
- Bump Ktor version in `codeSnippets` from `3.0.0` to `3.0.1`.
- Add release details in the Releases topic.
- Update the version switcher to show the new version.