### PR TITLE
KTOR-7955 Fix broken links in the migration guide

### DIFF
--- a/topics/migrating-3.md
+++ b/topics/migrating-3.md
@@ -35,10 +35,10 @@ These changes will impact existing code that relies on the previous model.
 #### `start()` and `stop()` methods are removed from `ApplicationEngineEnvironment` {id="ApplicationEnvironment"}
 
 With the merge of `AplicationEngineEnvironment`
-to [`ApplicationEnvironment`](https://api.ktor.io/older/3.0.0-beta-1/ktor-server/ktor-server-core/io.ktor.server.application/-application-environment/index.html),
+to [`ApplicationEnvironment`](https://api.ktor.io/ktor-server/ktor-server-core/io.ktor.server.application/-application-environment/index.html),
 the `start()` and `stop()` methods are now
 only accessible
-through [`ApplicationEngine`](https://api.ktor.io/older/3.0.0-beta-1/ktor-server/ktor-server-core/io.ktor.server.engine/-application-engine/index.html).
+through [`ApplicationEngine`](https://api.ktor.io/ktor-server/ktor-server-core/io.ktor.server.engine/-application-engine/index.html).
 
 | 2.x.x                                                 | 3.0.x                                |
 |-------------------------------------------------------|--------------------------------------|
@@ -120,7 +120,7 @@ to reflect this new configuration approach.
 #### Introduction of `EmbeddedServer` {id="EmbeddedServer"}
 
 The
-class [`EmbeddedServer`](https://api.ktor.io/older/3.0.0-beta-1/ktor-server/ktor-server-core/io.ktor.server.engine/-embedded-server/index.html)
+class [`EmbeddedServer`](https://api.ktor.io/ktor-server/ktor-server-core/io.ktor.server.engine/-embedded-server/index.html)
 is introduced and used to replace `ApplicationEngine` as a return type of the `embeddedServer()`
 function.
 
@@ -241,7 +241,7 @@ plugin package has been renamed due to a typo.
 
 Due to `Application` requiring knowledge of `ApplicationEngine`, the contents of `ktor-server-host-common` module have
 been merged into `ktor-server-core`, namely
-the [`io.ktor.server.engine`](https://api.ktor.io/older/3.0.0-beta-1/ktor-server/ktor-server-core/io.ktor.server.engine/index.html)
+the [`io.ktor.server.engine`](https://api.ktor.io/ktor-server/ktor-server-core/io.ktor.server.engine/index.html)
 package.
 
 Ensure that your dependencies are updated accordingly. In most cases, you can simply remove

--- a/topics/releases.md
+++ b/topics/releases.md
@@ -122,7 +122,6 @@ A patch release including bug fixes in ContentNegotiation, WebSockets, and the m
 <tr><td>3.0.0-beta-1</td><td>November 23, 2023</td><td>
 <p>
 A major pre-release version with various improvements and bug fixes, including client and server SSE support.
-For more information on breaking changes, see <a href="https://ktor.io/docs/3.0.0-beta-1/migrating-3.html">the migration guide</a>.
 </p>
 <var name="version" value="3.0.0-beta-1"/>
 <include from="lib.topic" element-id="release_details_link"/>


### PR DESCRIPTION
- Fixed broken links in the 3.0 Migration Guide.
- Removed the link to the migration guide for `3.0.0-beta-1` from 'Releases' as it is no longer available.