### PR TITLE
fix: add missing supported native targets

### DIFF
--- a/codeSnippets/snippets/embedded-server-native/build.gradle.kts
+++ b/codeSnippets/snippets/embedded-server-native/build.gradle.kts
@@ -19,7 +19,8 @@ kotlin {
         hostOs == "Mac OS X" && arch == "aarch64" -> macosArm64("native")
         hostOs == "Linux" && arch == "x86_64" -> linuxX64("native")
         hostOs == "Linux" && arch == "aarch64" -> linuxArm64("native")
-        // Other supported targets are listed here: https://ktor.io/docs/native-server.html#targets
+        hostOs.startsWith("Windows") -> mingwX64("native")
+        // Other supported targets are listed here: https://ktor.io/docs/server-native.html#targets
         else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
     }
 

--- a/topics/server-native.md
+++ b/topics/server-native.md
@@ -13,7 +13,6 @@ Ktor supports [Kotlin/Native](https://kotlinlang.org/docs/native-overview.html) 
 * a [server should be created](server-create-and-configure.topic) using `embeddedServer`
 * only the [CIO engine](server-engines.md) is supported
 * [HTTPS](server-ssl.md) without a reverse proxy is not supported
-* Windows [target](server-platforms.md) is not supported
 
 <include from="client-engines.md" element-id="newmm-note"/>
 

--- a/topics/server-platforms.md
+++ b/topics/server-platforms.md
@@ -59,6 +59,28 @@ The following [targets](https://kotlinlang.org/docs/multiplatform-dsl-reference.
 
 <tr>
     <td>
+        Android
+    </td>
+    <td>
+        <list>
+            <li>
+                <code>androidNativeArm32</code>
+            </li>
+            <li>
+                <code>androidNativeArm64</code>
+            </li>
+            <li>
+                <code>androidNativeX86</code>
+            </li>
+            <li>
+                <code>androidNativeX64</code>
+            </li>
+        </list>
+    </td>
+</tr>
+
+<tr>
+    <td>
         iOS
     </td>
     <td>
@@ -150,6 +172,19 @@ The following [targets](https://kotlinlang.org/docs/multiplatform-dsl-reference.
             </li>
             <li>
                 <code>linuxArm64</code>
+            </li>
+        </list>
+    </td>
+</tr>
+
+<tr>
+    <td>
+        Windows
+    </td>
+    <td>
+        <list>
+            <li>
+                <code>mingwX64</code>
             </li>
         </list>
     </td>


### PR DESCRIPTION
The `Native Server` section of the Ktor documentation currently says that `Windows target is not supported` as follows:
<img width="741" height="515" alt="image" src="https://github.com/user-attachments/assets/5a671abc-78fe-45b2-8c0b-dffbe8cd5caa" />

This statement almost stopped me from proceeding on [my project](https://github.com/SaltifyDev/acidify), which is based on Kotlin/Native and Ktor and intended to support all desktop platforms (Windows, macOS, Linux). Later I checked [Maven Central](https://repo1.maven.org/maven2/io/ktor/) and found that nearly every module had a distribution suffixed `-mingwX64`, which convinced me that Windows platform had been well supported after April 2024, so I deleted the misleading statement in this PR.

I further read through the  documentation and found more missing platforms in `Supported Platform` section, e.g. `androidNativeX64`. I appended them to that section in this PR.

Additionally, I added Windows target to the related code snippet, and corrected the link to `Supported Platform` section (the older link also points to this page but the user will experience a redirection).