### PR TITLE
Upgrade Ktor version to 3.0.2 and add release details

### DIFF
--- a/codeSnippets/gradle.properties
+++ b/codeSnippets/gradle.properties
@@ -6,7 +6,7 @@ kotlin.native.binary.memoryModel = experimental
 org.gradle.configureondemand = false
 # versions
 kotlin_version = 2.0.20
-ktor_version = 3.0.1
+ktor_version = 3.0.2
 kotlinx_coroutines_version = 1.9.0
 kotlinx_serialization_version = 1.7.2
 kotlin_css_version = 1.0.0-pre.721

--- a/codeSnippets/snippets/aws-elastic-beanstalk/build.gradle.kts
+++ b/codeSnippets/snippets/aws-elastic-beanstalk/build.gradle.kts
@@ -3,7 +3,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.1"
+    id("io.ktor.plugin") version "3.0.2"
 }
 
 application {

--- a/codeSnippets/snippets/client-engine-js/build.gradle.kts
+++ b/codeSnippets/snippets/client-engine-js/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+
 val ktor_version: String by project
 val kotlinx_html_version: String by project
 

--- a/codeSnippets/snippets/deployment-ktor-plugin/build.gradle.kts
+++ b/codeSnippets/snippets/deployment-ktor-plugin/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.1"
+    id("io.ktor.plugin") version "3.0.2"
 }
 
 application {

--- a/codeSnippets/snippets/engine-main-custom-environment/build.gradle.kts
+++ b/codeSnippets/snippets/engine-main-custom-environment/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.1"
+    id("io.ktor.plugin") version "3.0.2"
 }
 
 application {

--- a/codeSnippets/snippets/forwarded-header/build.gradle.kts
+++ b/codeSnippets/snippets/forwarded-header/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.1"
+    id("io.ktor.plugin") version "3.0.2"
 }
 
 application {

--- a/codeSnippets/snippets/legacy-interactive-website/build.gradle.kts
+++ b/codeSnippets/snippets/legacy-interactive-website/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.1"
+    id("io.ktor.plugin") version "3.0.2"
 }
 
 application {

--- a/codeSnippets/snippets/migrating-express-ktor/gradle.properties
+++ b/codeSnippets/snippets/migrating-express-ktor/gradle.properties
@@ -1,4 +1,4 @@
-ktor_version=3.0.1
+ktor_version=3.0.2
 kotlin_version=2.0.0
 logback_version=1.5.6
 kotlin.code.style=official

--- a/codeSnippets/snippets/proguard/build.gradle.kts
+++ b/codeSnippets/snippets/proguard/build.gradle.kts
@@ -17,7 +17,7 @@ buildscript {
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.1"
+    id("io.ktor.plugin") version "3.0.2"
 }
 
 application {

--- a/codeSnippets/snippets/server-websockets-sharedflow/build.gradle.kts
+++ b/codeSnippets/snippets/server-websockets-sharedflow/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.1"
+    id("io.ktor.plugin") version "3.0.2"
     kotlin("plugin.serialization").version("2.0.0")
 }
 

--- a/codeSnippets/snippets/tutorial-client-kmm/gradle/libs.versions.toml
+++ b/codeSnippets/snippets/tutorial-client-kmm/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.3.1"
 kotlin = "2.0.0"
 coroutines = "1.9.0"
-ktor = "3.0.1"
+ktor = "3.0.2"
 compose = "1.6.8"
 compose-compiler = "1.5.4"
 compose-material3 = "1.2.1"

--- a/codeSnippets/snippets/tutorial-server-db-integration/gradle/libs.versions.toml
+++ b/codeSnippets/snippets/tutorial-server-db-integration/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 exposed-version = "0.56.0"
 h2-version = "2.3.232"
 kotlin-version = "2.0.21"
-ktor-version = "3.0.1"
+ktor-version = "3.0.2"
 logback-version = "1.4.14"
 postgres-version = "42.7.4"
 

--- a/codeSnippets/snippets/tutorial-server-docker-compose/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-docker-compose/build.gradle.kts
@@ -8,7 +8,7 @@ val h2_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.1"
+    id("io.ktor.plugin") version "3.0.2"
     id("org.jetbrains.kotlin.plugin.serialization") version "2.0.0"
 }
 

--- a/codeSnippets/snippets/tutorial-server-get-started/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-get-started/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.1"
+    id("io.ktor.plugin") version "3.0.2"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-server-restful-api/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-restful-api/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.1"
+    id("io.ktor.plugin") version "3.0.2"
     id("org.jetbrains.kotlin.plugin.serialization") version "2.0.0"
 }
 

--- a/codeSnippets/snippets/tutorial-server-routing-and-requests/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-routing-and-requests/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.1"
+    id("io.ktor.plugin") version "3.0.2"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-server-web-application/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-web-application/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.1"
+    id("io.ktor.plugin") version "3.0.2"
 }
 
 application {

--- a/codeSnippets/snippets/tutorial-server-websockets/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-websockets/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 
 plugins {
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.1"
+    id("io.ktor.plugin") version "3.0.2"
     id("org.jetbrains.kotlin.plugin.serialization") version "2.0.0"
 }
 

--- a/codeSnippets/snippets/tutorial-website-static/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-website-static/build.gradle.kts
@@ -5,7 +5,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.0.1"
+    id("io.ktor.plugin") version "3.0.2"
 }
 
 application {

--- a/help-versions.json
+++ b/help-versions.json
@@ -10,7 +10,7 @@
     "isCurrent": false
   },
   {
-    "version": "3.0.1",
+    "version": "3.0.2",
     "url": "/docs/",
     "isCurrent": true
   }

--- a/project.ihp
+++ b/project.ihp
@@ -14,7 +14,7 @@
     <categories src="c.list"/>
     <instance src="ktor.tree"
               web-path="/docs/"
-              version="3.0.1"
+              version="3.0.2"
               id="docs"
               keymaps-mode="none"/>
 

--- a/topics/releases.md
+++ b/topics/releases.md
@@ -33,6 +33,13 @@ The following table lists details of the latest Ktor releases.
 
 <table>
 <tr><td>Version</td><td>Release Date</td><td>Highlights</td></tr>
+<tr><td>3.0.2</td><td>December 4, 2024</td><td><p>
+A patch release addressing multiple bug fixes related to response corruption, truncated bodies, connection handling, 
+and incorrect headers, along with extended binary encoding support and performance enhancements for Android. 
+</p>
+<var name="version" value="3.0.2"/>
+<include from="lib.topic" element-id="release_details_link"/>
+</td></tr>
 <tr><td>2.3.13</td><td>November 20, 2024</td><td><p>
 A patch release with bug fixes, security patches, and improvements, including added support for the
 <code>watchosDeviceArm64</code> target.  

--- a/v.list
+++ b/v.list
@@ -4,7 +4,7 @@
 
 <vars>
 
-    <var name="ktor_version" value="3.0.1"/>
+    <var name="ktor_version" value="3.0.2"/>
     <var name="kotlin_version" value="2.0.20"/>
     <var name="coroutines_version" value="1.9.0"/>
     <var name="kotlin_css_version" value="1.0.0-pre.625"/>


### PR DESCRIPTION
- Upgraded Ktor version from `3.0.1` to `3.0.2`.
- Added release details in the `Releases` topic.
- Updated the version switcher version.