### PR TITLE
KTOR-7580 and KTOR-7627: Remove usage of `Principal` from auth docs

### DIFF
--- a/codeSnippets/snippets/auth-digest/src/main/kotlin/authdigest/Application.kt
+++ b/codeSnippets/snippets/auth-digest/src/main/kotlin/authdigest/Application.kt
@@ -2,7 +2,6 @@ package authdigest
 
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
-import io.ktor.server.auth.Principal
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import java.security.*
@@ -41,4 +40,4 @@ fun Application.main() {
     }
 }
 
-data class CustomPrincipal(val userName: String, val realm: String) : Principal
+data class CustomPrincipal(val userName: String, val realm: String)

--- a/codeSnippets/snippets/auth-form-session-nested/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/auth-form-session-nested/src/main/kotlin/com/example/Application.kt
@@ -10,7 +10,7 @@ import kotlinx.html.*
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class UserSession(val name: String, val count: Int) : Principal
+data class UserSession(val name: String, val count: Int)
 
 fun Application.main() {
     install(Sessions) {

--- a/codeSnippets/snippets/auth-form-session/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/auth-form-session/src/main/kotlin/com/example/Application.kt
@@ -10,7 +10,7 @@ import kotlinx.html.*
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class UserSession(val name: String, val count: Int) : Principal
+data class UserSession(val name: String, val count: Int)
 
 fun Application.main() {
     install(Sessions) {

--- a/topics/server-auth.md
+++ b/topics/server-auth.md
@@ -79,7 +79,12 @@ After [installing Authentication](#install), you can configure and use `Authenti
 
 ### Step 1: Choose an authentication provider {id="choose-provider"}
 
-To use a specific authentication provider ([basic](server-basic-auth.md), [digest](server-digest-auth.md), [form](server-form-based-auth.md), and so on), you need to call the corresponding function inside the `install` block. For example, to use the `basic` authentication, call the [basic](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/basic.html) function:
+To use a specific authentication
+provider, such as [basic](server-basic-auth.md), [digest](server-digest-auth.md), or [form](server-form-based-auth.md),
+you need to call the corresponding function inside the `install` block. For example, to use basic authentication,
+call the [
+`.basic()`](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/basic.html)
+function:
 
 ```kotlin
 import io.ktor.server.application.*
@@ -91,12 +96,16 @@ install(Authentication) {
     }
 }
 ```
-Inside this function, you can [configure](#configure-provider) settings specific to this provider.
 
+Inside this function, you can [configure](#configure-provider) settings specific to this provider.
 
 ### Step 2: Specify a provider name {id="provider-name"}
 
-A function for [using a specific provider](#choose-provider) optionally allows you to specify a provider name. A code sample below installs the [basic](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/basic.html) and [form](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/form.html) providers with the _auth-basic_ and _auth-form_ names, respectively:
+A function for [using a specific provider](#choose-provider) optionally allows you to specify a provider name. A code
+sample below installs
+the [basic](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/basic.html)
+and [form](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/form.html) providers
+with the `"auth-basic"` and `"auth-form"` names, respectively:
 
 ```kotlin
 install(Authentication) {
@@ -113,27 +122,49 @@ install(Authentication) {
 
 These names can be used later to [authenticate different routes](#authenticate-route) using different providers.
 > Note that a provider name should be unique, and you can define only one provider without a name.
-
+>
+{style="note"}
 
 ### Step 3: Configure a provider {id="configure-provider"}
 
-Each [provider type](#choose-provider) has its own configuration. For instance, the [BasicAuthenticationProvider.Config](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-basic-authentication-provider/-config/index.html) class contains options passed to the [basic](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/basic.html) function. The most important function exposed by this class is [validate](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-basic-authentication-provider/-config/validate.html) that validates a username and password. A code sample below shows how it can look:
+Each [provider type](#choose-provider) has its own configuration. For example,
+the [`BasicAuthenticationProvider.Config`](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-basic-authentication-provider/-config/index.html)
+class provides options for the
+[`.basic()`](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/basic.html)
+function. The key function in this class
+is [`validate()`](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-basic-authentication-provider/-config/validate.html)
+, which is responsible for validating a username and password. The following code example demonstrates its usage:
 
 ```kotlin
 ```
 {src="snippets/auth-basic/src/main/kotlin/authbasic/Application.kt" include-lines="9-20"}
 
-To understand how the `validate` function works, we need to introduce two terms:
-* A _principal_ is an entity that can be authenticated: a user, a computer, a service, etc. In Ktor, various authentication providers might use different principals. For example, the `basic`, `digest`, and `form` providers authenticate [UserIdPrincipal](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-user-id-principal/index.html) while the `jwt` provider verifies [JWTPrincipal](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/io.ktor.server.auth.jwt/-j-w-t-principal/index.html).
-  > You can also create a custom principal by implementing the [Principal](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-principal/index.html) interface.
-  > This might be useful in the following cases:
-  > - Mapping the credentials to a custom principal allows you to have additional information about the authenticated principal inside a [route handler](#get-principal).
-  > - If you use [session authentication](server-session-auth.md), a principal might be a data class that stores session data.
-* A _credential_ is a set of properties for a server to authenticate a principal: a user/password pair, an API key, and so on. For instance, the `basic` and `form` providers use [UserPasswordCredential](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-user-password-credential/index.html) to validate a username and password while `jwt` validates [JWTCredential](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/io.ktor.server.auth.jwt/-j-w-t-credential/index.html).
+To understand how the `validate()` function works, we need to introduce two terms:
 
-So, the `validate` function checks a specified [Credential](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-credential/index.html) and returns a [Principal](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-principal/index.html) in the case of successful authentication or `null` if authentication fails.
+* A _principal_ is an entity that can be authenticated: a user, a computer, a service, etc. In Ktor, various
+  authentication providers might use different principals. For example, the `basic`, `digest`, and `form` providers
+  authenticate [`UserIdPrincipal`](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-user-id-principal/index.html)
+  while the `jwt` provider
+  verifies [`JWTPrincipal`](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/io.ktor.server.auth.jwt/-j-w-t-principal/index.html).
+  > You can also create a custom principal. This might be useful in the following cases:
+  > - Mapping the credentials to a custom principal allows you to have additional information about the authenticated
+      principal inside a [route handler](#get-principal).
+  > - If you use [session authentication](server-session-auth.md), a principal might be a data class that stores session
+      data.
+* A _credential_ is a set of properties for a server to authenticate a principal: a user/password pair, an API key, and
+  so on. For instance, the `basic` and `form` providers
+  use [
+  `UserPasswordCredential`](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-user-password-credential/index.html)
+  to validate a username and password while `jwt`
+  validates [
+  `JWTCredential`](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth-jwt/io.ktor.server.auth.jwt/-j-w-t-credential/index.html).
 
-> To skip authentication based on specific criteria, use [skipWhen](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-authentication-provider/-config/skip-when.html). For example, you can skip `basic` authentication if a [session](server-sessions.md) already exists:
+So, the `validate()` function checks a specified credential and returns a principal `Any` in the case of successful
+authentication or `null` if authentication fails.
+
+> To skip authentication based on specific criteria,
+> use [`skipWhen()`](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-authentication-provider/-config/skip-when.html).
+> For example, you can skip `basic` authentication if a [session](server-sessions.md) already exists:
 > ```kotlin
 > basic {
 >     skipWhen { call -> call.sessions.get<UserSession>() != null }
@@ -142,8 +173,9 @@ So, the `validate` function checks a specified [Credential](https://api.ktor.io/
 
 ### Step 4: Protect specific resources {id="authenticate-route"}
 
-The final step is to protect specific resources in our application. You can do this by using the
-[authenticate](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/authenticate.html) function. This function accepts two optional parameters:
+The final step is to protect specific resources in your application. You can do this by using the
+[`authenticate()`](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/authenticate.html)
+function. This function accepts two optional parameters:
 
 - A [name of a provider](#provider-name) used to authenticate nested routes.
   The code snippet below uses a provider with the _auth-basic_ name to protect the `/login` and `/orders` routes:
@@ -163,10 +195,13 @@ The final step is to protect specific resources in our application. You can do t
    }
    ```
 - A strategy used to resolve nested authentication providers.
-  This strategy is represented by the [AuthenticationStrategy](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-authentication-strategy/index.html) enumeration value.
-  For instance, the client should provide authentication data for all providers registered 
+  This strategy is represented by the
+  [`AuthenticationStrategy`](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-authentication-strategy/index.html)
+  enumeration value.
+
+  For example, the client should provide authentication data for all providers registered
   with the `AuthenticationStrategy.Required` strategy.
-  In the code snippet below, only a user that passed [session authentication](server-session-auth.md) 
+  In the code snippet below, only a user that passed [session authentication](server-session-auth.md)
   can try to access the `/admin` route using basic authentication:
    ```kotlin
    routing {
@@ -182,30 +217,35 @@ The final step is to protect specific resources in our application. You can do t
        }
    }
    ```
-  
-  You can find the full example here: [auth-form-session-nested](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-form-session-nested).
-   
+
+> For the full example, see
+> [auth-form-session-nested](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-form-session-nested).
 
 
 
 ### Step 5: Get a principal inside a route handler {id="get-principal"}
 
-In the case of successful authentication, you can retrieve an authenticated [Principal](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-principal/index.html) inside a route handler using the `call.principal` function. This function accepts a specific principal type returned by the [configured authentication provider](#configure-provider). In a code sample below, `call.principal` is used to obtain `UserIdPrincipal` and get a name of an authenticated user.
+Upon successful authentication, you can retrieve an
+authenticated principal inside a route handler using the `call.principal()` function. This function accepts a specific
+principal type returned by the [configured authentication provider](#configure-provider). In the following example,
+`call.principal()` is used to obtain `UserIdPrincipal` and get a name of an authenticated user.
 
 ```kotlin
 ```
 {src="snippets/auth-basic/src/main/kotlin/authbasic/Application.kt" include-lines="21-27"}
 
 
-If you use [session authentication](server-session-auth.md), a principal might be a data class that stores session data. So, you need to pass this data class to `call.principal`:
+If you use [session authentication](server-session-auth.md), a principal might be a data class that stores session data.
+So, you need to pass this data class to `call.principal()`:
 
 ```kotlin
 ```
 {src="snippets/auth-form-session/src/main/kotlin/com/example/Application.kt" include-lines="77-79,82-83"}
 
-In the case of [nested authentication providers](#authenticate-route), 
-you can pass a [provider name](#provider-name) to `call.principal` to get a principal for the desired provider.
-In the example below, the _auth-session_ value is passed to get a principal for a topmost session provider:
+In the case of [nested authentication providers](#authenticate-route),
+you can pass a [provider name](#provider-name) to `call.principal()` to get a principal for the desired provider.
+
+In the example below, the `"auth-session"` value is passed to get a principal for a topmost session provider:
 
 ```kotlin
 ```

--- a/topics/server-session-auth.md
+++ b/topics/server-session-auth.md
@@ -57,30 +57,47 @@ install(Authentication) {
 ```
 
 ## Configure session authentication {id="configure"}
-This section demonstrates how to authenticate a user with a [form-based authentication](server-form-based-auth.md), save information about this user to a cookie session, and then authorize this user on subsequent requests using the `session` provider. You can find the complete example here: [auth-form-session](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-form-session).
+
+This section demonstrates how to authenticate a user with a [form-based authentication](server-form-based-auth.md), save
+information about this user to a cookie session, and then authorize this user on subsequent requests using the `session`
+provider.
+
+> For the complete example, see
+> [auth-form-session](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-form-session).
 
 ### Step 1: Create a data class {id="data-class"}
-First, you need to create a data class for storing session data. Note that this class should inherit [Principal](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-principal/index.html) since the [validate](#configure-session-auth) function should return a `Principal` in the case of successful authentication.
+
+First, you need to create a data class for storing session data:
 
 ```kotlin
 ```
 {src="snippets/auth-form-session/src/main/kotlin/com/example/Application.kt" include-lines="12-13"}
 
 ### Step 2: Install and configure a session {id="install-session"}
-After creating a data class, you need to install and configure the `Sessions` plugin. A code snippet below shows how to install and configure a cookie session with the specified cookie path and expiration time.
+
+After creating a data class, you need to install and configure the `Sessions` plugin. The example below
+installs and configures a cookie session with a specified cookie path and expiration time.
 
 ```kotlin
 ```
+
 {src="snippets/auth-form-session/src/main/kotlin/com/example/Application.kt" include-lines="17-21"}
 
-You can learn more about configuring sessions from [](server-sessions.md#configuration_overview).
+> To learn more about configuring sessions, see [](server-sessions.md#configuration_overview).
 
 
 ### Step 3: Configure session authentication {id="configure-session-auth"}
 
-The `session` authentication provider exposes its settings via the [SessionAuthenticationProvider.Config](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-session-authentication-provider/-config/index.html) class. In the example below, the following settings are specified:
-* The `validate` function checks the [session instance](#data-class) and returns `Principal` in the case of successful authentication.
-* The `challenge` function specifies an action performed if authentication fails. For instance, you can redirect back to a login page or send [UnauthorizedResponse](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-unauthorized-response/index.html).
+The `session` authentication provider exposes its settings via
+the [
+`SessionAuthenticationProvider.Config`](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-session-authentication-provider/-config/index.html)
+class. In the example below, the following settings are specified:
+
+* The `validate()` function checks the [session instance](#data-class) and returns a principal of type `Any` in the case
+  of successful authentication.
+* The `challenge()` function specifies an action performed if authentication fails. For instance, you can redirect back
+  to a login page or send an [
+  `UnauthorizedResponse`](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-unauthorized-response/index.html).
 
 ```kotlin
 ```
@@ -89,20 +106,33 @@ The `session` authentication provider exposes its settings via the [SessionAuthe
 
 ### Step 4: Save user data in a session {id="save-session"}
 
-To save information about a logged-in user to a session, use the [call.sessions.set](server-sessions.md#use_sessions) function.
-> This example shows a simple authentication flow using a web form.
-For more information on how to define it, please refer to the [Form-based authentication](server-form-based-auth.md) documentation.
+To save information about a logged-in user to a session, use the [
+`call.sessions.set()`](server-sessions.md#use_sessions)
+function.
+
+The following example shows a simple authentication flow using a web form:
 
 ```kotlin
 ```
+
 {src="snippets/auth-form-session/src/main/kotlin/com/example/Application.kt" include-lines="69-75"}
+
+> For more details on the form-based authentication flow, refer to
+the [Form-based authentication](server-form-based-auth.md) documentation.
 
 ### Step 5: Protect specific resources {id="authenticate-route"}
 
-After configuring the `session` provider, you can protect specific resources in our application using the **[authenticate](server-auth.md#authenticate-route)** function. In the case of successful authentication, you can retrieve an authenticated `Principal` (the [UserSession](#data-class) instance) inside a route handler using the `call.principal` function and information about a user.
+After configuring the `session` provider, you can protect specific resources in your application with the
+[`authenticate()`](server-auth.md#authenticate-route) function.
+
+Upon successful authentication, you can
+retrieve an authenticated principal (in this case, the [`UserSession`](#data-class) instance) by
+using the `call.principal()` function inside a route handler:
 
 ```kotlin
 ```
+
 {src="snippets/auth-form-session/src/main/kotlin/com/example/Application.kt" include-lines="77-83"}
 
-You can find the full example here: [auth-form-session](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-form-session).
+> For the full example, see
+> [auth-form-session](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-form-session).

--- a/topics/server-sessions.md
+++ b/topics/server-sessions.md
@@ -62,8 +62,6 @@ For example, the `UserSession` class below will be used to store the session ID 
 
 You need to create several data classes if you are going to use several sessions.
 
-> You can optionally inherit your data class from [Principal](https://api.ktor.io/ktor-server/ktor-server-plugins/ktor-server-auth/io.ktor.server.auth/-principal/index.html) to use a session for [](server-auth.md). Learn more from [](server-session-auth.md).
-
 ## Pass session data: Cookie vs Header {id="cookie_header"}
 
 ### Cookie {id="cookie"}


### PR DESCRIPTION
**Description:**

Update code examples and auth-related topics to exclude deprecated `Principal` and `Credential` interfaces.

**Related issues:**

[KTOR-7627](https://youtrack.jetbrains.com/issue/KTOR-7627) 
[KTOR-7580](https://youtrack.jetbrains.com/issue/KTOR-7580)