### PR TITLE
docs(server-create-a-new-project.topic): Fix unclosed brackets syntax error in Routing.kt

### DIFF
--- a/topics/server-create-a-new-project.topic
+++ b/topics/server-create-a-new-project.topic
@@ -722,7 +722,8 @@
                         fun Application.configureRouting() {
                             routing {
                                 get("/") {
-                                call.respondText("Hello World!")
+                                    call.respondText("Hello World!")
+                                }
                             }
                         }
                     </code-block>
@@ -735,11 +736,12 @@
                     <code-block lang="kotlin">
                         fun Application.configureRouting() {
                             routing {
-                            // Add the line below
-                            staticResources("/content", "mycontent")
+                                // Add the line below
+                                staticResources("/content", "mycontent")
 
-                            get("/") {
-                                call.respondText("Hello World!")
+                                get("/") {
+                                    call.respondText("Hello World!")
+                                }
                             }
                         }
                     </code-block>


### PR DESCRIPTION
It seems that`Routing.kt` of https://ktor.io/docs/server-create-a-new-project.html#configure-static-content is broken due to lack of `}`. Besides that, I fix the indent as well.