### PR TITLE
Fix server-routing.md documentation about greedy Regex

### DIFF
--- a/topics/server-routing.md
+++ b/topics/server-routing.md
@@ -97,7 +97,7 @@ Below are several path examples:
 * `/user/{param...}`  
   A path containing a [path parameter with tailcard](#path_parameter_tailcard).
 * `Regex("/.+/hello")`  
-  A path containing a [regular expression](#regular_expression) that matches path segments up to and including the first occurrence of the `/hello`.
+  A path containing a [regular expression](#regular_expression) that matches path segments up to and including the last occurrence of the `/hello`.
 
 
 ### Wildcard {id="wildcard"}


### PR DESCRIPTION
`Regex`es in Kotlin are greedy by default, so it would match the last `hello` in the path. 