### PR TITLE
Made $KTOR_ENV environment variable optional

### DIFF
--- a/codeSnippets/snippets/engine-main-custom-environment/src/main/resources/application.yaml
+++ b/codeSnippets/snippets/engine-main-custom-environment/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 ktor:
-    environment: $KTOR_ENV
+    environment: $?KTOR_ENV
     deployment:
         port: 8080
     application:


### PR DESCRIPTION
The environment variable is optional in the .conf file, and the code uses getPropertyOrNull, which implies the property is optional