### PR TITLE
KTOR-8630: Use `coroutineScope` instead of `runBlocking`

### DIFF
--- a/codeSnippets/snippets/client-parallel-requests/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/client-parallel-requests/src/main/kotlin/com/example/Application.kt
@@ -6,10 +6,10 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.coroutineScope
 
-fun main() {
-    runBlocking {
+suspend fun main() {
+    coroutineScope {
         val client = HttpClient(CIO)
 
         // Sequential requests

--- a/codeSnippets/snippets/client-parallel-requests/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/client-parallel-requests/src/main/kotlin/com/example/Application.kt
@@ -13,8 +13,8 @@ suspend fun main() {
         val client = HttpClient(CIO)
 
         // Sequential requests
-/*        val firstRequestContent: String = client.get("http://localhost:8080/path1")
-        val secondRequestContent: String = client.get("http://localhost:8080/path2")*/
+/*        val firstRequestContent: String = client.get("http://localhost:8080/path1").bodyAsText()
+        val secondRequestContent: String = client.get("http://localhost:8080/path2").bodyAsText()*/
 
         // Parallel requests
         val firstRequest: Deferred<String> = async { client.get("http://localhost:8080/path1").bodyAsText() }


### PR DESCRIPTION
## What

This PR fixes [KTOR-8630](https://youtrack.jetbrains.com/issue/KTOR-8630/Replace-runBlocking-with-coroutineScope-in-ktor-client-doc).
And I found `.bodyAsText()` is needed in sequential example.

## Check

Following README.md of this project, I've confirmed that the app works as expected.

```console
$ ./gradlew :simulate-slow-server:run
$ ./gradlew :client-parallel-requests:run
Response time: 17:38:00.148553
Response time: 17:38:00.147823
```