### PR TITLE
KTOR-7222 POST call in tutorial should return 201 Created status

### DIFF
--- a/codeSnippets/snippets/tutorial-server-restful-api/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/tutorial-server-restful-api/src/main/kotlin/com/example/Application.kt
@@ -1,6 +1,5 @@
 package com.example
 
-import com.example.plugins.*
 import io.ktor.server.application.*
 
 fun main(args: Array<String>) {

--- a/codeSnippets/snippets/tutorial-server-restful-api/src/main/kotlin/com/example/Routing.kt
+++ b/codeSnippets/snippets/tutorial-server-restful-api/src/main/kotlin/com/example/Routing.kt
@@ -1,4 +1,4 @@
-package com.example.plugins
+package com.example
 
 import com.example.model.*
 import io.ktor.http.*

--- a/codeSnippets/snippets/tutorial-server-restful-api/src/main/kotlin/com/example/Serialization.kt
+++ b/codeSnippets/snippets/tutorial-server-restful-api/src/main/kotlin/com/example/Serialization.kt
@@ -1,4 +1,4 @@
-package com.example.plugins
+package com.example
 
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*

--- a/codeSnippets/snippets/tutorial-server-restful-api/src/test/kotlin/com/example/ApplicationTest.kt
+++ b/codeSnippets/snippets/tutorial-server-restful-api/src/test/kotlin/com/example/ApplicationTest.kt
@@ -71,7 +71,7 @@ class ApplicationTest {
 
             setBody(task)
         }
-        assertEquals(HttpStatusCode.NoContent, response1.status)
+        assertEquals(HttpStatusCode.Created, response1.status)
 
         val response2 = client.get("/tasks")
         assertEquals(HttpStatusCode.OK, response2.status)

--- a/topics/server-create-restful-apis.topic
+++ b/topics/server-create-restful-apis.topic
@@ -539,7 +539,7 @@
                                     try {
                                         val task = call.receive<Task>()
                                         TaskRepository.addTask(task)
-                                        call.respond(HttpStatusCode.NoContent)
+                                        call.respond(HttpStatusCode.Created)
                                     } catch (ex: IllegalStateException) {
                                         call.respond(HttpStatusCode.BadRequest)
                                     } catch (ex: JsonConvertException) {

--- a/topics/server-create-restful-apis.topic
+++ b/topics/server-create-restful-apis.topic
@@ -160,7 +160,7 @@
                     implementation below:
                 </p>
                 <code-block lang="kotlin">
-                    package com.example.plugins
+                    package com.example
 
                     import com.example.model.*
                     import io.ktor.server.application.*
@@ -235,11 +235,11 @@
                 inside the generated code in the project you will find a file called
                 <path>Serialization.kt</path>
                 inside
-                <path>src/kotlin/main/com/example/plugins</path>
+                <path>src/kotlin/main/com/example</path>
                 , which includes the following:
             </p>
             <code-block lang="kotlin"
-                        src="snippets/tutorial-server-restful-api/src/main/kotlin/com/example/plugins/Serialization.kt"
+                        src="snippets/tutorial-server-restful-api/src/main/kotlin/com/example/Serialization.kt"
                         include-lines="10-12"/>
             <p>
                 This code installs the <code>ContentNegotiation</code> plugin, and also configures the <code>kotlinx.serialization</code>
@@ -335,7 +335,7 @@
                         Navigate to the
                         <path>Routing.kt</path>
                         file in
-                        <path>src/main/kotlin/com/example/plugins</path>
+                        <path>src/main/kotlin/com/example</path>
                         .
                     </p>
                 </step>
@@ -345,7 +345,7 @@
                         <code>Application.configureRouting()</code> function with the following implementation:
                     </p>
                     <code-block lang="kotlin"><![CDATA[
-                    package example.com.plugins
+                    package com.example
 
                     import com.example.model.Priority
                     import com.example.model.TaskRepository
@@ -516,7 +516,7 @@
                     Open the
                     <path>Routing.kt</path>
                     file inside
-                    <path>src/main/kotlin/com/example/plugins</path>
+                    <path>src/main/kotlin/com/example</path>
                     .
                 </p>
             </step>

--- a/topics/server-create-restful-apis.topic
+++ b/topics/server-create-restful-apis.topic
@@ -730,16 +730,23 @@
             </step>
             <step>
                 <p>
-                    Add the following dependencies into your
+                    Add the following dependency into your version catalog located in
+                    <path>gradle/libs.versions.toml</path>
+                </p>
+                <code-block lang="toml">
+                    [libraries]
+                    # ...
+                    ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor-version" }
+                </code-block>
+            </step>
+            <step>
+                <p>
+                    Add the new dependency into your
                     <path>build.gradle.kts</path>
                     file:
                 </p>
                 <code-block lang="kotlin">
-                    val ktor_version: String by project
-
-                    //...
-                    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
-                    testImplementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
+                    testImplementation(libs.ktor.client.content.negotiation)
                 </code-block>
             </step>
         </procedure>


### PR DESCRIPTION
At first I wanted to address only the ticket issue.
But it turned out, the tutorial was a little bit outdated.

I have carefully read the content of the "How to create RESTful APIs in Kotlin with Ktor﻿" tutorial and tested each step.

Current version of the [Project wizzard](https://start.ktor.io/settings?name=ktor-sample&website=example.com&artifact=com.example.ktor-sample&kotlinVersion=2.1.0&ktorVersion=3.0.2&buildSystem=GRADLE_KTS&buildSystemArgs.version_catalog=true&engine=NETTY&configurationIn=YAML&addSampleCode=true&plugins=routing%252Ccontent-negotiation%252Cstatic-content) does not create a "plugins" package, so I changed the routes and packages in the article.

There was also one mistake in the package name.

And I added one additional step in "Create unit tests with Ktor client" section, to add required dependency.
[YouTrack ticket](https://youtrack.jetbrains.com/issue/KTOR-7222/POST-call-in-tutorial-should-return-201-Created-status)
