### PR TITLE
Make the dependency platform-specific

### DIFF
--- a/topics/server-configuration-file.topic
+++ b/topics/server-configuration-file.topic
@@ -63,7 +63,7 @@
                 </p>
                 <note>
                     <p>
-                        To use a YAML configuration file, you need to add the <code>ktor-server-config-yaml</code>
+                        To use a YAML configuration file, you need to add the <code>ktor-server-config-yaml-jvm</code>
                         <a href="server-dependencies.topic">
                             dependency
                         </a>


### PR DESCRIPTION
I encountered an error to inform that the app failed to load `application.conf`, instead of `application.yaml` when I set `ktor-server-config-yaml` to `build.gradle.kts`. This means the library doesn't work or just failed to read `application.yaml`. After some investigations, the following issue told me how I could resolve this error:

- https://youtrack.jetbrains.com/issue/KTOR-4757/Yaml-configuration-v2.1.0-does-not-seem-to-work

I think the dependency should be platform-specific. Otherwise it comes to a result of failing to load configuration file.

By the way, I'm a newbie for ktor and Kotlin. Please tell me if I overlooked something.