### PR TITLE
docs: KTOR-7626 Adjust topic titles for SEO and add labels

### DIFF
--- a/ktor.tree
+++ b/ktor.tree
@@ -190,6 +190,7 @@
             </toc-element>
 
             <toc-element topic="server-websockets.md"
+                         toc-title="WebSockets"
                          accepts-web-file-names="servers-features-websockets.html,websocket.html">
                 <toc-element topic="server-websocket-serialization.md"
                              accepts-web-file-names="websocket-serialization.html"/>

--- a/ktor.tree
+++ b/ktor.tree
@@ -37,13 +37,16 @@
                 <toc-element topic="server-platforms.md"
                              accepts-web-file-names="supported-platforms.html"/>
                 <toc-element topic="server-dependencies.topic"
+                             toc-title="Adding dependencies"
                              accepts-web-file-names="artifacts.html,maven.html,gradle.html">
                     <toc-element topic="server-native.md"
                                  accepts-web-file-names="native-server.html"/>
                 </toc-element>
                 <toc-element topic="server-create-and-configure.topic"
                              accepts-web-file-names="create-server.html"/>
-                <toc-element topic="server-engines.md" accepts-web-file-names="custom-engines.html,engines.html"/>
+                <toc-element topic="server-engines.md"
+                             toc-title="Engines"
+                             accepts-web-file-names="custom-engines.html,engines.html"/>
                 <toc-element topic="server-configuration-code.topic"
                              accepts-web-file-names="configuration-code.html"/>
                 <toc-element topic="server-configuration-file.topic"
@@ -51,13 +54,16 @@
                 <toc-element topic="server-modules.md"
                              accepts-web-file-names="modules.html"/>
                 <toc-element topic="server-plugins.md"
+                             toc-title="Plugins"
                              accepts-web-file-names="zfeatures.html,features.html,plugins.html"/>
                 <toc-element topic="server-ssl.md"
+                             toc-title="SSL and certificates"
                              accepts-web-file-names="certificates.html,self-signed-certificate.html,ssl.html"/>
                 <toc-element topic="server-http2.md" accepts-web-file-names="advanced-http2.html,http2.html"/>
                 <toc-element topic="server-development-mode.topic"
                              accepts-web-file-names="development-mode.html"/>
                 <toc-element topic="server-logging.md"
+                             toc-title="Logging"
                              accepts-web-file-names="servers-logging.html,logging.html"/>
             </toc-element>
 
@@ -93,6 +99,7 @@
             </toc-element>
 
             <toc-element topic="server-serialization.md"
+                         toc-title="Content negotiation and serialization"
                          accepts-web-file-names="serialization.html"
                          accepts-web-file-names-ref="serialization_server"/>
 
@@ -128,14 +135,19 @@
             <toc-element topic="server-auth.md"
                          accepts-web-file-names="features-authentication.html,authentication.html">
                 <toc-element topic="server-basic-auth.md"
+                             toc-title="Basic authentication"
                              accepts-web-file-names="basic.html"/>
                 <toc-element topic="server-digest-auth.md"
+                             toc-title="Digest authentication"
                              accepts-web-file-names="digest.html"/>
                 <toc-element topic="server-bearer-auth.md"
+                             toc-title="Bearer authentication"
                              accepts-web-file-names="bearer.html"/>
                 <toc-element topic="server-form-based-auth.md"
+                             toc-title="Form-based authentication"
                              accepts-web-file-names="form.html"/>
                 <toc-element topic="server-session-auth.md"
+                             toc-title="Session authentication"
                              accepts-web-file-names="session-auth.html"/>
                 <toc-element topic="server-ldap.md"
                              accepts-web-file-names="ldap.html"/>
@@ -186,7 +198,9 @@
                 <toc-element topic="server-websocket-extensions.md"
                              accepts-web-file-names="websocket-extensions-api.html"/>
             </toc-element>
-            <toc-element topic="server-server-sent-events.topic" accepts-web-file-names="sse-server.html"/>
+            <toc-element topic="server-server-sent-events.topic"
+                         toc-title="Server-Sent Events"
+                         accepts-web-file-names="sse-server.html"/>
 
             <toc-element topic="server-sockets.md"
                          accepts-web-file-names="servers-raw-sockets.html"/>
@@ -195,6 +209,7 @@
                 <toc-element topic="server-call-logging.md"
                              accepts-web-file-names="call-logging.html"/>
                 <toc-element topic="server-call-id.md"
+                             toc-title="Tracing requests"
                              accepts-web-file-names="call-id.html"/>
                 <toc-element topic="server-metrics-micrometer.md"
                              accepts-web-file-names="metrics-micrometer.html,micrometer-metrics.html"/>
@@ -216,6 +231,7 @@
         </toc-element>
 
         <toc-element topic="server-testing.md"
+                     toc-title="Testing"
                      accepts-web-file-names="servers-testing.html,testing.html"/>
 
         <toc-element topic="server-deployment.md"
@@ -247,6 +263,7 @@
 
         <toc-element toc-title="Extending Ktor">
             <toc-element topic="server-custom-plugins.md"
+                         toc-title="Custom plugins"
                          accepts-web-file-names="advanced-index.html,advanced-features.html,creating-custom-features.html,attributes.html,intercepting-routes.html,route.html,custom-plugins.html"/>
             <toc-element topic="server-custom-plugins-base-api.md"
                          accepts-web-file-names="creating-custom-plugins.html,advanced-authentication.html,pipelines.html,pipeline.html,custom-plugins-base-api.html"/>
