### PR TITLE
docs: changing "Applciation" to "Application"

### DIFF
--- a/codeSnippets/snippets/tutorial-kotlin-rpc-app/README.md
+++ b/codeSnippets/snippets/tutorial-kotlin-rpc-app/README.md
@@ -1,4 +1,4 @@
-# A simple Ktor applciation using Kotlin RPC
+# A simple Ktor application using Kotlin RPC
 
 A sample project created in
 the [First steps with Kotlin RPC](https://ktor.io/docs/tutorial-first-steps-with-kotlin-rpc.html)

--- a/topics/migrating-3.md
+++ b/topics/migrating-3.md
@@ -157,7 +157,7 @@ The following table summarizes the key changes:
 | Package                    | 2.x.x                          | 3.0.x                 |
 |----------------------------|--------------------------------|-----------------------|
 | `io.ktor:ktor-server-core` | `ApplicationProperties`        | `ServerConfig`        |
-| `io.ktor:ktor-server-core` | `ApplciationPropertiesBuilder` | `ServerConfigBuilder` |
+| `io.ktor:ktor-server-core` | `ApplicationPropertiesBuilder` | `ServerConfigBuilder` |
 
 Additionally, in the `embeddedServer()` function, the `applicationProperties` attribute has been renamed to `rootConfig`
 to reflect this new configuration approach.


### PR DESCRIPTION
## Description

Noticed a small typo when looking at the 2 to 3 migration docs, so fixing it here.