### PR TITLE
docs: feat: KTOR-8860 Documentation for OpenAPI generation build extension preview

### DIFF
--- a/ktor.tree
+++ b/ktor.tree
@@ -379,6 +379,7 @@
     <toc-element toc-title="Integrations">
         <toc-element topic="full-stack-development-with-kotlin-multiplatform.topic"/>
         <toc-element topic="htmx-integration.md"/>
+        <toc-element topic="openapi-spec-generation.md"/>
         <toc-element topic="tutorial-first-steps-with-kotlin-rpc.topic"/>
     </toc-element>
 

--- a/labels.list
+++ b/labels.list
@@ -12,6 +12,7 @@
     <primary-label id="experimental" name="Experimental" short-name="" color="tangerine">
         This feature is experimental. It may be dropped or changed at any time. Opt-in is required (see details below).
     </primary-label>
+    <secondary-label id="server-feature" name="Server" color="purple">Server</secondary-label>
 
     <secondary-label id="wip" name="WIP" color="purple">Work in progress</secondary-label>
     <secondary-label id="beta" name="β" color="tangerine">Beta</secondary-label>

--- a/topics/openapi-spec-generation.md
+++ b/topics/openapi-spec-generation.md
@@ -8,6 +8,11 @@ Ktor provides experimental support for generating OpenAPI specifications directl
 This functionality is available via the Ktor Gradle plugin and can be combined with the [OpenAPI](server-openapi.md)
 and [SwaggerUI](server-swagger-ui.md) plugins to serve interactive API documentation.
 
+> The OpenAPI Gradle extension requires Kotlin 2.2.20. Using earlier versions may result in compilation
+> errors.
+>
+{style="note"}
+
 ## Add the Gradle plugin
 
 To enable specification generation, apply the Ktor Gradle plugin to your project:

