### PR TITLE
fix: Update the WebSocket configuration example code to use kotlin.time instead of java.time

### DIFF
--- a/topics/server-create-websocket-application.topic
+++ b/topics/server-create-websocket-application.topic
@@ -164,8 +164,8 @@
                         fun Application.configureSockets() {
                             install(WebSockets) {
                                 contentConverter = KotlinxWebsocketSerializationConverter(Json)
-                                pingPeriod = Duration.ofSeconds(15)
-                                timeout = Duration.ofSeconds(15)
+                                pingPeriod = 15.seconds
+                                timeout = 15.seconds
                                 maxFrameSize = Long.MAX_VALUE
                                 masking = false
                             }


### PR DESCRIPTION
## Motivation
The current WebSocket plugin configuration example uses a `java.time.Duration` for `pingPeriod`, `timeout`, which is outdated due to recent interface changes. (https://github.com/ktorio/ktor/pull/4315)
The `pingPeriod`, `timeout` parameter now expects a `kotlin.time.Duration` type. To align with idiomatic Kotlin usage, it is better to use the `15.seconds` extension from the `kotlin.time` instead of calling `Duration.ofSeconds(15)`.

## Changes
Updated the WebSocket configuration example to use `15.seconds` for the `pingPeriod`, `timeout` setting.
