### PR TITLE
KTOR-8862 HTTP/2 without TLS

### DIFF
--- a/codeSnippets/snippets/http2-netty/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/http2-netty/src/main/kotlin/com/example/Application.kt
@@ -5,7 +5,14 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 
-fun Application.main() {
+fun main() {
+    embeddedServer(Netty, port = 8080, configure = {
+        enableHttp2 = true
+        enableH2c = true
+    }, module = Application::module).start(wait = true)
+}
+
+fun Application.module() {
     routing {
         get("/") {
             call.respondText("HTTP version is ${call.request.httpVersion}")

--- a/topics/server-http2.md
+++ b/topics/server-http2.md
@@ -49,9 +49,6 @@ The next step is configuring Ktor to use your keystore. See the example `applica
 </tab>
 </tabs>
 
-
-
-
 ## ALPN implementation {id="apln_implementation"}
 
 HTTP/2 requires ALPN ([Application-Layer Protocol Negotiation](https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation)) to be enabled. The first option is to use an external ALPN implementation that needs to be added to the boot classpath.
@@ -78,3 +75,17 @@ The example below shows how to add a native implementation (statically linked Bo
 
 `tc.native.classifier` should be one of the following: `linux-x86_64`, `osx-x86_64`, or `windows-x86_64`. 
 The [http2-netty](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/http2-netty) runnable example demonstrates how to enable HTTP/2 support for Netty.
+
+#### HTTP/2 without TLS
+
+The Netty engine also supports [HTTP/2 over cleartext (h2c)](https://httpwg.org/specs/rfc7540.html#discover-http).
+This allows HTTP/2 communication without TLS, typically within private networks where encryption is not required. 
+Clients can initiate communication with an HTTP/1.1 request and then upgrade to HTTP/2.
+
+To enable h2c, set the `enableH2c` flag to `true` in the engine configuration:
+
+```kotlin
+```
+{src="snippets/http2-netty/src/main/kotlin/com/example/Application.kt" include-lines="9-12"}
+
+Note that h2c requires `enableHttp2 = true` and cannot be used if an SSL connector is configured on the server.

--- a/topics/whats-new-330.md
+++ b/topics/whats-new-330.md
@@ -46,6 +46,15 @@ ktor {
 We plan to restore support for blocking function references in a future release. Until then, prefer a `suspend` module
 or configuration reference in `development` mode.
 
+### HTTP/2 cleartext (h2c) support
+
+Ktor 3.3.0 introduces support for HTTP/2 over cleartext (h2c) for the Netty engine,
+which allows HTTP/2 communication without TLS encryption. 
+This setup is typically used in trusted environments, such as local testing or private networks.
+
+To enable h2c, set the `enableH2c` flag to true in the engine configuration.
+For more information, see [HTTP/2 without TLS](server-http2.md#http-2-without-tls).
+
 ## Ktor Client
 
 ### SSE response body buffer


### PR DESCRIPTION
[KTOR-8862](https://youtrack.jetbrains.com/issue/KTOR-8862)

- Add a new section to the What's new in Ktor 3.3.0 page.
- Add a new sub-section in the Netty﻿ chapter of the HTTP/2 page.