### PR TITLE
docs: Fix org.jetbrains.compose resource api in kmp tutorial

### DIFF
--- a/topics/full-stack-development-with-kotlin-multiplatform.topic
+++ b/topics/full-stack-development-with-kotlin-multiplatform.topic
@@ -334,7 +334,6 @@
             :
         </p>
         <code-block lang="kotlin"><![CDATA[
-            @OptIn(ExperimentalResourceApi::class)
             @Composable
             fun App() {
                 MaterialTheme {
@@ -352,7 +351,7 @@
                         }
                         AnimatedVisibility(showImage) {
                             Image(
-                                painterResource("compose-multiplatform.xml"),
+                                painterResource(Res.drawable.compose_multiplatform),
                                 null
                             )
                         }


### PR DESCRIPTION
It seems the provided code here is outdated and no longer compilable from Compose Multiplatform 1.6.

* `@OptIn(ExperimentalResourceApi::class)` is no longer needed since it is stable in Compose Multiplatform 1.6.10
  * https://www.jetbrains.com/help/kotlin-multiplatform-dev/whats-new-compose-1610.html#stable-resource-library
* resource access using  `painterResource` API changed
  * https://www.jetbrains.com/help/kotlin-multiplatform-dev/whats-new-compose.html#across-platforms
  * https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-multiplatform-resources-usage.html#images