### PR TITLE
Fix correct OPTIONS method name and improve formParameters grammar.

### DIFF
--- a/topics/client-requests.md
+++ b/topics/client-requests.md
@@ -14,7 +14,7 @@ Learn how to make requests and specify various request parameters: a request URL
 </link-summary>
 
 After [setting up the client](client-create-and-configure.md), you can make HTTP requests. The main way of making HTTP requests is the [request](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.request/request.html) function that can take a URL as a parameter. Inside this function, you can configure various request parameters: 
-* Specify an HTTP method, such as `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`, or `PATCH`.
+* Specify an HTTP method, such as `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`, or `PATCH`.
 * Specify a URL as a string or configure URL components (a domain, a path, query parameters, etc.) separately.
 * Add headers and cookies.
 * Set the body of a request, for example, a plain text, a data object, or form parameters.
@@ -181,7 +181,7 @@ function for sending form parameters with the `application/x-www-form-urlencoded
 demonstrates its usage:
 
 * `url` specifies a URL for making a request.
-* `formParameters` a set of form parameters built using `parameters`.
+* `formParameters` is a set of form parameters built using `parameters`.
 
 ```kotlin
 ```


### PR DESCRIPTION
### What was fixed

This pull request fixes two small but meaningful issues in the `client-requests.md` documentation file.

---

#### 1. Incorrect HTTP Method Name (`OPTION` → `OPTIONS`)

- **Before**:
  ```kotlin
  * Specify an HTTP method, such as `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`, or `PATCH`.
  ```

- **After**:
  ```kotlin
  * Specify an HTTP method, such as `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`, or `PATCH`.
  ```

- **Reason**:
OPTIONS is the correct HTTP method defined in [RFC 7231 4.3.7](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.7).


#### 2. Grammar improvement for formParameters

- **Before**:
  ```kotlin
  * `formParameters` a set of form parameters built using `parameters`.
  ```

- **After**:
  ```kotlin
  * `formParameters` is a set of form parameters built using `parameters`.
  ```

- **Reason**:
The original sentence lacked a verb and was grammatically incorrect.
Adding is clarifies the definition and improves readability.

</br>

Please let me know if there’s anything I should revise. Thank you!