@@ -270,10 +287,12 @@
                 <toc-element topic="client-create-and-configure.md"
                              accepts-web-file-names="client.html,clients-index.html,quick-start.html,create-client.html"/>
                 <toc-element topic="client-engines.md"
+                             toc-title="Engines"
                              accepts-web-file-names="http-client-multiplatform.html,http-client-engines.html"/>
                 <toc-element topic="client-plugins.md"
+                             toc-title="Plugins"
                              accepts-web-file-names="http-client-features.html,http-client-plugins.html"/>
-                <toc-element topic="client-ssl.md"/>
+                <toc-element topic="client-ssl.md" toc-title="SSL"/>
                 <toc-element topic="client-proxy.md"
                              accepts-web-file-names="proxy.html"/>
             </toc-element>
@@ -300,41 +319,55 @@
                              accepts-web-file-names="http-redirect.html"/>
             </toc-element>
             <toc-element topic="client-serialization.md"
+                         toc-title="Content negotiation and serialization"
                          accepts-web-file-names="json-feature.html,json.html,serialization-client.html"/>
             <toc-element topic="client-auth.md"
+                         toc-title="Authentication and authorization"
                          accepts-web-file-names="features-auth.html,auth.html">
                 <toc-element topic="client-basic-auth.md"
+                             toc-title="Basic authentication"
                              accepts-web-file-names="basic-client.html"/>
                 <toc-element topic="client-digest-auth.md"
+                             toc-title="Digest authentication"
                              accepts-web-file-names="digest-client.html"/>
                 <toc-element topic="client-bearer-auth.md"
+                             toc-title="Bearer authentication"
                              accepts-web-file-names="bearer-client.html"/>
             </toc-element>
             <toc-element topic="client-cookies.md"
                          accepts-web-file-names="http-cookies.html"/>
             <toc-element topic="client-content-encoding.md"
                          accepts-web-file-names="content-encoding.html"/>
-            <toc-element topic="bom-remover.md"/>
+            <toc-element topic="client-bom-remover.md"
+                         accepts-web-file-names="bom-remover.html"/>
             <toc-element topic="client-caching.md"/>
             <toc-element topic="client-text-and-charsets.md"
                          accepts-web-file-names="http-plain-text.html"/>
             <toc-element topic="client-timeout.md"
                          accepts-web-file-names="timeout.html"/>
             <toc-element topic="client-logging.md"
+                         toc-title="Logging"
                          accepts-web-file-names="features-logging.html"/>
             <toc-element topic="client-websockets.topic"
+                         toc-title="WebSockets"
                          accepts-web-file-names="websocket-client.html,http-client-features-websockets.html,clients-websockets.html">
                 <toc-element topic="client-websocket-serialization.md"
+                             toc-title="WebSockets serialization"
                              accepts-web-file-names="websocket-client-serialization.html"/>
             </toc-element>
-            <toc-element topic="client-server-sent-events.topic" accepts-web-file-names="sse-client.html"/>
+            <toc-element topic="client-server-sent-events.topic"
+                         toc-title="Server-Sent Events"
+                         accepts-web-file-names="sse-client.html"/>
             <toc-element toc-title="Monitoring">
-                <toc-element topic="client_call_id.md"/>
+                <toc-element topic="client-call-id.md"
+                             toc-title="Tracing requests"/>
             </toc-element>
-            <toc-element topic="client-custom-plugins.md"/>
+            <toc-element topic="client-custom-plugins.md"
+                         toc-title="Custom plugins"/>
         </toc-element>
 
         <toc-element topic="client-testing.md"
+                     toc-title="Testing"
                      accepts-web-file-names="http-client-testing.html"/>
     </toc-element>
 

--- a/labels.list
+++ b/labels.list
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE labels SYSTEM "https://resources.jetbrains.com/writerside/1.0/labels-list.dtd">
+<labels xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/labels.xsd">
+    <primary-label id="client-plugin" short-name="C" name="Client Plugin" color="strawberry">
+        Client Plugin
+    </primary-label>
+
+    <primary-label id="server-plugin" short-name="S" name="Server Plugin" color="purple">
+        Server Plugin
+    </primary-label>
+
+    <secondary-label id="wip" name="WIP" color="purple">Work in progress</secondary-label>
+    <secondary-label id="beta" name="β" color="tangerine">Beta</secondary-label>
+
+    <secondary-label id="experimental" name="Experimental" color="purple">This is an experimental feature</secondary-label>
+    <secondary-label id="2023.3" name="2023.3" color="blue">New in version 2023.3</secondary-label>
+</labels>

--- a/project.ihp
+++ b/project.ihp
@@ -3,7 +3,7 @@
         SYSTEM "https://resources.jetbrains.com/writerside/1.0/ihp.dtd">
 <ihp version="2.0">
     <settings>
-        <wrs-supernova use-version="2.1.1738-p5259"/>
+        <wrs-supernova use-version="243.22562"/>
     </settings>
 
     <module name="ktor"/>

