### PR TITLE
chore(snippets): update Dockerfile to use new key value format

### DIFF
--- a/codeSnippets/snippets/tutorial-server-docker-compose/Dockerfile
+++ b/codeSnippets/snippets/tutorial-server-docker-compose/Dockerfile
@@ -1,7 +1,7 @@
 # Stage 1: Cache Gradle dependencies
 FROM gradle:latest AS cache
 RUN mkdir -p /home/gradle/cache_home
-ENV GRADLE_USER_HOME /home/gradle/cache_home
+ENV GRADLE_USER_HOME=/home/gradle/cache_home
 COPY build.gradle.* gradle.properties /home/gradle/app/
 COPY gradle /home/gradle/app/gradle
 WORKDIR /home/gradle/app


### PR DESCRIPTION
The correct way to declare environment variables in a Dockerfile is using ENV key=value, with the key and value separated by =.

https://docs.docker.com/reference/build-checks/legacy-key-value-format/