### PR TITLE
Update used snippet line in server uploads documentation

### DIFF
--- a/topics/server-requests.md
+++ b/topics/server-requests.md
@@ -161,7 +161,7 @@ In this example, the new limit is set to 100MB.
 ```kotlin
 ```
 
-{src="snippets/upload-file/src/main/kotlin/uploadfile/UploadFile.kt" include-lines="21,26-30,33"}
+{src="snippets/upload-file/src/main/kotlin/uploadfile/UploadFile.kt" include-lines="25,26-30,33"}
 
 The [`.provider()`](https://api.ktor.io/ktor-http/io.ktor.http.content/-part-data/-file-item/provider.html)
 function returns a `ByteReadChannel`, which allows you to read data incrementally.


### PR DESCRIPTION
Looking at the files upload documentation, we can see that the included line in the example uses `PartData.FormItem` 
![image](https://github.com/user-attachments/assets/ee9297c2-2c02-4c7f-9567-ebec0211accb)

Which does not have for example a `.provider()` method.

I believe the line we want to include is line 25, which is the `is PartData.FileItem` part of the snippet