### PR TITLE
KTOR-7565 Docker: script compilation errors when Gradle version catalog is used

### DIFF
--- a/codeSnippets/snippets/tutorial-server-docker-compose/Dockerfile
+++ b/codeSnippets/snippets/tutorial-server-docker-compose/Dockerfile
@@ -3,6 +3,7 @@ FROM gradle:latest AS cache
 RUN mkdir -p /home/gradle/cache_home
 ENV GRADLE_USER_HOME /home/gradle/cache_home
 COPY build.gradle.* gradle.properties /home/gradle/app/
+COPY gradle /home/gradle/app/gradle
 WORKDIR /home/gradle/app
 RUN gradle clean build -i --stacktrace
 

--- a/codeSnippets/snippets/tutorial-server-docker-compose/Dockerfile
+++ b/codeSnippets/snippets/tutorial-server-docker-compose/Dockerfile
@@ -20,7 +20,7 @@ RUN gradle buildFatJar --no-daemon
 
 # Stage 3: Create the Runtime Image
 FROM amazoncorretto:22 AS runtime
-EXPOSE 8080 8080
+EXPOSE 8080
 RUN mkdir /app
 COPY --from=build /home/gradle/src/build/libs/*.jar /app/ktor-docker-sample.jar
 ENTRYPOINT ["java","-jar","/app/ktor-docker-sample.jar"]


### PR DESCRIPTION
Fix `Dockerfile` missing copy of `gradle` folder to `cache` step leading to build failure.
[YouTrack ticker](https://youtrack.jetbrains.com/issue/KTOR-7565/Docker-script-compilation-errors-when-Gradle-version-catalog-is-used)