### PR TITLE
fix: Update tutorial-client-kmm sample for Kotlin 2.1.20 Compose compatibility

### DIFF
--- a/codeSnippets/snippets/tutorial-client-kmm/androidApp/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-client-kmm/androidApp/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.kotlinAndroid)
+    alias(libs.plugins.kotlinCompose)
 }
 
 android {

--- a/codeSnippets/snippets/tutorial-client-kmm/androidApp/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-client-kmm/androidApp/build.gradle.kts
@@ -17,9 +17,6 @@ android {
     buildFeatures {
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
-    }
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/codeSnippets/snippets/tutorial-client-kmm/gradle/libs.versions.toml
+++ b/codeSnippets/snippets/tutorial-client-kmm/gradle/libs.versions.toml
@@ -4,7 +4,6 @@ kotlin = "2.1.20"
 coroutines = "1.9.0"
 ktor = "3.2.3"
 compose = "1.6.8"
-compose-compiler = "2.1.20"
 compose-material3 = "1.2.1"
 androidx-activityCompose = "1.8.2"
 

--- a/codeSnippets/snippets/tutorial-client-kmm/gradle/libs.versions.toml
+++ b/codeSnippets/snippets/tutorial-client-kmm/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.1.20"
 coroutines = "1.9.0"
 ktor = "3.2.3"
 compose = "1.6.8"
-compose-compiler = "1.5.4"
+compose-compiler = "2.1.20"
 compose-material3 = "1.2.1"
 androidx-activityCompose = "1.8.2"
 
@@ -28,3 +28,4 @@ androidLibrary = { id = "com.android.library", version.ref = "agp" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinCocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
+kotlinCompose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }


### PR DESCRIPTION
### Background
This version (1.5.4) of the Compose Compiler requires Kotlin version 1.9.20 but you appear to be using Kotlin version 2.1.20 which is not known to be compatible.

### Solution

- Updates compose-compiler version to 2.1.20 (matches Kotlin version)
- Adds `kotlinCompose` plugin per [official migration guide](https://kotlinlang.org/docs/compose-compiler-migration-guide.html)

Since Kotlin 2.0+, Compose Compiler versions align with Kotlin versions and require the new plugin.

### Impact
tutorial-client-kmm sample only