### PR TITLE
Correct the object from Routing to RoutingRoot

### DIFF
--- a/topics/server-routing.md
+++ b/topics/server-routing.md
@@ -15,12 +15,12 @@ The Routing plugin can be installed in the following way:
 ```Kotlin
 import io.ktor.server.routing.*
 
-install(Routing) {
+install(RoutingRoot) {
     // ...
 }
 ```
 
-Given the `Routing` plugin is so common in any application, there is a convenient `routing` function that makes it simpler to install routing. In the code snippet below, `install(Routing)` is replaced with the `routing` function:
+Given the Routing plugin is so common in any application, there is a convenient `routing` function that makes it simpler to install routing. In the code snippet below, `install(RoutingRoot)` is replaced with the `routing` function:
 
 ```kotlin
 import io.ktor.server.routing.*


### PR DESCRIPTION
The name of the routing tree builder has undergone multiple changes. As a result, the plugin object was renamed to `RoutingRoot` in [KTOR-7101](https://youtrack.jetbrains.com/issue/KTOR-7101).

- Updated the code snippet to ensure compatibility with this change.
- Removed the code block for Routing, as it is a commonly used name for a plugin.

This is my first contribution to the Ktor documentation, and you are welcome to edit it at any time.