### PR TITLE
KTOR-7822 Document `SocketTimeoutException` becoming typealias

### DIFF
--- a/topics/migrating-3.md
+++ b/topics/migrating-3.md
@@ -550,11 +550,10 @@ Prior to Ktor 3.0.0, the `content` property of
 provided a raw `ByteReadChannel` to the response content as it is read from the network. Starting with Ktor 3.0.0, the
 `content` property has been renamed to `rawContent` to better reflect its purpose.
 
-### `SocketTimeoutException` is now typealias
+### `SocketTimeoutException` is now a typealias
 
 [`SocketTimeoutException`](https://api.ktor.io/older/3.0.0/ktor-client/ktor-client-core/io.ktor.client.network.sockets/-socket-timeout-exception/index.html)
-from the `io.ktor.client.network.sockets` package has been converted from a Kotlin class to a typealias for
-`java.net.SocketTimeoutException`.
+from the `io.ktor.client.network.sockets` package has been converted from a Kotlin class to an alias for a Java class.
 This change may cause a `NoClassDefFoundError` in certain cases and may require updates to existing code.
 
 To migrate your application, ensure your code is not referencing the old class and is compiled with the latest Ktor

--- a/topics/migrating-3.md
+++ b/topics/migrating-3.md
@@ -550,6 +550,25 @@ Prior to Ktor 3.0.0, the `content` property of
 provided a raw `ByteReadChannel` to the response content as it is read from the network. Starting with Ktor 3.0.0, the
 `content` property has been renamed to `rawContent` to better reflect its purpose.
 
+### `SocketTimeoutException` is now typealias
+
+[`SocketTimeoutException`](https://api.ktor.io/older/3.0.0/ktor-client/ktor-client-core/io.ktor.client.network.sockets/-socket-timeout-exception/index.html)
+from the `io.ktor.client.network.sockets` package has been converted from a Kotlin class to a typealias for
+`java.net.SocketTimeoutException`.
+This change may cause a `NoClassDefFoundError` in certain cases and may require updates to existing code.
+
+To migrate your application, ensure your code is not referencing the old class and is compiled with the latest Ktor
+version. Here's how to update exception checks:
+
+<compare type="top-bottom" first-title="2.x.x" second-title="3.0.x">
+    <code-block lang="kotlin">
+    if (exception is io.ktor.client.network.sockets.SocketTimeoutException) { ... }
+    </code-block>
+    <code-block lang="kotlin">
+    if (exception is java.net.SocketTimeoutException) { ... }
+    </code-block>
+</compare>
+
 ## Shared modules
 
 ### Attribute keys now require exact type matching


### PR DESCRIPTION
**Description**

Add a subsection in the migration guide for `SocketTimeoutException` becoming typealias.

**Related issue**

[KTOR-7822](https://youtrack.jetbrains.com/issue/KTOR-7822)

**Resources**

Slack ref: https://jetbrains.slack.com/archives/C07U498LLUR/p1732032882783529
Binary compatibility: https://stackoverflow.com/questions/14973380/what-is-binary-compatibility-in-java/14973523#14973523