### PR TITLE
`client-websockets`: add `ktor-client-cio` to required dependencies

### DIFF
--- a/topics/client-websockets.topic
+++ b/topics/client-websockets.topic
@@ -9,7 +9,7 @@
     <var name="artifact_name" value="ktor-client-websockets"/>
     <tldr>
         <p>
-            <b>Required dependencies</b>: <code>io.ktor:ktor-client-websockets</code>
+            <b>Required dependencies</b>: <code>io.ktor:ktor-client-websockets</code> <code>io.ktor:ktor-client-cio</code>
         </p>
         <include from="lib.topic" element-id="download_example"/>
     </tldr>


### PR DESCRIPTION
After going through the docs I found that it was necessary to include:
 ```implementation ("io.ktor:ktor-client-cio:3.0.2")```. 
 
 Just adding `implementation("io.ktor:ktor-client-websockets:3.0.2")` was not enough to get the example working due to missing dependencies.

Let me know if anything else is needed, this is just my assumption of where the change needs to be made.

Documentation: https://ktor.io/docs/client-websockets.html#add_dependencies