### PR TITLE
fix: Failing tests from recent changes and wrong src path provided in code-block

### DIFF
--- a/codeSnippets/snippets/html-templates/src/test/kotlin/HtmlTest.kt
+++ b/codeSnippets/snippets/html-templates/src/test/kotlin/HtmlTest.kt
@@ -22,6 +22,10 @@ class HtmlTest {
     <article>
       <h2>Hello from Ktor!</h2>
       <p>Kotlin Framework for creating connected systems.</p>
+      <ul>
+        <li><b>One</b></li>
+        <li>Two</li>
+      </ul>
     </article>
   </body>
 </html>

--- a/codeSnippets/snippets/tutorial-server-restful-api/src/main/kotlin/com/example/Routing.kt
+++ b/codeSnippets/snippets/tutorial-server-restful-api/src/main/kotlin/com/example/Routing.kt
@@ -58,7 +58,7 @@ fun Application.configureRouting() {
                 try {
                     val task = call.receive<Task>()
                     TaskRepository.addTask(task)
-                    call.respond(HttpStatusCode.NoContent)
+                    call.respond(HttpStatusCode.Created)
                 } catch (ex: IllegalStateException) {
                     call.respond(HttpStatusCode.BadRequest)
                 } catch (ex: JsonConvertException) {

--- a/topics/full-stack-development-with-kotlin-multiplatform.topic
+++ b/topics/full-stack-development-with-kotlin-multiplatform.topic
@@ -573,7 +573,7 @@
                     for the client configuration:
                 </p>
                 <code-block lang="kotlin"
-                            src="snippets/tutorial-full-stack-task-manager/composeApp/src/commonMain/kotlin/org/example/ktor/core/network/HttpClientManager.kt"
+                            src="snippets/tutorial-full-stack-task-manager/composeApp/src/commonMain/kotlin/org/example/ktor/network/HttpClientManager.kt"
                 />
                 <p>
                     Note you should replace <code>1.2.3.4</code> with the IP address of your current machine. You will


### PR DESCRIPTION
1. Fixes a couple of tests that were failing due to recent updates in code examples. 
2. Fixes incorrect `src` path of the newly introduced `HttpClientManager.kt` in the full-stack with KMP tutorial.