--- a/topics/openapi-spec-generation.md
+++ b/topics/openapi-spec-generation.md
@@ -1,0 +1,97 @@
+[//]: # (title: OpenAPI specification generation)
+
+<show-structure for="chapter" depth="2"/>
+<primary-label ref="experimental"/>
+<secondary-label ref="server-feature"/>
+
+Ktor provides experimental support for generating OpenAPI specifications directly from your Kotlin code.
+This functionality is available via the Ktor Gradle plugin and can be combined with the [OpenAPI](server-openapi.md)
+and [SwaggerUI](server-swagger-ui.md) plugins to serve interactive API documentation.
+
+## Add the Gradle plugin
+
+To enable specification generation, apply the Ktor Gradle plugin to your project:
+
+```kotlin
+plugins {
+    id("io.ktor.plugin") version "%ktor_version%"
+}
+```
+
+## Configure the extension
+
+To configure the extension, use the `openApi` block inside the `ktor` extension in your
+<path>build.gradle.kts</path>
+file. You can provide metadata such as title, description, license, and contact information:
+
+```kotlin
+ktor {
+    @OptIn(OpenApiPreview::class)
+    openApi {
+        title = "OpenAPI example"
+        version = "2.1"
+        summary = "This is a sample API"
+        description = "This is a longer description"
+        termsOfService = "https://example.com/terms/"
+        contact = "contact@example.com"
+        license = "Apache/1.0"
+        version = "0.1"
+
+        // Location of the generated specification (defaults to openapi/generated.json)
+        target = project.layout.buildDirectory.file("open-api.json")
+    }
+}
+```
+
+## Annotate routes
+
+The plugin can infer the structure of your API, but to generate a complete and useful specification, you should annotate
+routes with KDoc tags. These annotations provide details such as parameters, responses, and descriptions:
+
+```kotlin
+/**
+ * Get a single user.
+ *
+ * @path id The ID of the user
+ * @response 404 The user was not found
+ * @response 200 [User] The user.
+ */
+get("/api/users/{id}") {
+    val user = repository.get(call.parameters["id"]!!)
+        ?: return@get call.respond(HttpStatusCode.NotFound)
+    call.respond(user)
+}
+
+```
+Supported KDoc tags include `@path`, `@query`, `@header`, `@cookie`, `@body`, `@response`, `@deprecated`,
+` @description`, `@security`, `@externalDocs`, and `@ignore`.
+
+
+## Generate the specification
+
+To generate the OpenAPI specification, run the following Gradle task:
+
+```shell
+./gradlew buildOpenApi
+```
+
+This task runs the Kotlin compiler with a custom plugin that analyzes your routing code and produces a
+JSON specification.
+
+> Some constructs cannot be evaluated at compile time. The generated specification may be incomplete. Improvements are
+> planned for later Ktor releases.
+>
+{style="note"}
+
+## Serve the specification
+
+To make the generated specification available at runtime, you can use the [OpenAPI](server-openapi.md)
+or [SwaggerUI](server-swagger-ui.md) plugins.
+
+The following example serves the generated specification file at an OpenAPI endpoint:
+
+```kotlin
+routing {
+    openAPI("/docs", swaggerFile = "openapi/generated.json")
+}
+```

--- a/topics/openapi-spec-generation.md
+++ b/topics/openapi-spec-generation.md
@@ -48,10 +48,31 @@ ktor {
 }
 ```
 
+## Routing API introspection
+
+The plugin can analyze your server routing DSL to infer basic path information, such as:
+
+- The merged path (`/api/v1/users/{id}`).
+- Path parameters.
+- HTTP methods (such as `GET` and `POST`).
+
+```kotlin
+routing {
+    route("/api/v1") {
+        get("/users") { }
+        get("/users/{id}") { }
+        post("/users") { }
+    }
+}
+```
+
+Because request parameters and responses are handled inside route lambdas, the plugin cannot infer detailed
+request/response schemas automatically. To generate a complete and useful specification, you can use annotations.
+
 ## Annotate routes
 
-The plugin can infer the structure of your API, but to generate a complete and useful specification, you should annotate
-routes with KDoc tags. These annotations provide details such as parameters, responses, and descriptions:
+To enrich the specification, Ktor uses a KDoc-like annotation API. Annotations provide metadata that cannot be inferred
+from code and integrate seamlessly with existing routes.
 
 ```kotlin
 /**
@@ -68,8 +89,22 @@ get("/api/users/{id}") {
 }
 
 ```
-Supported KDoc tags include `@path`, `@query`, `@header`, `@cookie`, `@body`, `@response`, `@deprecated`,
-` @description`, `@security`, `@externalDocs`, and `@ignore`.
+
+### Supported KDoc fields
+
+| Tag             | Format                                          | Description                                     |
+|-----------------|-------------------------------------------------|-------------------------------------------------|
+| `@tags`         | `@tags *name`                                   | Associates the endpoint with a tag for grouping |
+| `@path`         | `@path [Type] name description`                 | Describes a path parameter                      |
+| `@query`        | `@query [Type] name description`                | Query parameter                                 |
+| `@header`       | `@header [Type] name description`               | Header parameter                                |
+| `@cookie`       | `@cookie [Type] name description`               | Cookie parameter                                |
+| `@body`         | `@body contentType [Type] description`          | Request body                                    |
+| `@response`     | `@response code contentType [Type] description` | Response with optional type                     |
+| `@deprecated`   | `@deprecated reason`                            | Marks endpoint deprecated                       |
+| `@description`  | `@description text`                             | Extended description                            |
+| `@security`     | `@security scheme`                              | Security requirements                           |
+| `@externalDocs` | `@external href`                                | External documentation links                    |
 
 
 ## Generate the specification

--- a/topics/openapi-spec-generation.md
+++ b/topics/openapi-spec-generation.md
@@ -8,7 +8,7 @@ Ktor provides experimental support for generating OpenAPI specifications directl
 This functionality is available via the Ktor Gradle plugin and can be combined with the [OpenAPI](server-openapi.md)
 and [SwaggerUI](server-swagger-ui.md) plugins to serve interactive API documentation.
 
-> The OpenAPI Gradle extension requires Kotlin 2.2.20. Using earlier versions may result in compilation
+> The OpenAPI Gradle extension requires Kotlin 2.2.20. Using other versions may result in compilation
 > errors.
 >
 {style="note"}

--- a/topics/server-openapi.md
+++ b/topics/server-openapi.md
@@ -19,10 +19,9 @@
 The OpenAPI plugin allows you to generate OpenAPI documentation for your project.
 </link-summary>
 
-Ktor allows you to generate and serve OpenAPI documentation for your project based on the existing OpenAPI specification.
-
-<include from="server-swagger-ui.md" element-id="open-api-note"/>
-
+Ktor allows you to generate and serve OpenAPI documentation for your project based on an existing OpenAPI specification.
+You can serve an existing YAML or JSON specification, or generate one using the
+[OpenAPI extension](openapi-spec-generation.md) of the Ktor Gradle plugin.
 
 ## Add dependencies {id="add_dependencies"}
 

--- a/topics/server-swagger-ui.md
+++ b/topics/server-swagger-ui.md
@@ -20,14 +20,8 @@ The SwaggerUI plugin allows you to generate Swagger UI for your project.
 </link-summary>
 
 Ktor allows you to generate and serve Swagger UI for your project based on the existing OpenAPI specification.
-With Swagger UI, you can visualize and interact with the API resources. 
-
-> The following tools are available for generating OpenAPI definitions from code and vice versa:
-> - The [Ktor plugin](https://www.jetbrains.com/help/idea/ktor.html#openapi) for IntelliJ IDEA provides the ability to generate OpenAPI documentation for server-side Ktor applications.
-> - The [OpenAPI generator](https://github.com/OpenAPITools/openapi-generator) allows you to create a Ktor project from your API definitions by using the [kotlin-server](https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/kotlin-server.md) generator. Alternatively, you can use IntelliJ IDEA's [functionality](https://www.jetbrains.com/help/idea/openapi.html#codegen).
-> 
-{id="open-api-note"}
-
+With Swagger UI, you can visualize and interact with the API resources. You can serve an existing YAML or JSON 
+specification, or generate one using the [OpenAPI extension](openapi-spec-generation.md) of the Ktor Gradle plugin.
 
 ## Add dependencies {id="add_dependencies"}
 

--- a/topics/whats-new-330.md
+++ b/topics/whats-new-330.md
@@ -83,7 +83,7 @@ In Ktor 3.3.0, the Ktor client's `OkHttp` engine has been upgraded to use OkHttp
 version bump may introduce API changes for projects that interact directly with OkHttp. Such projects should verify
 compatibility.
 
-## Shared
+## Gradle plugin
 
 ### OpenAPI specification generation
 <secondary-label ref="experimental"/>
@@ -99,60 +99,31 @@ It provides the following capabilities:
     - Security, descriptions, deprecations, and external documentation links
 - Infer request and response bodies from `call.receive()` and `call.respond()`.
 
-#### Annotating routes
 
-KDoc tags are used to describe endpoints:
+<include from="openapi-spec-generation.md" element-id="configure-the-extension"></include>
 
-```kotlin
-/**
- * Get a single user.
- *
- * @path id The ID of the user
- * @response 404 The user was not found
- * @response 200 [User] The user.
- */
-get("/api/users/{id}") {
-    val user = repository.get(call.parameters["id"]!!)
-        ?: return@get call.respond(HttpStatusCode.NotFound)
-    call.respond(user)
-}
+#### Generate the OpenAPI specification
 
-```
-Supported KDoc tags include `@path`, `@query`, `@header`, `@cookie`, `@body`, `@response`, `@deprecated`,
-` @description`, `@security`, `@externalDocs`, and `@ignore`.
-
-#### Configuring the Gradle plugin
-
-```kotlin
-import io.ktor.plugin.*
-
-plugins {
-    alias(libs.plugins.ktor)
-    alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.kotlinx.serialization)
-}
-
-application.mainClass = "io.ktor.samples.openapi.ApplicationKt"
-
-ktor {
-    @OptIn(OpenApiPreview::class)
-    openApi {
-        title = "OpenAPI example"
-        version = "2.1"
-        summary = "This is a sample API"
-    }
-}
-```
-
-#### Generating the OpenAPI specification
-
-To generate the OpenAPI specification file (for example, at
-<path>openapi/generated.json</path>
-) from your Ktor routes and KDoc annotations, use the following command:
+To generate the OpenAPI specification file from your Ktor routes and KDoc annotations, use the following command:
 
 ```shell
 ./gradlew buildOpenApi
 ```
+
+#### Serve the specification
+
+To make the generated specification available at runtime, you can then use the [OpenAPI](server-openapi.md)
+or [SwaggerUI](server-swagger-ui.md) plugins.
+
+The following example serves the generated specification file at an OpenAPI endpoint:
+
+```kotlin
+routing {
+    openAPI("/docs", swaggerFile = "openapi/generated.json")
+}
+```
+
+## Shared
 
 ### Updated Jetty version
 

--- a/topics/whats-new-330.md
+++ b/topics/whats-new-330.md
@@ -85,6 +85,75 @@ compatibility.
 
 ## Shared
 
+### OpenAPI specification generation
+<secondary-label ref="experimental"/>
+
+Ktor 3.3.0 introduces an experimental OpenAPI generation feature via the Gradle plugin and a compiler plugin. This
+allows you to generate OpenAPI specifications directly from your application code at build time.
+
+It provides the following capabilities:
+- Analyze Ktor route definitions and merge nested routes, local extensions, and resource paths.
+- Parse preceding KDoc annotations to supply OpenAPI metadata, including:
+    - Path, query, header, cookie, and body parameters
+    - Response codes and types
+    - Security, descriptions, deprecations, and external documentation links
+- Infer request and response bodies from `call.receive()` and `call.respond()`.
+
+#### Annotating routes
+
+KDoc tags are used to describe endpoints:
+
+```kotlin
+/**
+ * Get a single user.
+ *
+ * @path id The ID of the user
+ * @response 404 The user was not found
+ * @response 200 [User] The user.
+ */
+get("/api/users/{id}") {
+    val user = repository.get(call.parameters["id"]!!)
+        ?: return@get call.respond(HttpStatusCode.NotFound)
+    call.respond(user)
+}
+
+```
+Supported KDoc tags include `@path`, `@query`, `@header`, `@cookie`, `@body`, `@response`, `@deprecated`,
+` @description`, `@security`, `@externalDocs`, and `@ignore`.
+
+#### Configuring the Gradle plugin
+
+```kotlin
+import io.ktor.plugin.*
+
+plugins {
+    alias(libs.plugins.ktor)
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlinx.serialization)
+}
+
+application.mainClass = "io.ktor.samples.openapi.ApplicationKt"
+
+ktor {
+    @OptIn(OpenApiPreview::class)
+    openApi {
+        title = "OpenAPI example"
+        version = "2.1"
+        summary = "This is a sample API"
+    }
+}
+```
+
+#### Generating the OpenAPI specification
+
+To generate the OpenAPI specification file (for example, at
+<path>openapi/generated.json</path>
+) from your Ktor routes and KDoc annotations, use the following command:
+
+```shell
+./gradlew buildOpenApi
+```
+
 ### Updated Jetty version
 
 The Jetty server and client engines have been upgraded to use Jetty 12. For most applications, this upgrade is fully

--- a/topics/whats-new-330.md
+++ b/topics/whats-new-330.md
@@ -123,6 +123,8 @@ routing {
 }
 ```
 
+For more details about this feature, see [OpenAPI specification generation](openapi-spec-generation.md).
+
 ## Shared
 
 ### Updated Jetty version


### PR DESCRIPTION
[KTOR-8860](https://youtrack.jetbrains.com/issue/KTOR-8860)

- Add a new topic _OpenAPI specification generation_ under _Integrations_.
- Add a section describing the feature in _What's new in Ktor 3.3.0_.
- Remove note from _OpenAPI_ and _SwaggerUI_ plugin topics regarding tools for generating spec and add a link to the new topic in the intro instead. 