--- a/topics/client-auth.md
+++ b/topics/client-auth.md
@@ -1,6 +1,7 @@
-[//]: # (title: Authentication and authorization)
+[//]: # (title: Authentication and authorization in Ktor Client)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="client-plugin"/>
 
 <tldr>
 <p>
@@ -16,6 +17,9 @@ Ktor provides
 the [Auth](https://api.ktor.io/ktor-client/ktor-client-plugins/ktor-client-auth/io.ktor.client.plugins.auth/-auth)
 plugin to handle authentication and authorization in your client application.
 Typical usage scenarios include logging in users and gaining access to specific resources.
+
+> On the server, Ktor provides the [Authentication](server-auth.md) plugin for handling authentication and
+> authorization.
 
 ## Supported authentication types {id="supported"}
 

--- a/topics/client-basic-auth.md
+++ b/topics/client-basic-auth.md
@@ -1,4 +1,4 @@
-[//]: # (title: Basic authentication)
+[//]: # (title: Basic authentication in Ktor Client)
 
 <tldr>
 <var name="example_name" value="client-auth-basic"/>

--- a/topics/client-bearer-auth.md
+++ b/topics/client-bearer-auth.md
@@ -1,4 +1,4 @@
-[//]: # (title: Bearer authentication)
+[//]: # (title: Bearer authentication in Ktor Client)
 
 <show-structure for="chapter" depth="2"/>
 

--- a/topics/client-bom-remover.md
+++ b/topics/client-bom-remover.md
@@ -1,6 +1,7 @@
 [//]: # (title: BOM remover)
 
 <var name="artifact_name" value="ktor-client-bom-remover"/>
+<primary-label ref="client-plugin"/>
 
 <tldr>
 <p>

--- a/topics/client-caching.md
+++ b/topics/client-caching.md
@@ -1,5 +1,7 @@
 [//]: # (title: Caching)
 
+<primary-label ref="client-plugin"/>
+
 <tldr>
 <var name="example_name" value="client-caching"/>
 <include from="lib.topic" element-id="download_example"/>

--- a/topics/client-call-id.md
+++ b/topics/client-call-id.md
@@ -1,6 +1,7 @@
-[//]: # (title: CallId)
+[//]: # (title: Tracing requests in Ktor Client)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="client-plugin"/>
 
 <var name="artifact_name" value="ktor-client-call-id"/>
 <var name="package_name" value="io.ktor.client.plugins.callid"/>
@@ -38,7 +39,9 @@ call ID.
 
 ## Configure %plugin_name% {id="configure"}
 
-The %plugin_name% plugin configuration, provided by the [CallIdConfig]() class, allows you to generate a call ID and add
+The %plugin_name% plugin configuration, provided by
+the [CallIdConfig](https://api.ktor.io/ktor-client/ktor-client-plugins/ktor-client-call-id/io.ktor.client.plugins.callid/-call-id-config/index.html)
+class, allows you to generate a call ID and add
 it to the call context.
 
 ### Generate a call ID
@@ -69,7 +72,7 @@ You can use multiple methods to generate a call ID. In this way, the first non-n
 
 After you retrieve a call ID, you have the following options available to add it to the request:
 
-* The `intercept()` function allows you to add a call ID to the request by using the [CallIdInterceptor]().
+* The `intercept()` function allows you to add a call ID to the request by using the `CallIdInterceptor`.
 
  ```kotlin
  ```

--- a/topics/client-content-encoding.md
+++ b/topics/client-content-encoding.md
@@ -1,5 +1,7 @@
 [//]: # (title: Content encoding)
 
+<primary-label ref="client-plugin"/>
+
 <var name="artifact_name" value="ktor-client-encoding"/>
 
 <tldr>

--- a/topics/client-cookies.md
+++ b/topics/client-cookies.md
@@ -1,5 +1,7 @@
 [//]: # (title: Cookies)
 
+<primary-label ref="client-plugin"/>
+
 <tldr>
 <var name="example_name" value="client-cookies"/>
 <include from="lib.topic" element-id="download_example"/>

--- a/topics/client-custom-plugins.md
+++ b/topics/client-custom-plugins.md
@@ -1,4 +1,4 @@
-[//]: # (title: Custom plugins)
+[//]: # (title: Custom client plugins)
 
 <show-structure for="chapter" depth="2"/>
 

--- a/topics/client-default-request.md
+++ b/topics/client-default-request.md
@@ -1,6 +1,7 @@
 [//]: # (title: Default request)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="client-plugin"/>
 
 <tldr>
 <var name="example_name" value="client-default-request"/>

--- a/topics/client-digest-auth.md
+++ b/topics/client-digest-auth.md
@@ -1,4 +1,4 @@
-[//]: # (title: Digest authentication)
+[//]: # (title: Digest authentication in Ktor Client)
 
 <tldr>
 <var name="example_name" value="client-auth-digest"/>

--- a/topics/client-engines.md
+++ b/topics/client-engines.md
@@ -1,4 +1,4 @@
-[//]: # (title: Engines)
+[//]: # (title: Client engines)
 
 <show-structure for="chapter" depth="2"/>
 

--- a/topics/client-http-send.md
+++ b/topics/client-http-send.md
@@ -1,5 +1,7 @@
 [//]: # (title: Intercepting requests using HttpSend)
 
+<primary-label ref="client-plugin"/>
+
 <tldr>
 <var name="example_name" value="client-http-send"/>
 <include from="lib.topic" element-id="download_example"/>

--- a/topics/client-logging.md
+++ b/topics/client-logging.md
@@ -1,6 +1,7 @@
-[//]: # (title: Logging)
+[//]: # (title: Logging in Ktor Client)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="client-plugin"/>
 
 <tldr>
 <p>
@@ -17,6 +18,9 @@ Ktor provides the capability to log HTTP calls using
 the [Logging](https://api.ktor.io/ktor-client/ktor-client-plugins/ktor-client-logging/io.ktor.client.plugins.logging/-logging)
 plugin.
 This plugin provides different logger types for different platforms.
+
+> On the server, Ktor provides the [Logging](server-logging.md) plugin for application logging and
+> the [CallLogging](server-call-logging.md) plugin for logging client requests.
 
 ## JVM
 

--- a/topics/client-plugins.md
+++ b/topics/client-plugins.md
@@ -1,4 +1,4 @@
-[//]: # (title: Plugins)
+[//]: # (title: Client plugins)
 
 <link-summary>
 Get acquainted with plugins that provide common functionality, for example, logging, serialization, authorization, etc.

--- a/topics/client-request-retry.md
+++ b/topics/client-request-retry.md
@@ -1,6 +1,7 @@
 [//]: # (title: Retrying failed requests)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="client-plugin"/>
 
 <tldr>
 <var name="example_name" value="client-retry"/>

--- a/topics/client-resources.md
+++ b/topics/client-resources.md
@@ -1,6 +1,7 @@
 [//]: # (title: Type-safe requests)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="client-plugin"/>
 
 <var name="plugin_name" value="Resources"/>
 <var name="artifact_name" value="ktor-client-resources"/>

--- a/topics/client-serialization.md
+++ b/topics/client-serialization.md
@@ -1,6 +1,7 @@
-[//]: # (title: Content negotiation and serialization)
+[//]: # (title: Content negotiation and serialization in Ktor Client)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="client-plugin"/>
 
 <var name="plugin_name" value="ContentNegotiation"/>
 <var name="artifact_name" value="ktor-client-content-negotiation"/>

--- a/topics/client-server-sent-events.topic
+++ b/topics/client-server-sent-events.topic
@@ -2,9 +2,10 @@
 <!DOCTYPE topic SYSTEM "https://resources.jetbrains.com/writerside/1.0/xhtml-entities.dtd">
 <topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
-       id="client-server-sent-events" title="Server-Sent Events" help-id="sse_client">
+       id="client-server-sent-events" title="Server-Sent Events in Ktor Client" help-id="sse_client">
 
     <show-structure for="chapter" depth="2"/>
+    <primary-label ref="client-plugin"/>
     <tldr>
         <var name="example_name" value="client-sse"/>
         <include from="lib.topic" element-id="download_example"/>

--- a/topics/client-ssl.md
+++ b/topics/client-ssl.md
@@ -1,6 +1,7 @@
-[//]: # (title: SSL)
+[//]: # (title: SSL in Ktor Client)
 
 <show-structure for="chapter" depth="3"/>
+<primary-label ref="client-plugin"/>
 
 <tldr>
 <var name="example_name" value="client-ssl-config"/>

--- a/topics/client-testing.md
+++ b/topics/client-testing.md
@@ -1,4 +1,4 @@
-[//]: # (title: Testing)
+[//]: # (title: Testing in Ktor Client)
 
 <show-structure for="chapter" depth="2"/>
 

--- a/topics/client-text-and-charsets.md
+++ b/topics/client-text-and-charsets.md
@@ -1,6 +1,7 @@
 [//]: # (title: Text and charsets)
 
 <include from="lib.topic" element-id="outdated_warning"/>
+<primary-label ref="client-plugin"/>
 
 This plugin allows you to process the plain text content in request and response: fills the `Accept` header with registered charsets, encode request body and decode response body according to `ContentType` charset.
 

--- a/topics/client-timeout.md
+++ b/topics/client-timeout.md
@@ -1,5 +1,7 @@
 [//]: # (title: Timeout)
 
+<primary-label ref="client-plugin"/>
+
 <tldr>
 <var name="example_name" value="client-timeout"/>
 <include from="lib.topic" element-id="download_example"/>

--- a/topics/client-user-agent.md
+++ b/topics/client-user-agent.md
@@ -1,5 +1,7 @@
 [//]: # (title: User agent)
 
+<primary-label ref="client-plugin"/>
+
 The [UserAgent](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.plugins/-user-agent) plugin adds a `User-Agent` header to all [requests](client-requests.md).
 
 ## Add dependencies {id="add_dependencies"}

--- a/topics/client-websocket-serialization.md
+++ b/topics/client-websocket-serialization.md
@@ -1,4 +1,4 @@
-[//]: # (title: WebSockets serialization)
+[//]: # (title: WebSockets serialization in Ktor Client)
 
 <show-structure for="chapter" depth="2"/>
 

--- a/topics/client-websockets.topic
+++ b/topics/client-websockets.topic
@@ -2,9 +2,10 @@
 <!DOCTYPE topic SYSTEM "https://resources.jetbrains.com/writerside/1.0/xhtml-entities.dtd">
 <topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
-       id="client-websockets" title="WebSockets">
+       id="client-websockets" title="WebSockets in Ktor Client">
 
     <show-structure for="chapter" depth="3"/>
+    <primary-label ref="client-plugin"/>
     <var name="example_name" value="client-websockets"/>
     <var name="artifact_name" value="ktor-client-websockets"/>
     <tldr>

--- a/topics/server-auth.md
+++ b/topics/server-auth.md
@@ -1,6 +1,7 @@
-[//]: # (title: Authentication and authorization)
+[//]: # (title: Authentication and authorization in Ktor Server)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <var name="plugin_name" value="Authentication"/>
 <var name="package_name" value="io.ktor.server.auth"/>
@@ -16,7 +17,14 @@
 The Authentication plugin handles authentication and authorization in Ktor.
 </link-summary>
 
-Ktor provides the [Authentication](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-authentication/index.html) plugin to handle authentication and authorization. Typical usage scenarios include logging in users, granting access to specific resources, and securely transmitting information between parties. You can also use `Authentication` with [Sessions](server-sessions.md) to keep a user's information between requests.
+Ktor provides
+the [Authentication](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-authentication/index.html)
+plugin to handle authentication and authorization. Typical usage scenarios include logging in users, granting access to
+specific resources, and securely transmitting information between parties. You can also use `Authentication`
+with [Sessions](server-sessions.md) to keep a user's information between requests.
+
+> On the client, Ktor provides the [Authentication](client-auth.md) plugin for handling authentication and
+> authorization.
 
 ## Supported authentication types {id="supported"}
 Ktor supports the following authentication and authorization schemes:

--- a/topics/server-autoheadresponse.md
+++ b/topics/server-autoheadresponse.md
@@ -2,6 +2,7 @@
 
 <var name="plugin_name" value="AutoHeadResponse"/>
 <var name="artifact_name" value="ktor-server-auto-head-response"/>
+<primary-label ref="server-plugin"/>
 
 <tldr>
 <p>

--- a/topics/server-basic-auth.md
+++ b/topics/server-basic-auth.md
@@ -1,4 +1,4 @@
-[//]: # (title: Basic authentication)
+[//]: # (title: Basic authentication in Ktor Server)
 
 <show-structure for="chapter" depth="2"/>
 

--- a/topics/server-bearer-auth.md
+++ b/topics/server-bearer-auth.md
@@ -1,4 +1,4 @@
-[//]: # (title: Bearer authentication)
+[//]: # (title: Bearer authentication in Ktor Server)
 
 <show-structure for="chapter" depth="2"/>
 

--- a/topics/server-caching-headers.md
+++ b/topics/server-caching-headers.md
@@ -1,6 +1,7 @@
 [//]: # (title: Caching headers)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <var name="plugin_name" value="CachingHeaders"/>
 <var name="package_name" value="io.ktor.server.plugins.cachingheaders"/>

--- a/topics/server-call-id.md
+++ b/topics/server-call-id.md
@@ -1,6 +1,7 @@
-[//]: # (title: CallId)
+[//]: # (title: Tracing requests in Ktor Server)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <var name="artifact_name" value="ktor-server-call-id"/>
 <var name="package_name" value="io.ktor.server.plugins.callid"/>

--- a/topics/server-call-logging.md
+++ b/topics/server-call-logging.md
@@ -1,6 +1,7 @@
 [//]: # (title: Call logging)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <var name="plugin_name" value="CallLogging"/>
 <var name="package_name" value="io.ktor.server.plugins.calllogging"/>

--- a/topics/server-compression.md
+++ b/topics/server-compression.md
@@ -1,6 +1,7 @@
 [//]: # (title: Compression)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <var name="artifact_name" value="ktor-server-compression"/>
 <var name="package_name" value="io.ktor.server.plugins.compression"/>

--- a/topics/server-conditional-headers.md
+++ b/topics/server-conditional-headers.md
@@ -1,5 +1,7 @@
 [//]: # (title: Conditional headers)
 
+<primary-label ref="server-plugin"/>
+
 <var name="artifact_name" value="ktor-server-conditional-headers"/>
 <var name="package_name" value="io.ktor.server.plugins.conditionalheaders"/>
 <var name="plugin_name" value="ConditionalHeaders"/>

--- a/topics/server-cors.md
+++ b/topics/server-cors.md
@@ -1,6 +1,7 @@
 [//]: # (title: CORS)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <var name="artifact_name" value="ktor-server-cors"/>
 <var name="package_name" value="io.ktor.server.plugins.cors"/>

--- a/topics/server-custom-plugins.md
+++ b/topics/server-custom-plugins.md
@@ -1,4 +1,4 @@
-[//]: # (title: Custom plugins)
+[//]: # (title: Custom server plugins)
 
 <show-structure for="chapter" depth="2"/>
 

--- a/topics/server-data-conversion.md
+++ b/topics/server-data-conversion.md
@@ -1,5 +1,7 @@
 [//]: # (title: Data conversion)
 
+<primary-label ref="server-plugin"/>
+
 <var name="artifact_name" value="ktor-server-data-conversion"/>
 <var name="package_name" value="io.ktor.server.plugins.dataconversion"/>
 <var name="plugin_name" value="DataConversion"/>

--- a/topics/server-default-headers.md
+++ b/topics/server-default-headers.md
@@ -1,6 +1,7 @@
 [//]: # (title: Default headers)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <var name="artifact_name" value="ktor-server-default-headers"/>
 <var name="package_name" value="io.ktor.server.plugins.defaultheaders"/>

--- a/topics/server-dependencies.topic
+++ b/topics/server-dependencies.topic
@@ -3,15 +3,16 @@
 
 <topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       title="Adding Ktor dependencies"
+       title="Adding server dependencies"
        id="server-dependencies" help-id="Gradle">
 
     <show-structure for="chapter" depth="2"/>
 
-    <link-summary>Learn how to add Ktor dependencies to an existing Gradle/Maven project.</link-summary>
+    <link-summary>Learn how to add Ktor Server dependencies to an existing Gradle/Maven project.</link-summary>
 
     <p>
-        In this topic, we'll show you how to add dependencies required for Ktor to the existing Gradle/Maven project.
+        In this topic, we'll show you how to add dependencies required for Ktor Server to an existing
+        Gradle/Maven project.
     </p>
 
     <chapter title="Configure the repositories" id="repositories">
@@ -131,8 +132,7 @@
     </chapter>
 
 
-
-    <chapter title="Add Ktor dependencies" id="add-ktor-dependencies">
+    <chapter title="Add dependencies" id="add-ktor-dependencies">
         <chapter title="Core dependencies" id="core-dependencies">
             <p>
                 Every Ktor application requires at least the following dependencies:

--- a/topics/server-digest-auth.md
+++ b/topics/server-digest-auth.md
@@ -1,4 +1,4 @@
-[//]: # (title: Digest authentication)
+[//]: # (title: Digest authentication in Ktor Server)
 
 <show-structure for="chapter" depth="2"/>
 

--- a/topics/server-double-receive.md
+++ b/topics/server-double-receive.md
@@ -1,5 +1,7 @@
 [//]: # (title: DoubleReceive)
 
+<primary-label ref="server-plugin"/>
+
 <var name="plugin_name" value="DoubleReceive"/>
 <var name="package_name" value="io.ktor.server.plugins.doublereceive"/>
 <var name="artifact_name" value="ktor-server-double-receive"/>

--- a/topics/server-engines.md
+++ b/topics/server-engines.md
@@ -1,4 +1,4 @@
-[//]: # (title: Choosing an engine)
+[//]: # (title: Server engines)
 
 <show-structure for="chapter" depth="3"/>
 

--- a/topics/server-form-based-auth.md
+++ b/topics/server-form-based-auth.md
@@ -1,4 +1,4 @@
-[//]: # (title: Form-based authentication)
+[//]: # (title: Form-based authentication in Ktor Server)
 
 <show-structure for="chapter" depth="2"/>
 

--- a/topics/server-forward-headers.md
+++ b/topics/server-forward-headers.md
@@ -1,6 +1,7 @@
 [//]: # (title: Forwarded headers)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <var name="artifact_name" value="ktor-server-forwarded-header"/>
 <var name="package_name" value="io.ktor.server.plugins.forwardedheaders"/>

--- a/topics/server-freemarker.md
+++ b/topics/server-freemarker.md
@@ -1,6 +1,7 @@
 [//]: # (title: FreeMarker)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 [freemarker_template_loading]: https://freemarker.apache.org/docs/pgui_config_templateloading.html
 

--- a/topics/server-hsts.md
+++ b/topics/server-hsts.md
@@ -1,5 +1,7 @@
 [//]: # (title: HSTS)
 
+<primary-label ref="server-plugin"/>
+
 <var name="plugin_name" value="HSTS"/>
 <var name="package_name" value="io.ktor.server.plugins.hsts"/>
 <var name="artifact_name" value="ktor-server-hsts"/>

--- a/topics/server-https-redirect.md
+++ b/topics/server-https-redirect.md
@@ -1,5 +1,7 @@
 [//]: # (title: HttpsRedirect)
 
+<primary-label ref="server-plugin"/>
+
 <var name="plugin_name" value="HttpsRedirect"/>
 <var name="package_name" value="io.ktor.server.plugins.httpsredirect"/>
 <var name="artifact_name" value="ktor-server-http-redirect"/>

--- a/topics/server-jte.md
+++ b/topics/server-jte.md
@@ -1,6 +1,7 @@
 [//]: # (title: JTE)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <var name="plugin_name" value="Jte"/>
 <var name="package_name" value="io.ktor.server.jte"/>

--- a/topics/server-jwt.md
+++ b/topics/server-jwt.md
@@ -1,6 +1,7 @@
 [//]: # (title: JSON Web Tokens)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <var name="plugin_name" value="Authentication JWT"/>
 

--- a/topics/server-logging.md
+++ b/topics/server-logging.md
@@ -1,4 +1,4 @@
-[//]: # (title: Logging)
+[//]: # (title: Logging in Ktor Server)
 
 
 <show-structure for="chapter" depth="2"/>

--- a/topics/server-method-override.md
+++ b/topics/server-method-override.md
@@ -1,5 +1,7 @@
 [//]: # (title: XHttpMethodOverride)
 
+<primary-label ref="server-plugin"/>
+
 <var name="plugin_name" value="XHttpMethodOverride"/>
 <var name="package_name" value="io.ktor.server.plugins.methodoverride"/>
 <var name="artifact_name" value="ktor-server-method-override"/>

--- a/topics/server-metrics-dropwizard.md
+++ b/topics/server-metrics-dropwizard.md
@@ -1,6 +1,7 @@
 [//]: # (title: Dropwizard metrics)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <var name="plugin_name" value="DropwizardMetrics"/>
 <var name="package_name" value="io.ktor.server.metrics.dropwizard"/>

--- a/topics/server-metrics-micrometer.md
+++ b/topics/server-metrics-micrometer.md
@@ -1,6 +1,7 @@
 [//]: # (title: Micrometer metrics)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 [micrometer_jvm_metrics]: https://micrometer.io/docs/ref/jvm
 

--- a/topics/server-mustache.md
+++ b/topics/server-mustache.md
@@ -1,6 +1,7 @@
 [//]: # (title: Mustache)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 [mustache_factory]: http://spullara.github.io/mustache/apidocs/com/github/mustachejava/MustacheFactory.html
 

--- a/topics/server-oauth.md
+++ b/topics/server-oauth.md
@@ -1,6 +1,7 @@
 [//]: # (title: OAuth)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <var name="plugin_name" value="OAuth"/>
 <var name="artifact_name" value="ktor-server-auth"/>

--- a/topics/server-openapi.md
+++ b/topics/server-openapi.md
@@ -1,5 +1,7 @@
 [//]: # (title: OpenAPI)
 
+<primary-label ref="server-plugin"/>
+
 <var name="artifact_name" value="ktor-server-openapi"/>
 <var name="package_name" value="io.ktor.server.plugins.openapi"/>
 <var name="plugin_api_link" value="https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-openapi/io.ktor.server.plugins.openapi/open-a-p-i.html"/>

--- a/topics/server-partial-content.md
+++ b/topics/server-partial-content.md
@@ -1,5 +1,7 @@
 [//]: # (title: Partial content)
 
+<primary-label ref="server-plugin"/>
+
 <var name="artifact_name" value="ktor-server-partial-content"/>
 <var name="package_name" value="io.ktor.server.plugins.partialcontent"/>
 <var name="plugin_name" value="PartialContent"/>

--- a/topics/server-pebble.md
+++ b/topics/server-pebble.md
@@ -1,6 +1,7 @@
 [//]: # (title: Pebble)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 [pebble_engine_builder]: https://pebbletemplates.io/com/mitchellbosecke/pebble/PebbleEngine/Builder/
 

--- a/topics/server-plugins.md
+++ b/topics/server-plugins.md
@@ -1,4 +1,4 @@
-[//]: # (title: Plugins)
+[//]: # (title: Server plugins)
 
 <show-structure for="chapter" depth="2"/>
 

--- a/topics/server-rate-limit.md
+++ b/topics/server-rate-limit.md
@@ -1,6 +1,7 @@
 [//]: # (title: Rate limiting)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <var name="plugin_name" value="RateLimit"/>
 <var name="package_name" value="io.ktor.server.plugins.ratelimit"/>

--- a/topics/server-request-validation.md
+++ b/topics/server-request-validation.md
@@ -1,6 +1,7 @@
 [//]: # (title: Request validation)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <var name="plugin_name" value="RequestValidation"/>
 <var name="package_name" value="io.ktor.server.plugins.requestvalidation"/>

--- a/topics/server-resources.md
+++ b/topics/server-resources.md
@@ -1,6 +1,7 @@
 [//]: # (title: Type-safe routing)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <var name="plugin_name" value="Resources"/>
 <var name="package_name" value="io.ktor.server.resources"/>

--- a/topics/server-routing.md
+++ b/topics/server-routing.md
@@ -1,6 +1,7 @@
 [//]: # (title: Routing)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <link-summary>
 Routing is a core plugin for handling incoming requests in a server application.

--- a/topics/server-serialization.md
+++ b/topics/server-serialization.md
@@ -1,6 +1,7 @@
-[//]: # (title: Content negotiation and serialization)
+[//]: # (title: Content negotiation and serialization in Ktor Server)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <var name="plugin_name" value="ContentNegotiation"/>
 <var name="package_name" value="io.ktor.server.plugins.contentnegotiation"/>
@@ -24,6 +25,8 @@ The [ContentNegotiation](https://api.ktor.io/ktor-server/ktor-server-plugins/kto
 * Negotiating media types between the client and server. For this, it uses the `Accept` and `Content-Type` headers.
 * Serializing/deserializing the content in a specific format. Ktor supports the following formats out-of-the-box: JSON, XML, CBOR, and ProtoBuf.
 
+> On the client, Ktor provides the [ContentNegotiation](client-serialization.md) plugin for serializing/deserializing
+content.
 
 ## Add dependencies {id="add_dependencies"}
 

--- a/topics/server-server-sent-events.topic
+++ b/topics/server-server-sent-events.topic
@@ -2,9 +2,11 @@
 <!DOCTYPE topic SYSTEM "https://resources.jetbrains.com/writerside/1.0/xhtml-entities.dtd">
 <topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
-       id="server-server-sent-events" title="Server-Sent Events" help-id="sse_server">
+       id="server-server-sent-events" title="Server-Sent Events in Ktor Server" help-id="sse_server">
 
     <show-structure for="chapter" depth="2"/>
+    <primary-label ref="server-plugin"/>
+
     <var name="plugin_name" value="SSE"/>
     <var name="example_name" value="server-sse"/>
     <var name="package_name" value="io.ktor.server.sse"/>

--- a/topics/server-session-auth.md
+++ b/topics/server-session-auth.md
@@ -1,4 +1,4 @@
-[//]: # (title: Session authentication)
+[//]: # (title: Session authentication in Ktor Server)
 
 <show-structure for="chapter" depth="2"/>
 

--- a/topics/server-sessions.md
+++ b/topics/server-sessions.md
@@ -1,6 +1,7 @@
 [//]: # (title: Sessions)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <var name="plugin_name" value="Sessions"/>
 <var name="package_name" value="io.ktor.server.sessions"/>

--- a/topics/server-shutdown-url.md
+++ b/topics/server-shutdown-url.md
@@ -1,5 +1,7 @@
 [//]: # (title: Shutdown URL)
 
+<primary-label ref="server-plugin"/>
+
 <tldr>
 <var name="example_name" value="shutdown-url"/>
 <include from="lib.topic" element-id="download_example"/>

--- a/topics/server-sockets.md
+++ b/topics/server-sockets.md
@@ -1,6 +1,7 @@
 [//]: # (title: Sockets)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <var name="plugin_name" value="Sockets"/>
 

--- a/topics/server-ssl.md
+++ b/topics/server-ssl.md
@@ -1,6 +1,7 @@
-[//]: # (title: SSL and certificates)
+[//]: # (title: SSL and certificates in Ktor Server)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <tldr>
 <p>

--- a/topics/server-status-pages.md
+++ b/topics/server-status-pages.md
@@ -1,6 +1,7 @@
 [//]: # (title: Status pages)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <var name="plugin_name" value="StatusPages"/>
 <var name="package_name" value="io.ktor.server.plugins.statuspages"/>

--- a/topics/server-swagger-ui.md
+++ b/topics/server-swagger-ui.md
@@ -1,5 +1,7 @@
 [//]: # (title: Swagger UI)
 
+<primary-label ref="server-plugin"/>
+
 <var name="artifact_name" value="ktor-server-swagger"/>
 <var name="package_name" value="io.ktor.server.plugins.swagger"/>
 <var name="plugin_api_link" value="https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-swagger/io.ktor.server.plugins.swagger/swagger-u-i.html"/>

--- a/topics/server-testing.md
+++ b/topics/server-testing.md
@@ -1,4 +1,4 @@
-[//]: # (title: Testing)
+[//]: # (title: Testing in Ktor Server)
 
 <show-structure for="chapter" depth="3"/>
 

--- a/topics/server-thymeleaf.md
+++ b/topics/server-thymeleaf.md
@@ -1,6 +1,7 @@
 [//]: # (title: Thymeleaf)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <var name="plugin_name" value="Thymeleaf"/>
 <var name="package_name" value="io.ktor.server.thymeleaf"/>

--- a/topics/server-velocity.md
+++ b/topics/server-velocity.md
@@ -1,6 +1,7 @@
 [//]: # (title: Velocity)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 [velocity_engine]: https://velocity.apache.org/engine/devel/apidocs/org/apache/velocity/app/VelocityEngine.html
 

--- a/topics/server-webjars.md
+++ b/topics/server-webjars.md
@@ -1,5 +1,7 @@
 [//]: # (title: Webjars)
 
+<primary-label ref="server-plugin"/>
+
 <var name="plugin_name" value="Webjars"/>
 <var name="package_name" value="io.ktor.server.webjars"/>
 <var name="artifact_name" value="ktor-server-webjars"/>

--- a/topics/server-websocket-serialization.md
+++ b/topics/server-websocket-serialization.md
@@ -1,4 +1,4 @@
-[//]: # (title: WebSockets serialization)
+[//]: # (title: WebSockets serialization in Ktor Server)
 
 <show-structure for="chapter" depth="2"/>
 

--- a/topics/server-websockets.md
+++ b/topics/server-websockets.md
@@ -1,4 +1,4 @@
-[//]: # (title: WebSockets)
+[//]: # (title: WebSockets in Ktor Server)
 
 <show-structure for="chapter" depth="2"/>
 <primary-label ref="server-plugin"/>

--- a/topics/server-websockets.md
+++ b/topics/server-websockets.md
@@ -1,6 +1,7 @@
 [//]: # (title: WebSockets)
 
 <show-structure for="chapter" depth="2"/>
+<primary-label ref="server-plugin"/>
 
 <var name="plugin_name" value="WebSockets"/>
 <var name="package_name" value="io.ktor.server.websocket"/>

--- a/topics/welcome.topic
+++ b/topics/welcome.topic
@@ -119,7 +119,7 @@
                     <a href="client-auth.md"/>
                     <a href="client-cookies.md"/>
                     <a href="client-content-encoding.md"/>
-                    <a href="bom-remover.md"/>
+                    <a href="client-bom-remover.md"/>
                     <a href="client-caching.md"/>
                     <a href="client-websockets.topic"/>
                     <a href="client-server-sent-events.topic"/>


### PR DESCRIPTION
## Details

1.  Include the "in Ktor Client" or "in Ktor Server" title suffix to topics for plugins that exist with the same name on the Ktor Client and Ktor Server. Also, include a note after the intro of each topic with a reference to "the other version".
- Logging -> Logging in Ktor Client
- Content negotiation and serialization -> Content negotiation and serialization inn Ktor Client
2. Add primary labels ("Client plugin" and "Server plugin") to all plugin-related topics.
3. Modify other topics with duplicate titles to include client/server, such as:
- Adding dependencies -> Adding server dependencies
- Engines -> Server engines
- Testing -> Testing in Ktor Server
4. Additionally renamed the "CallId" topics to "Tracing requests" to match the way other plugin topics are named.

## Related issue

[KTOR-7626](https://youtrack.jetbrains.com/issue/KTOR-7626) SEO issue: Can't differentiate between client and server related results for Ktor docs