### PR TITLE
KTOR-7601: Fix dependencies for Maven build system tutorial

### DIFF
--- a/codeSnippets/snippets/tutorial-server-get-started-maven/pom.xml
+++ b/codeSnippets/snippets/tutorial-server-get-started-maven/pom.xml
@@ -8,9 +8,9 @@
     <name>tutorial-server-get-started-maven</name>
     <description>tutorial-server-get-started-maven</description>
     <properties>
-        <ktor_version>3.0.0-beta-1</ktor_version>
+        <ktor_version>3.0.3</ktor_version>
         <kotlin.code.style>official</kotlin.code.style>
-        <kotlin_version>1.9.22</kotlin_version>
+        <kotlin_version>2.0.20</kotlin_version>
         <logback_version>1.5.6</logback_version>
         <slf4j_version>2.0.12</slf4j_version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/codeSnippets/snippets/tutorial-server-get-started-maven/pom.xml
+++ b/codeSnippets/snippets/tutorial-server-get-started-maven/pom.xml
@@ -27,7 +27,7 @@
         </dependency>
         <dependency>
             <groupId>io.ktor</groupId>
-            <artifactId>ktor-server-netty</artifactId>
+            <artifactId>ktor-server-netty-jvm</artifactId>
             <version>${ktor_version}</version>
         </dependency>
         <dependency>
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>io.ktor</groupId>
-            <artifactId>ktor-server-tests-jvm</artifactId>
+            <artifactId>ktor-server-test-host-jvm</artifactId>
             <version>${ktor_version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
This PR fix [KTOR-7601](https://youtrack.jetbrains.com/issue/KTOR-7601/Update-dependency-and-Ktor-version-in-tutorial-server-get-started-maven)

* Following [Adding Ktor dependencies](https://ktor.io/docs/server-dependencies.html#add-ktor-dependencies), use platform-specific artifacts (i.e. `ktor-server-netty-jvm` and `ktor-server-test-host-jvm`) e81e3125594dc12857072dbc637c6013bda82bd2
  * This is the same as the dependencies which I choose 'Build System' as 'Maven' in Ktor project create page https://start.ktor.io/settings
* ktor and kotlin versions are same as [gradle.properties](https://github.com/ktorio/ktor-documentation/blob/main/codeSnippets/gradle.properties) respectively cd4a883057f816ac0326c7bdbb8df2effb29aa96

After this change, successfully I could build and run the application following README.md instructions.

(This is my first time to tackle with YouTrack issue, so please tell me if I missed any procedure. For example, should I assign the issue to me in advance?)
