### PR TITLE
docs: KTOR-8533 Add docs for SaveBodyPlugin deprecation

### DIFF
--- a/ktor.tree
+++ b/ktor.tree
@@ -381,6 +381,7 @@
 
     <toc-element toc-title="Releases">
         <toc-element topic="releases.md"/>
+        <toc-element topic="What-s-new-in-Ktor-3-2-0.md"/>
         <toc-element topic="migration-to-20x.md"
                      accepts-web-file-names="migrating-2.html"/>
         <toc-element topic="migration-to-22x.md"

--- a/topics/Whats-new-in-Ktor-3-2-0.md
+++ b/topics/Whats-new-in-Ktor-3-2-0.md
@@ -1,0 +1,33 @@
+<show-structure for="chapter,procedure" depth="2"/>
+
+# What's new in Ktor 3.2.0
+
+## Ktor Client
+
+### `SaveBodyPlugin` and `HttpRequestBuilder.skipSavingBody()` are deprecated
+
+Prior to Ktor 3.2.0, the `SaveBodyPlugin` was installed by default. It cached the entire response body in memory,
+allowing it to be accessed multiple times. To avoid saving response body, the plugin had to be disabled explicitly.
+
+Starting with Ktor 3.2.0, the `SaveBodyPlugin` is deprecated and replaced by a new internal plugin that automatically saves
+the response body for all non-streaming requests. This improves resource management and simplifies the HTTP response
+lifecycle.
+
+The `HttpRequestBuilder.skipSavingBody()` is also deprecated. If you need to handle a response
+without caching the body, use a streaming approach instead.
+
+<compare first-title="Before" second-title="After">
+
+```kotlin
+val file = client.get("/some-file").bodyAsChannel()
+saveFile(file)
+```
+```kotlin
+client.prepareGet("/some-file").execute { response ->
+    saveFile(response.bodyAsChannel())
+}
+```
+
+</compare>
+
+This approach streams the response directly, preventing the body from being saved in memory.

--- a/topics/client-responses.md
+++ b/topics/client-responses.md
@@ -76,8 +76,11 @@ below shows how to get a response as a `ByteArray` and save it to a file:
 The [`onDownload()`](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.plugins/on-download.html) extension
 function in the example above is used to display download progress.
 
-This approach loads the entire response into memory at once, which can be problematic for large files. To reduce memory
-usage, consider [streaming the data](#streaming) in chunks.
+For non-streaming requests, calling `.body()` loads and caches the full response body in memory, allowing repeated 
+access. While this is efficient for small payloads, it may lead to high memory usage with large responses.
+
+To handle large responses efficiently, use a [streaming approach](#streaming),
+which processes the response incrementally without saving it in memory.
 
 ### JSON object {id="json"}
 


### PR DESCRIPTION
[KTOR-8533](https://youtrack.jetbrains.com/issue/KTOR-8533)

- Create a new topic "What's new in Ktor 3.2.0" to contain all release updates.
- Document SaveBodyPlugin and HttpRequestBuilder.skipSavingBody() deprecation.
- clarify memory behaviour in client responses topic

The are no mentions of the deprecated plugin and method in the docs, so no other changes have been made.