### PR TITLE
Mention linuxArm64 support

### DIFF
--- a/codeSnippets/snippets/client-engine-curl/build.gradle.kts
+++ b/codeSnippets/snippets/client-engine-curl/build.gradle.kts
@@ -18,7 +18,8 @@ kotlin {
     val nativeTarget = when {
         hostOs == "Mac OS X" && arch == "x86_64" -> macosX64("native")
         hostOs == "Mac OS X" && arch == "aarch64" -> macosArm64("native")
-        hostOs == "Linux" -> linuxX64("native")
+        hostOs == "Linux" && arch == "x86_64" -> linuxX64("native")
+        hostOs == "Linux" && arch == "aarch64" -> linuxArm64("native")
         isMingwX64 -> mingwX64("native")
         else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
     }

--- a/codeSnippets/snippets/embedded-server-native/build.gradle.kts
+++ b/codeSnippets/snippets/embedded-server-native/build.gradle.kts
@@ -17,7 +17,8 @@ kotlin {
     val nativeTarget = when {
         hostOs == "Mac OS X" && arch == "x86_64" -> macosX64("native")
         hostOs == "Mac OS X" && arch == "aarch64" -> macosArm64("native")
-        hostOs == "Linux" -> linuxX64("native")
+        hostOs == "Linux" && arch == "x86_64" -> linuxX64("native")
+        hostOs == "Linux" && arch == "aarch64" -> linuxArm64("native")
         // Other supported targets are listed here: https://ktor.io/docs/native-server.html#targets
         else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
     }

--- a/topics/client-engines.md
+++ b/topics/client-engines.md
@@ -287,7 +287,7 @@ To use the `WinHttp` engine, follow the steps below:
 
 ### Curl {id="curl"}
 
-For desktop platforms, Ktor also provides the `Curl` engine. This engine is supported for the following platforms: `linuxX64`, `macosX64`, `macosArm64`, `mingwX64`. To use the `Curl` engine, follow the steps below:
+For desktop platforms, Ktor also provides the `Curl` engine. This engine is supported for the following platforms: `linuxX64`, `linuxArm64`, `macosX64`, `macosArm64`, `mingwX64`. To use the `Curl` engine, follow the steps below:
 
 1. Install the [libcurl library](https://curl.se/libcurl/).
    > On Linux, you have to install the `gnutls` version of libcurl.

--- a/topics/client-supported-platforms.md
+++ b/topics/client-supported-platforms.md
@@ -148,6 +148,9 @@ You can use it in [multiplatform projects](https://kotlinlang.org/docs/multiplat
             <li>
                 <code>linuxX64</code>
             </li>
+            <li>
+                <code>linuxArm64</code>
+            </li>
         </list>
     </td>
 </tr>

--- a/topics/server-platforms.md
+++ b/topics/server-platforms.md
@@ -120,6 +120,9 @@ The following [targets](https://kotlinlang.org/docs/multiplatform-dsl-reference.
             <li>
                 <code>linuxX64</code>
             </li>
+            <li>
+                <code>linuxArm64</code>
+            </li>
         </list>
     </td>
 </tr>


### PR DESCRIPTION
This updates the Ktor docs to add the missing mentions of linuxArm64, which is actually supported but was never documented.