### PR TITLE
KTOR-7821 Document removal of `commandLineEnvironment` and usage of `CommandLineConfig`

### DIFF
--- a/codeSnippets/snippets/embedded-server/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/embedded-server/src/main/kotlin/com/example/Application.kt
@@ -6,8 +6,8 @@ import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 
 /*
-   Important: The contents of this file are referenced by line number in `server-configuration-code.topic`
-    and `server-engines.md`. If you add, remove, or modify any lines, ensure you update the corresponding
+   Important: The contents of this file are referenced by line number in `server-configuration-code.topic`,
+   `server-engines.md` and `migrating-3.md`. If you add, remove, or modify any lines, ensure you update the corresponding
     line numbers in the `code-block` element of the referenced file.
 */
 fun main(args: Array<String>) {
@@ -20,7 +20,7 @@ fun main(args: Array<String>) {
     when (args[0]) {
         "basic" -> runBasicServer()
         "configured" -> runConfiguredServer()
-        else -> println("Unknown argument: ${args[0]}. Use 'basic' or 'configured'.")
+        else -> runServerWithCommandLineConfig(args)
     }
 }
 
@@ -46,6 +46,23 @@ fun runConfiguredServer() {
         shutdownGracePeriod = 2000
         shutdownTimeout = 3000
     }) {
+        routing {
+            get("/") {
+                call.respondText("Hello, world!")
+            }
+        }
+    }.start(wait = true)
+}
+
+fun runServerWithCommandLineConfig(args: Array<String>) {
+    embeddedServer(
+        factory = Netty,
+        configure = {
+            val cliConfig = CommandLineConfig(args)
+            takeFrom(cliConfig.engineConfig)
+            loadCommonConfiguration(cliConfig.rootConfig.environment.config)
+        }
+    ) {
         routing {
             get("/") {
                 call.respondText("Hello, world!")

--- a/topics/migrating-3.md
+++ b/topics/migrating-3.md
@@ -20,6 +20,7 @@ This restructuring comes with the following set of breaking changes:
 
 - [`ApplicationEngineEnvironmentBuilder` and `applicationEngineEnvironment` classes are renamed](#renamed-classes).
 - [`start()` and `stop()` methods are removed from `ApplicationEngineEnvironment`](#ApplicationEnvironment).
+- [`commandLineEnvironment()` is removed.](#CommandLineConfig).
 - [Introduction of `ServerConfigBuilder`](#ServerConfigBuilder).
 - [`embeddedServer()` returns`EmbeddedServer`](#EmbeddedServer) instead of `ApplicationEngine`.
 
@@ -99,6 +100,46 @@ fun defaultServer(module: Application.() -> Unit) =
 ```
 
 </compare>
+
+#### `commandLineEnvironment()` is removed {id="CommandLineConfig"}
+
+The `commandLineEnvironment()` function, used to create an `ApplicationEngineEnvironment` instance from command line
+arguments has been removed in Ktor `3.0.0`. Instead, you can use the
+[`CommandLineConfig`](https://api.ktor.io/ktor-server/ktor-server-core/io.ktor.server.engine/-command-line-config.html)
+function to parse command-line arguments into a configuration object.
+
+To migrate your application from `commandLineEnvironment` to `CommandLineConfig`, replace `commandLineEnvironment()`
+with a `configure` block as shown below.
+
+<compare first-title="2.2.x" second-title="3.0.x">
+
+```kotlin
+fun main(args: Array<String>) {
+    embeddedServer(Netty, commandLineEnvironment(args) {
+        connector { port = 8080 }
+        module {
+            routing {
+                get("/") {
+                    call.respondText("Hello, world!")
+                }
+            }
+        }
+    }) {
+        requestReadTimeoutSeconds = 5
+        responseWriteTimeoutSeconds = 5
+    }.start(wait = true)
+}
+```
+
+```kotlin
+```
+
+{src="snippets/embedded-server/src/main/kotlin/com/example/Application.kt" include-lines="13,58-72"}
+
+</compare>
+
+For more information on command-line configuration with `embeddedServer`, see the
+[Configuration in code](server-configuration-code.topic#command-line) topic.
 
 #### Introduction of `ServerConfigBuilder` {id="ServerConfigBuilder"}
 

--- a/topics/server-configuration-code.topic
+++ b/topics/server-configuration-code.topic
@@ -219,4 +219,50 @@
             </p>
         </tip>
     </chapter>
+    <chapter id="command-line" title="Command-line configuration">
+        <p>
+            Ktor allows you to dynamically configure an <code>embeddedServer</code> using command-line arguments. This
+            can be particularly useful in cases where configurations like ports, hosts, or timeouts need to be
+            specified at runtime.
+        </p>
+        <p>
+            To achieve this, use the
+            <a href="https://api.ktor.io/ktor-server/ktor-server-core/io.ktor.server.engine/-command-line-config.html">
+                CommandLineConfig
+            </a>
+            class to parse command-line arguments into a configuration object and pass it within the configuration
+            block:
+        </p>
+        <code-block src="snippets/embedded-server/src/main/kotlin/com/example/Application.kt"
+                    include-lines="13,58-72"
+                    lang="kotlin"
+        />
+        <p>
+            In this example, the
+            <a href="https://api.ktor.io/ktor-server/ktor-server-core/io.ktor.server.engine/-application-engine/-configuration/take-from.html">
+                <code>takeFrom()</code>
+            </a>
+            function from <code>Application.Configuration</code> is used to override engine configuration values, such
+            as <code>port</code> and <code>host</code>.
+            The
+            <a href="https://api.ktor.io/ktor-server/ktor-server-core/io.ktor.server.engine/load-common-configuration.html">
+                <code>loadCommonConfiguration()</code>
+            </a>
+            function loads configuration from the root environment, such as timeouts.
+        </p>
+        <p>
+            To run the server, specify arguments in the following way:
+        </p>
+        <code-block lang="shell">
+            ./gradlew run --args="-port=8080"
+        </code-block>
+        <tip>
+            For static configurations, you can use a configuration file or environment variables.
+            To learn more, see
+            <a href="server-configuration-file.topic" anchor="command-line">
+                Configuration in a file
+            </a>
+            .
+        </tip>
+    </chapter>
 </topic>


### PR DESCRIPTION
[KTOR-7821](https://youtrack.jetbrains.com/issue/KTOR-7821)

- Documented removal of `commandLineEnvironment` in the Ktor 3.0 migration guide.
- Added a sub-section in "Configuration in code" for "Command-line configuration", explaining the usage of `CommandLineConfig`.
- Extended the `embedded-server` snippets project to include an example usage with command line config.

[Preview Migration Guide](https://ktor.staging.kotlin-aws.intellij.net/docs/migrating-3.html#CommandLineConfig)
[Preview Configuration in code](https://ktor.staging.kotlin-aws.intellij.net/docs/server-configuration-code.html#command-line)