### PR TITLE
Curl engine supports WebSockets

### DIFF
--- a/topics/client-engines.md
+++ b/topics/client-engines.md
@@ -60,7 +60,7 @@ The table below shows whether a specific engine supports HTTP/2 and [WebSockets]
 | Js      | ✅                  | ✅          |
 | Darwin  | ✅                  | ✅          |
 | WinHttp | ✅                  | ✅          |
-| Curl    | ✅                  | ✖️         |
+| Curl    | ✅                  | ✅         |
 
 
 You also need to consider the following limitations that affect general client configuration and using of specific plugins:


### PR DESCRIPTION
I didn't test it yet, but from the changelog and source code it looks like Curl now supports WebSockets and the docs need an update.