### PR TITLE
KTOR-8469 Add documentation about wrapWithContent and wrap deprecation

### DIFF
--- a/ktor.tree
+++ b/ktor.tree
@@ -381,7 +381,7 @@
 
     <toc-element toc-title="Releases">
         <toc-element topic="releases.md"/>
-        <toc-element topic="What-s-new-in-Ktor-3-2-0.md"/>
+        <toc-element topic="Whats-new-in-Ktor-3-2-0.md"/>
         <toc-element topic="migration-to-20x.md"
                      accepts-web-file-names="migrating-2.html"/>
         <toc-element topic="migration-to-22x.md"

--- a/topics/Whats-new-in-Ktor-3-2-0.md
+++ b/topics/Whats-new-in-Ktor-3-2-0.md
@@ -33,3 +33,30 @@ client.prepareGet("/some-file").execute { response ->
 </compare>
 
 This approach streams the response directly, preventing the body from being saved in memory.
+
+### The .wrapWithContent() and .wrap() extension functions are deprecated
+
+In Ktor 3.2.0, the [`.wrapWithContent()`](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.plugins.observer/wrap-with-content.html) and [`.wrap()`](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.plugins.observer/wrap.html) extension functions
+are deprecated in favor of the new `.replaceResponse()` function.
+
+The `.wrapWithContent()` and `.wrap()` functions replace the original response body with a `ByteReadChannel` that can only be read once.
+If the same channel instance is passed directly instead of a function that returns a new one, reading the body multiple times fails.
+This can break compatibility with [`SaveBodyPlugin`](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.plugins/-save-body-plugin.html?query=val%20SaveBodyPlugin:%20ClientPlugin%3CSaveBodyPluginConfig%3E),
+which relies on reading the response multiple times:
+
+```kotlin
+// Replaces the body with a channel decoded once from rawContent
+val decodedResponse = decode(response.rawContent)
+call.wrapWithContent(decodedResponse)
+// This fails on subsequent accesses
+```
+
+To avoid this issue, use the `.replaceResponse()` function instead.
+It accepts a lambda that returns a new channel on each access, ensuring safe integration with other plugins:
+
+```kotlin
+// Replaces the body with a new decoded channel on each access
+call.replaceResponse {
+    decode(response.rawContent)
+}
+```

--- a/topics/Whats-new-in-Ktor-3-2-0.md
+++ b/topics/Whats-new-in-Ktor-3-2-0.md
@@ -34,7 +34,7 @@ client.prepareGet("/some-file").execute { response ->
 
 This approach streams the response directly, preventing the body from being saved in memory.
 
-### The .wrapWithContent() and .wrap() extension functions are deprecated
+### The `.wrapWithContent()` and `.wrap()` extension functions are deprecated
 
 In Ktor 3.2.0, the [`.wrapWithContent()`](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.plugins.observer/wrap-with-content.html) and [`.wrap()`](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.plugins.observer/wrap.html) extension functions
 are deprecated in favor of the new `.replaceResponse()` function.


### PR DESCRIPTION
[KTOR-8469](https://youtrack.jetbrains.com/issue/KTOR-8469) Documentation for HttpClientCall: Deprecate `wrapWithContent` and `wrap`

This update modifies:

- What's new in Ktor 3.2.0