### PR TITLE
[KTOR-8431] fix: variable scope in multipart formdata

### DIFF
--- a/codeSnippets/snippets/upload-file/src/main/kotlin/uploadfile/UploadFile.kt
+++ b/codeSnippets/snippets/upload-file/src/main/kotlin/uploadfile/UploadFile.kt
@@ -11,10 +11,9 @@ import java.io.File
 
 fun Application.main() {
     routing {
-        var fileDescription = ""
-        var fileName = ""
-
         post("/upload") {
+            var fileDescription = ""
+            var fileName = ""
             val multipartData = call.receiveMultipart(formFieldLimit = 1024 * 1024 * 100)
 
             multipartData.forEachPart { part ->


### PR DESCRIPTION
## What

Fix [KTOR-8431](https://youtrack.jetbrains.com/issue/KTOR-8431/Multipart-form-data-variables-are-places-in-the-wrong-scope).

Run check by following README.md

```console
$ ./gradlew :upload-file:run
$  curl 'http://localhost:8080/upload' -F 'image=@ktor_logo.png;type=image/png"'
 is uploaded to 'uploads/ktor_logo.png'
$ ls uploads/ktor_logo.png
uploads/ktor_logo.png
```