### PR TITLE
fix(server): update snippet lines

### DIFF
--- a/topics/server-openapi.md
+++ b/topics/server-openapi.md
@@ -63,6 +63,6 @@ You can customize generation settings inside the `openAPI` block:
 
 ```kotlin
 ```
-{src="snippets/json-kotlinx-openapi/src/main/kotlin/com/example/Application.kt" include-lines="39,55-58"}
+{src="snippets/json-kotlinx-openapi/src/main/kotlin/com/example/Application.kt" include-lines="40,56-58,59"}
 
 You can now [run](server-run.md) the application and open the `/openapi` page to see the generated documentation.

--- a/topics/server-swagger-ui.md
+++ b/topics/server-swagger-ui.md
@@ -58,7 +58,7 @@ For example, you can use another Swagger UI version or apply a custom style.
 
 ```kotlin
 ```
-{src="snippets/json-kotlinx-openapi/src/main/kotlin/com/example/Application.kt" include-lines="39,52-54,58"}
+{src="snippets/json-kotlinx-openapi/src/main/kotlin/com/example/Application.kt" include-lines="40,53-55,59"}
 
 You can now [run](server-run.md) the application and open the `/swagger` page to see the available endpoints, and test them.
 
@@ -72,4 +72,4 @@ The example below applies the following CORS configuration:
 
 ```kotlin
 ```
-{src="snippets/json-kotlinx-openapi/src/main/kotlin/com/example/Application.kt" include-lines="35-38"}
+{src="snippets/json-kotlinx-openapi/src/main/kotlin/com/example/Application.kt" include-lines="36-39"}


### PR DESCRIPTION
Problem:
Some of the examples are being misrendered due to the underlying file changing.

https://ktor.io/docs/server-swagger-ui.html#configure-swagger
<img width="733" height="213" alt="Screenshot 2025-08-15 at 11 23 43 am" src="https://github.com/user-attachments/assets/1d26816b-5b70-4ebc-a329-625e5d902a2c" />
<img width="728" height="327" alt="Screenshot 2025-08-15 at 11 23 29 am" src="https://github.com/user-attachments/assets/1afdb44a-09d4-455f-912f-9ec7b22ac3b7" />

https://ktor.io/docs/server-openapi.html#configure-swagger
<img width="710" height="338" alt="Screenshot 2025-08-15 at 11 24 30 am" src="https://github.com/user-attachments/assets/7151209f-ceab-4b78-911c-a65719455a64" />

The issue comes from this PR: https://github.com/ktorio/ktor-documentation/pull/605
Which added an import line


Solution:

I've updated the line numbers to address the issue

Fixed screenshots are from Writerside in my IDE
<img width="693" height="251" alt="Screenshot 2025-08-15 at 11 25 47 am" src="https://github.com/user-attachments/assets/6a56fd17-022e-4295-8920-833f30911106" />

<img width="694" height="174" alt="Screenshot 2025-08-15 at 11 26 12 am" src="https://github.com/user-attachments/assets/5324fb5d-c075-4cdc-9ddf-59f8669490b1" />


<img width="686" height="327" alt="Screenshot 2025-08-15 at 11 26 39 am" src="https://github.com/user-attachments/assets/0f31cf45-4ee5-4ac8-b2ac-9e7f95613f95" />

