### PR TITLE
Fix broken links and remove Ktor version branch from GH links

### DIFF
--- a/topics/FAQ.topic
+++ b/topics/FAQ.topic
@@ -52,9 +52,7 @@
         <p>
             If you are running an <a href="server-create-and-configure.topic" anchor="engine-main">EngineMain</a>, it will be handled
             automatically.
-            Otherwise, you need to <a
-                href="https://github.com/ktorio/ktor/blob/main/ktor-server/ktor-server-cio/jvmAndNix/src/io/ktor/server/cio/EngineMain.kt#L21">handle
-            it manually</a>.
+            Otherwise, you need to handle it manually.
             You can use the <code>Runtime.getRuntime().addShutdownHook</code> JVM's facility.
         </p>
     </chapter>
@@ -216,7 +214,7 @@
                     <li>Client <a href="https://ktor.io/docs/websocket-client.html">WebSockets</a> and
                         Server <a href="https://ktor.io/docs/websocket.html">WebSockets</a></li>
                     <li>Client <a href="https://ktor.io/docs/serialization-client.html">ContentNegotiation</a> and
-                        Server <a href="https://ktor.io/docs/serialization.html">ContentNegotiation</a></li>
+                        Server <a href="https://ktor.io/docs/server-serialization.html">ContentNegotiation</a></li>
                     <li><a href="https://ktor.io/docs/compression.html">Compression</a></li>
                 </list>
             </step>

--- a/topics/azure-app-service.md
+++ b/topics/azure-app-service.md
@@ -13,7 +13,7 @@ Before starting this tutorial, you will need the following:
 
 ## Create a sample application {id="create-sample-app"}
 
-Create a sample application as described in [](server-create-a-new-project.topic). This example shows code and commands based on the following projects: [embedded-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/embedded-server) and [engine-main](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main).
+Create a sample application as described in [](server-create-a-new-project.topic). This example shows code and commands based on the following projects: [embedded-server](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server) and [engine-main](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main).
 
 > The tutorial above provides two ways to configure your application: either by specifying values directly in the code or by using a configuration file. In both cases, the key configuration is the port on which the server listens for incoming requests.
 

--- a/topics/client-basic-auth.md
+++ b/topics/client-basic-auth.md
@@ -83,6 +83,6 @@ authentication provider:
     > For details on clearing cached credentials programmatically, see the general [Token caching and cache control](client-auth.md#token-caching)
     > section.
 
-> For a full example of basic authentication in Ktor Client, see [client-auth-basic](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-auth-basic).
+> For a full example of basic authentication in Ktor Client, see [client-auth-basic](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-auth-basic).
 
 

--- a/topics/client-bearer-auth.md
+++ b/topics/client-bearer-auth.md
@@ -147,7 +147,7 @@ Disabling caching can be useful when tokens change frequently.
 This example demonstrates how to use bearer authentication with Google APIs, which use the [OAuth 2.0 protocol](https://developers.google.com/identity/protocols/oauth2)
 for authentication and authorization. 
 
-The example application [client-auth-oauth-google](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-auth-oauth-google) retrieves the user's Google profile information. 
+The example application [client-auth-oauth-google](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-auth-oauth-google) retrieves the user's Google profile information. 
 
 ### Obtain client credentials {id="google-client-credentials"}
 
@@ -344,7 +344,7 @@ The `ErrorInfo` class is defined as follows:
 ```
 {src="snippets/client-auth-oauth-google/src/main/kotlin/com/example/models/ErrorInfo.kt" include-lines="3-13"}
 
-> For the full example, see [client-auth-oauth-google](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-auth-oauth-google).
+> For the full example, see [client-auth-oauth-google](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-auth-oauth-google).
 > 
 {style="tip"}
 

--- a/topics/client-caching.md
+++ b/topics/client-caching.md
@@ -46,4 +46,4 @@ whether this storage is used as a shared or private cache.
 ```
 {src="snippets/client-caching/src/main/kotlin/com/example/Application.kt" include-lines="18-22,24"}
 
-> You can find the full example here: [client-caching](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-caching).
+> You can find the full example here: [client-caching](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-caching).

--- a/topics/client-call-id.md
+++ b/topics/client-call-id.md
@@ -114,4 +114,4 @@ In this way the Ktor server retrieves the ID of the specified header of the requ
 property of the call.
 
 For the full example,
-see [client-call-id](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-call-id)
+see [client-call-id](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-call-id)

--- a/topics/client-content-encoding.md
+++ b/topics/client-content-encoding.md
@@ -51,7 +51,7 @@ val client = HttpClient(CIO) {
 
 You can configure which encoders are supported and specify their quality values (used in the `Accept-Encoding` header).
 
-The [example](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-content-encoding) below enables the `deflate` and `gzip` encoders with custom quality values:
+The [example](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-content-encoding) below enables the `deflate` and `gzip` encoders with custom quality values:
 
 ```kotlin
 ```

--- a/topics/client-cookies.md
+++ b/topics/client-cookies.md
@@ -28,7 +28,7 @@ To install `HttpCookies`, pass it to the `install` function inside a [client con
 ```
 {src="snippets/client-cookies/src/main/kotlin/com/example/Application.kt" include-lines="16-18"}
 
-This is enough to enable the Ktor client to keep cookies between requests. You can find the full example here: [client-cookies](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-cookies).
+This is enough to enable the Ktor client to keep cookies between requests. You can find the full example here: [client-cookies](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-cookies).
 
 
 The `HttpCookies` plugin also allows you to add a specific set of cookies to each request by using `ConstantCookiesStorage`. This might be useful in a test case that verifies a server response. The example below shows how to add a specified cookie to all requests for a specific domain:

--- a/topics/client-custom-plugins.md
+++ b/topics/client-custom-plugins.md
@@ -375,7 +375,7 @@ Shows how to transform request and response bodies using the `transformRequestBo
 </tab>
 </tabs>
 
-You can find the full example here: [client-custom-plugin-data-transformation](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-custom-plugin-data-transformation).
+You can find the full example here: [client-custom-plugin-data-transformation](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-custom-plugin-data-transformation).
 
 
 ### Authentication {id="authentication"}
@@ -399,4 +399,4 @@ A sample Ktor project showing how to use the `on(Send)` hook to add a bearer tok
 </tab>
 </tabs>
 
-You can find the full example here: [client-custom-plugin-auth](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-custom-plugin-auth).
+You can find the full example here: [client-custom-plugin-auth](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-custom-plugin-auth).

--- a/topics/client-default-request.md
+++ b/topics/client-default-request.md
@@ -170,7 +170,7 @@ The request below made by this client specifies a latter path segment only and a
 ```
 {src="snippets/client-default-request/src/main/kotlin/com/example/Application.kt" include-lines="25-26"}
 
-You can find the full example here: [client-default-request](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-default-request).
+You can find the full example here: [client-default-request](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-default-request).
 
 
 

--- a/topics/client-digest-auth.md
+++ b/topics/client-digest-auth.md
@@ -66,4 +66,4 @@ To send user credentials in the `Authorization` header using the `Digest` scheme
 ```
 {src="snippets/client-auth-digest/src/main/kotlin/com/example/Application.kt" include-lines="17-26"}
 
-> You can find the full example here: [client-auth-digest](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-auth-digest).
+> You can find the full example here: [client-auth-digest](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-auth-digest).

--- a/topics/client-engines.md
+++ b/topics/client-engines.md
@@ -268,7 +268,7 @@ uses [`NSURLSession`](https://developer.apple.com/documentation/foundation/nsurl
    {src="snippets/client-engine-darwin/src/nativeMain/kotlin/Main.kt" include-lines="8-14"}
 
    For the full example,
-   see [client-engine-darwin](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-engine-darwin).
+   see [client-engine-darwin](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-engine-darwin).
 
 ### WinHttp {id="winhttp"}
 
@@ -296,7 +296,7 @@ To use the `WinHttp` engine, follow the steps below:
    {src="snippets/client-engine-winhttp/src/nativeMain/kotlin/Main.kt" include-lines="9-13"}
 
    For the full example,
-   see [client-engine-winhttp](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-engine-winhttp).
+   see [client-engine-winhttp](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-engine-winhttp).
 
 ### Curl {id="curl"}
 
@@ -323,7 +323,7 @@ For desktop platforms, Ktor provides the `Curl` engine. It is supported on `linu
    {src="snippets/client-engine-curl/src/nativeMain/kotlin/Main.kt" include-lines="8-12"}
 
    For the full example,
-   see [client-engine-curl](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-engine-curl).
+   see [client-engine-curl](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-engine-curl).
 
 ## JVM, Android, Native, JS and WasmJs {id="jvm-android-native-wasm-js"}
 
@@ -377,7 +377,7 @@ for Node.js. To use it, follow the steps below:
    ```
 
 For the full example,
-see [client-engine-js](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-engine-js).
+see [client-engine-js](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-engine-js).
 
 ## Limitations {id="limitations"}
 

--- a/topics/client-http-send.md
+++ b/topics/client-http-send.md
@@ -16,5 +16,5 @@ The `HttpSend` plugin doesn't require installation. To use it, pass `HttpSend` t
 ```
 {src="snippets/client-http-send/src/main/kotlin/com/example/Application.kt" include-lines="12-20"}
 
-You can find the full sample here: [client-http-send](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-http-send).
+You can find the full sample here: [client-http-send](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-http-send).
 

--- a/topics/client-logging.md
+++ b/topics/client-logging.md
@@ -127,7 +127,7 @@ the example below, the `Authorization` header value will be replaced with '***' 
 {src="snippets/client-logging/src/main/kotlin/com/example/Application.kt"}
 
 For the full example,
-see [client-logging](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-logging).
+see [client-logging](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-logging).
 
 ### Provide a custom logger {id="custom_logger"}
 
@@ -141,4 +141,4 @@ The example below shows how to use the [Napier](https://github.com/AAkira/Napier
 {src="snippets/client-logging-napier/src/main/kotlin/com/example/Application.kt" include-symbol="main"}
 
 For the full example,
-see [client-logging-napier](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-logging-napier).
+see [client-logging-napier](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-logging-napier).

--- a/topics/client-request-retry.md
+++ b/topics/client-request-retry.md
@@ -53,7 +53,7 @@ val client = HttpClient(CIO) {
 
 ### Basic retry configuration {id="basic_config"}
 
-A [runnable example](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-retry) below shows how to configure the basic retry policy:
+A [runnable example](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-retry) below shows how to configure the basic retry policy:
 
 ```kotlin
 ```

--- a/topics/client-requests.md
+++ b/topics/client-requests.md
@@ -261,7 +261,7 @@ demonstrates its usage:
 * `url` specifies a URL for making a request.
 * `formParameters` is a set of form parameters built using `parameters`.
 
-For the full example, see [client-submit-form](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-submit-form).
+For the full example, see [client-submit-form](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-submit-form).
 
 > To send form parameters encoded in a URL, set `encodeInQuery` to `true`.
 
@@ -292,7 +292,7 @@ the file content is small enough to be safely read into memory using `.readBytes
 {src="snippets/client-upload/src/main/kotlin/com/example/Application.kt" include-lines="13-24"}
 
 For the full example,
-see [client-upload](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-upload).
+see [client-upload](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-upload).
 
 #### Using `MultiPartFormDataContent`
 
@@ -320,7 +320,7 @@ You can also construct a `MultiPartFormDataContent` with a custom boundary and c
 {src="snippets/client-upload-progress/src/main/kotlin/com/example/Application.kt" include-lines="54-58"}
 
 For the full example, see
-[client-upload-progress](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-upload-progress).
+[client-upload-progress](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-upload-progress).
 
 ### Binary data {id="binary"}
 
@@ -336,7 +336,7 @@ function to open a read channel for a file:
 {src="snippets/client-upload-binary-data/src/main/kotlin/com/example/Application.kt" include-lines="14-16"}
 
 For the full example, see
-[client-upload-binary-data](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-upload-binary-data).
+[client-upload-binary-data](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-upload-binary-data).
 
 ## Parallel requests {id="parallel_requests"}
 
@@ -352,7 +352,7 @@ functions. The following example demonstrates how to execute two requests in par
 {src="snippets/client-parallel-requests/src/main/kotlin/com/example/Application.kt" include-lines="12,19-23,28"}
 
 For the full example, see
-[client-parallel-requests](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-parallel-requests).
+[client-parallel-requests](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-parallel-requests).
 
 ## Cancel a request {id="cancel-request"}
 

--- a/topics/client-resources.md
+++ b/topics/client-resources.md
@@ -65,7 +65,7 @@ Let's summarize the examples above and create the `Articles` resource for CRUD o
 
 This resource can be used to list all articles, post a new article, edit it, and so on. We'll see how to [make type-safe requests](#make_requests) to this resource in the next section.
 
-> You can find the full example here: [client-type-safe-requests](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-type-safe-requests).
+> You can find the full example here: [client-type-safe-requests](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-type-safe-requests).
 
 
 ## Make type-safe requests {id="make_requests"}
@@ -95,4 +95,4 @@ The example below shows how to make typed requests to the `Articles` resource cr
 
 The [defaultRequest](client-default-request.md) function is used to specify a default URL for all requests.
 
-> You can find the full example here: [client-type-safe-requests](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-type-safe-requests).
+> You can find the full example here: [client-type-safe-requests](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-type-safe-requests).

--- a/topics/client-response-validation.md
+++ b/topics/client-response-validation.md
@@ -4,8 +4,8 @@
 
 <tldr>
 <p><b>Code examples</b>:
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-validate-2xx-response">client-validate-2xx-response</a>,
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-validate-non-2xx-response">client-validate-non-2xx-response</a>
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-validate-2xx-response">client-validate-2xx-response</a>,
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-validate-non-2xx-response">client-validate-non-2xx-response</a>
 </p>
 </tldr>
 
@@ -74,7 +74,7 @@ The `validateResponse {}` block inspects the response body and throws a custom e
 
 {src="snippets/client-validate-2xx-response/src/main/kotlin/com/example/Application.kt" include-lines="26-36"}
 
-> For the full example, see [client-validate-2xx-response](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-validate-2xx-response).
+> For the full example, see [client-validate-2xx-response](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-validate-2xx-response).
 > 
 {style="tip"}
 
@@ -91,6 +91,6 @@ default `ClientRequestException`:
 
 {src="snippets/client-validate-non-2xx-response/src/main/kotlin/com/example/Application.kt" include-lines="11-40"}
 
-> For the full example, see [client-validate-non-2xx-response](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-validate-non-2xx-response).
+> For the full example, see [client-validate-non-2xx-response](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-validate-non-2xx-response).
 > 
 {style="tip"}

--- a/topics/client-responses.md
+++ b/topics/client-responses.md
@@ -88,7 +88,7 @@ Similarly, you can get a body as a [`ByteArray`](https://kotlinlang.org/api/late
 ```
 {src="snippets/_misc_client/ResponseTypes.kt" include-lines="11,13"}
 
-A [runnable example](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-download-file)
+A [runnable example](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-download-file)
 below shows how to get a response as a `ByteArray` and save it to a file:
 
 ```kotlin
@@ -191,7 +191,7 @@ Using `ByteReadChannel.readRemaining()` retrieves all available bytes in the cha
 `Source.transferTo()` directly writes the data to the file, reducing unnecessary allocations.
 
 > For the full streaming example, see
-> [client-download-streaming](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-download-streaming).
+> [client-download-streaming](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-download-streaming).
 
 #### Writing the response directly to a file
 

--- a/topics/client-serialization.md
+++ b/topics/client-serialization.md
@@ -132,7 +132,7 @@ In the `json` constructor, you can access the [JsonBuilder](https://kotlinlang.o
 ```
 {src="snippets/client-json-kotlinx/src/main/kotlin/com/example/Application.kt" include-lines="24-31"}
 
-You can find the full example here: [client-json-kotlinx](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-json-kotlinx).
+You can find the full example here: [client-json-kotlinx](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-json-kotlinx).
 
 </tab>
 <tab title="Gson" group-key="gson">
@@ -311,4 +311,4 @@ When a server sends a [response](client-responses.md) with the `application/json
 ```
 {src="snippets/client-json-kotlinx/src/main/kotlin/com/example/Application.kt" include-lines="39"}
 
-You can find the full example here: [client-json-kotlinx](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-json-kotlinx).
+You can find the full example here: [client-json-kotlinx](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-json-kotlinx).

--- a/topics/client-server-sent-events.topic
+++ b/topics/client-server-sent-events.topic
@@ -226,7 +226,7 @@
             <code-block lang="kotlin" src="snippets/client-sse/src/main/kotlin/com.example/Application.kt"
                         include-lines="18-33,55-56"/>
             <p>For the full example, see
-                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-sse">client-sse</a>.
+                <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-sse">client-sse</a>.
             </p>
         </chapter>
         <chapter title="Deserialization" id="deserialization">
@@ -248,7 +248,7 @@
             <code-block lang="Kotlin" src="snippets/client-sse/src/main/kotlin/com.example/Application.kt"
                         include-lines="36-53"/>
             <p>For the full example, see
-                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-sse">client-sse</a>.
+                <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-sse">client-sse</a>.
             </p>
         </chapter>
     </chapter>

--- a/topics/client-ssl.md
+++ b/topics/client-ssl.md
@@ -26,7 +26,7 @@ Given that different engines use different [JSSE API](https://docs.oracle.com/en
 ## Configure SSL in Ktor {id="configure-ssl"}
 
 In this section, we'll see how to configure SSL for different engines.
-You can find the full example here: [client-ssl-config](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-ssl-config).
+You can find the full example here: [client-ssl-config](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-ssl-config).
 
 
 ### JVM {id="jvm"}
@@ -72,7 +72,7 @@ In our example, a `TrustManager` instance is used to configure a certificate:
 ```
 {src="snippets/client-ssl-config/src/main/kotlin/com/example/Application.kt" include-lines="39-45"}
 
-> The [sockets-client-tls](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/sockets-client-tls) example shows how to trust all certificates.
+> The [sockets-client-tls](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/sockets-client-tls) example shows how to trust all certificates.
 > This approach should be used for development purposes only.
 
 

--- a/topics/client-testing.md
+++ b/topics/client-testing.md
@@ -62,4 +62,4 @@ Then, you can pass the created `MockEngine` to initialize `ApiClient` and make r
 ```
 {src="snippets/client-testing-mock/src/test/kotlin/ApplicationTest.kt" include-lines="10-26"}
 
-You can find the full example here: [client-testing-mock](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-testing-mock).
+You can find the full example here: [client-testing-mock](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-testing-mock).

--- a/topics/client-websocket-serialization.md
+++ b/topics/client-websocket-serialization.md
@@ -133,4 +133,4 @@ To receive and convert a content of a text frame, call the `receiveDeserialized`
 
 To receive deserialized frames from the [incoming](client-websockets.topic#incoming) channel, use the [WebsocketContentConverter.deserialize](https://api.ktor.io/ktor-serialization/io.ktor.serialization/-websocket-content-converter/deserialize.html) function. `WebsocketContentConverter` is available via the `DefaultClientWebSocketSession.converter` property.
 
-> You can find the full example here: [client-websockets-serialization](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-websockets-serialization).
+> You can find the full example here: [client-websockets-serialization](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-websockets-serialization).

--- a/topics/client-websockets.topic
+++ b/topics/client-websockets.topic
@@ -189,7 +189,7 @@
             </code-block>
             <p>For the full example,
                 see
-                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-websockets">client-websockets</a>.
+                <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-websockets">client-websockets</a>.
             </p>
         </chapter>
     </chapter>

--- a/topics/db-connection-pooling-caching.md
+++ b/topics/db-connection-pooling-caching.md
@@ -173,4 +173,4 @@ Let's create an instance of `DAOFacadeCacheImpl` and add a sample article to be 
    And that's it. 
    You can now [run the application](db-persistence.md#run_app) and make sure everything works as before.
 
-> You can find the complete example with connection pooling and caching here: [tutorial-website-interactive-persistence-advanced](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/tutorial-website-interactive-persistence-advanced).
+> You can find the complete example with connection pooling and caching here: [tutorial-website-interactive-persistence-advanced](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/tutorial-website-interactive-persistence-advanced).

--- a/topics/db-persistence.md
+++ b/topics/db-persistence.md
@@ -229,7 +229,7 @@ Finally, go to the `post("{id}")` handler and use `dao.editArticle` to update an
 ```
 {src="snippets/tutorial-website-interactive-persistence/src/main/kotlin/com/example/plugins/Routing.kt" include-lines="43-58"}
 
-> You can find the resulting project for this tutorial here: [tutorial-website-interactive-persistence](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/tutorial-website-interactive-persistence).
+> You can find the resulting project for this tutorial here: [tutorial-website-interactive-persistence](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/tutorial-website-interactive-persistence).
 
 
 ## Run the application {id="run_app"}

--- a/topics/docker-compose.topic
+++ b/topics/docker-compose.topic
@@ -9,12 +9,12 @@
         <p>
             <control>Initial project</control>
             : <a
-                href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/tutorial-server-db-integration">tutorial-server-db-integration</a>
+                href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/tutorial-server-db-integration">tutorial-server-db-integration</a>
         </p>
         <p>
             <control>Final project</control>
             : <a
-                href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/tutorial-server-docker-compose">tutorial-server-docker-compose</a>
+                href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/tutorial-server-docker-compose">tutorial-server-docker-compose</a>
         </p>
     </tldr>
     <p>In this topic, we'll show you how to run a server Ktor application under

--- a/topics/elastic-beanstalk.md
+++ b/topics/elastic-beanstalk.md
@@ -4,17 +4,17 @@
 
 <tldr>
 <p>
-<control>Initial project</control>: <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/embedded-server">embedded-server</a> or 
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main">engine-main</a>
+<control>Initial project</control>: <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server">embedded-server</a> or 
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main">engine-main</a>
 </p>
 <p>
-<control>Final project</control>: <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/aws-elastic-beanstalk">aws-elastic-beanstalk</a>
+<control>Final project</control>: <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/aws-elastic-beanstalk">aws-elastic-beanstalk</a>
 </p>
 </tldr>
 
 In this tutorial, we'll show you how to prepare and deploy a Ktor application to AWS Elastic Beanstalk. You can use one of the following initial projects depending on the way used to [create a Ktor server](server-create-and-configure.topic):
-* [embedded-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/embedded-server)
-* [engine-main](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main)
+* [embedded-server](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server)
+* [engine-main](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main)
 
 > Learn more about deploying Java applications from [Elastic Beanstalk docs](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create_deploy_Java.html).
 
@@ -26,15 +26,15 @@ Before starting this tutorial, you need to create an AWS account.
 ## Clone a sample application {id="clone"}
 To open a sample application, follow the steps below:
 
-1. Clone a Ktor documentation repository and open the [codeSnippets](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets) project.
-2. Open the [embedded-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/embedded-server) or [engine-main](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main) sample. These samples demonstrate different approaches to [creating and configuring a Ktor server](server-create-and-configure.topic): in code or by using a configuration file. The only difference in deploying these projects is how to [specify a port](#port) used to listen for incoming requests.
+1. Clone a Ktor documentation repository and open the [codeSnippets](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets) project.
+2. Open the [embedded-server](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server) or [engine-main](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main) sample. These samples demonstrate different approaches to [creating and configuring a Ktor server](server-create-and-configure.topic): in code or by using a configuration file. The only difference in deploying these projects is how to [specify a port](#port) used to listen for incoming requests.
 
 ## Prepare an application {id="prepare-app"}
 
 ### Step 1: Configure a port {id="port"}
 
 First, you need to specify a port used to listen for incoming requests. Elastic Beanstalk forwards requests to your application on port 5000. Optionally, you can override the default port by setting the `PORT` environment variable. Depending on the way used to [configure a Ktor server](server-create-and-configure.topic), you can configure a port in one of the following ways:
-* If you've chosen the [embedded-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/embedded-server) sample with server configuration specified in code, you can obtain the environment variable value using `System.getenv` or use the default _5000_ value in a case an environment variable is not specified. Open the `Application.kt` file placed in the `src/main/kotlin/com/example` folder and change the `port` parameter value of the `embeddedServer` function as shown below:
+* If you've chosen the [embedded-server](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server) sample with server configuration specified in code, you can obtain the environment variable value using `System.getenv` or use the default _5000_ value in a case an environment variable is not specified. Open the `Application.kt` file placed in the `src/main/kotlin/com/example` folder and change the `port` parameter value of the `embeddedServer` function as shown below:
    ```kotlin
    fun main() {
       embeddedServer(Netty, port = (System.getenv("PORT")?:"5000").toInt()) {
@@ -43,7 +43,7 @@ First, you need to specify a port used to listen for incoming requests. Elastic 
    }
     ```
 
-* If you've chosen the [engine-main](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main) sample with server configuration specified in the `application.conf` file, you can assign the environment variable to the `port` parameter by using the `${ENV}` syntax. Open the `application.conf` file placed in `src/main/resources` and update it as shown below:
+* If you've chosen the [engine-main](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main) sample with server configuration specified in the `application.conf` file, you can assign the environment variable to the `port` parameter by using the `${ENV}` syntax. Open the `application.conf` file placed in `src/main/resources` and update it as shown below:
    ```
    ```
   {src="snippets/aws-elastic-beanstalk/src/main/resources/application.conf" include-lines="1-5,9" style="block"}

--- a/topics/google-app-engine.md
+++ b/topics/google-app-engine.md
@@ -4,10 +4,10 @@
 
 <tldr>
 <p>
-<control>Initial project</control>: <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main">engine-main</a>
+<control>Initial project</control>: <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main">engine-main</a>
 </p>
 <p>
-<control>Final project</control>: <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/google-appengine-standard">google-appengine-standard</a>
+<control>Final project</control>: <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/google-appengine-standard">google-appengine-standard</a>
 </p>
 </tldr>
 
@@ -19,7 +19,7 @@ This tutorial shows how to prepare and deploy a Ktor project to a Google App Eng
 Learn how to deploy your project to a Google App Engine standard environment.
 </link-summary>
 
-In this tutorial, we'll show you how to prepare and deploy a Ktor project to a Google App Engine standard environment. This tutorial uses the [engine-main](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main) sample project as a starting project.
+In this tutorial, we'll show you how to prepare and deploy a Ktor project to a Google App Engine standard environment. This tutorial uses the [engine-main](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main) sample project as a starting project.
 
 
 
@@ -34,8 +34,8 @@ Before starting this tutorial, you need to perform the steps below:
 
 ## Clone a sample application {id="clone"}
 To open a sample application, follow the steps below:
-1. Clone a Ktor documentation repository and open the [codeSnippets](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets) project.
-2. Open the [engine-main](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main) module.
+1. Clone a Ktor documentation repository and open the [codeSnippets](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets) project.
+2. Open the [engine-main](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main) module.
    > Note that Ktor provides two approaches to [create and configure a server](server-create-and-configure.topic): in code or by using a configuration file. In this tutorial, deploying process is the same for both approaches.
 
 ## Prepare an application {id="prepare-app"}
@@ -105,4 +105,4 @@ To deploy the application, open the terminal and follow the steps below:
    >
    {type="note"}
 
-You can find the completed example here: [google-appengine-standard](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/google-appengine-standard).
+You can find the completed example here: [google-appengine-standard](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/google-appengine-standard).

--- a/topics/lib.topic
+++ b/topics/lib.topic
@@ -294,7 +294,7 @@
     <snippet id="download_example">
         <p>
             <b>Code example</b>:
-            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/%example_name%">
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
                 %example_name%
             </a>
         </p>

--- a/topics/maven-assembly-plugin.md
+++ b/topics/maven-assembly-plugin.md
@@ -2,7 +2,7 @@
 
 <tldr>
 <p>
-<control>Sample project</control>: <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/tutorial-server-get-started-maven">tutorial-server-get-started-maven</a>
+<control>Sample project</control>: <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/tutorial-server-get-started-maven">tutorial-server-get-started-maven</a>
 </p>
 </tldr>
 

--- a/topics/migrating-3.md
+++ b/topics/migrating-3.md
@@ -640,7 +640,7 @@ This approach transfers data directly from the channel to the file's sink, minim
 allocations and improving performance.
 
 For the full example,
-see [client-download-streaming](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-download-streaming).
+see [client-download-streaming](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-download-streaming).
 
 > For more details on API replacements, refer to the
 > [`kotlinx-io` documentation](https://kotlinlang.org/api/kotlinx-io/).

--- a/topics/migration-from-express-js.topic
+++ b/topics/migration-from-express-js.topic
@@ -13,8 +13,8 @@
     <tldr>
         <p>
             <b>Code examples</b>:
-            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express">migrating-express</a>
-            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor">migrating-express-ktor</a>
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express">migrating-express</a>
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor">migrating-express-ktor</a>
         </p>
     </tldr>
     <p>
@@ -110,7 +110,7 @@
                     <code-block lang="javascript" src="snippets/migrating-express/1_hello/app.js"/>
                     <p>
                         For the full example, see the
-                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/1_hello/app.js">1_hello</a>
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/1_hello/app.js">1_hello</a>
                         project.
                     </p>
                 </td>
@@ -129,7 +129,7 @@
                                 include-lines="3-17"/>
                     <p>
                         For the full example, see the
-                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/1_hello/src/main/kotlin/com/example/Application.kt">1_hello</a>
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/1_hello/src/main/kotlin/com/example/Application.kt">1_hello</a>
                         project.
                     </p>
                     <p>
@@ -204,7 +204,7 @@
                     <code-block lang="javascript" src="snippets/migrating-express/2_static/app.js"/>
                     <p>
                         For the full example, see the
-                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/2_static/app.js">2_static</a>
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/2_static/app.js">2_static</a>
                         project.
                     </p>
                 </td>
@@ -230,7 +230,7 @@
                                 include-lines="3-15"/>
                     <p>
                         For the full example, see the <a
-                            href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/2_static/src/main/kotlin/com/example/Application.kt">2_static</a>
+                            href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/2_static/src/main/kotlin/com/example/Application.kt">2_static</a>
                         project.
                     </p>
                 </td>
@@ -294,7 +294,7 @@
                                 include-lines="7-13"/>
                     <p>
                         For the full example, see the
-                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
                         project.
                     </p>
                 </td>
@@ -316,7 +316,7 @@
                     </tip>
                     <p>
                         For the full example, see the
-                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
                         project.
                     </p>
                 </td>
@@ -342,7 +342,7 @@
                                 include-lines="16-25"/>
                     <p>
                         For the full example, see the
-                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
                         project.
                     </p>
                 </td>
@@ -361,7 +361,7 @@
                                 include-lines="12,22-32,36"/>
                     <p>
                         For the full example, see the
-                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
                         project.
                     </p>
                 </td>
@@ -397,7 +397,7 @@
                     </tabs>
                     <p>
                         For the full example, see the
-                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
                         project.
                     </p>
                 </td>
@@ -432,7 +432,7 @@
                     </tabs>
                     <p>
                         For the full example, see the
-                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
                         project.
                     </p>
                 </td>
@@ -472,7 +472,7 @@
                                 include-lines="6-12"/>
                     <p>
                         For the full example, see the
-                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a>
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a>
                         project.
                     </p>
                 </td>
@@ -491,7 +491,7 @@
                                 include-lines="11-18,24"/>
                     <p>
                         For the full example, see the
-                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a>
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a>
                         project.
                     </p>
                 </td>
@@ -521,7 +521,7 @@
                                 include-lines="14-18"/>
                     <p>
                         For the full example, see the
-                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a>
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a>
                         project.
                     </p>
                 </td>
@@ -540,7 +540,7 @@
                                 include-lines="11,19-24"/>
                     <p>
                         For the full example, see the
-                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a>
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a>
                         project.
                     </p>
                 </td>
@@ -570,7 +570,7 @@
                                     include-lines="6-9"/>
                         <p>
                             For the full example, see the
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
                             project.
                         </p>
                     </td>
@@ -603,7 +603,7 @@
                                     include-lines="23-25"/>
                         <p>
                             For the full example, see the
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
                             project.
                         </p>
                     </td>
@@ -625,7 +625,7 @@
                                     include-lines="2,10-13"/>
                         <p>
                             For the full example, see the
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
                             project.
                         </p>
                     </td>
@@ -643,7 +643,7 @@
                                     include-lines="26-29"/>
                         <p>
                             For the full example, see the
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
                             project.
                         </p>
                     </td>
@@ -676,7 +676,7 @@
                                     include-lines="15-17"/>
                         <p>
                             For the full example, see the
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
                             project.
                         </p>
                     </td>
@@ -696,7 +696,7 @@
                                     include-lines="30-38"/>
                         <p>
                             For the full example, see the
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
                             project.
                         </p>
                     </td>
@@ -718,7 +718,7 @@
                                     include-lines="19-25"/>
                         <p>
                             For the full example, see the
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
                             project.
                         </p>
                     </td>
@@ -736,7 +736,7 @@
                                     include-lines="39-44"/>
                         <p>
                             For the full example, see the
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
                             project.
                         </p>
                     </td>
@@ -769,7 +769,7 @@
                                 include-lines="5-10"/>
                     <p>
                         For the full example, see the
-                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/6_templates/app.js">6_templates</a>
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/6_templates/app.js">6_templates</a>
                         project.
                     </p>
                 </td>
@@ -791,7 +791,7 @@
                                 include-lines="11-23"/>
                     <p>
                         For the full example, see the
-                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/6_templates/src/main/kotlin/com/example/Application.kt">6_templates</a>
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/6_templates/src/main/kotlin/com/example/Application.kt">6_templates</a>
                         project.
                     </p>
                 </td>
@@ -832,7 +832,7 @@
                                     include-lines="8-11"/>
                         <p>
                             For the full example, see the
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
                             project.
                         </p>
                     </td>
@@ -850,7 +850,7 @@
                                     include-lines="31-34"/>
                         <p>
                             For the full example, see the
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
                             project.
                         </p>
                     </td>
@@ -879,7 +879,7 @@
                                     include-lines="2,12-16"/>
                         <p>
                             For the full example, see the
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
                             project.
                         </p>
                     </td>
@@ -911,7 +911,7 @@
                                     include-lines="35-38"/>
                         <p>
                             For the full example, see the
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
                             project.
                         </p>
                     </td>
@@ -942,7 +942,7 @@
                                     include-lines="2,17-21"/>
                         <p>
                             For the full example, see the
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
                             project.
                         </p>
                     </td>
@@ -960,7 +960,7 @@
                                     include-lines="39-43"/>
                         <p>
                             For the full example, see the
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
                             project.
                         </p>
                     </td>
@@ -990,7 +990,7 @@
                                     include-lines="2-3,22-27"/>
                         <p>
                             For the full example, see the
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
                             project.
                         </p>
                     </td>
@@ -1009,7 +1009,7 @@
                                     include-lines="44-48"/>
                         <p>
                             For the full example, see the
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive
                                 request</a>
                             project.
                         </p>
@@ -1045,7 +1045,7 @@
                                     include-lines="4,28-40"/>
                         <p>
                             For the full example, see the
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
                             project.
                         </p>
                     </td>
@@ -1066,7 +1066,7 @@
                                     include-lines="49-75"/>
                         <p>
                             For the full example, see the
-                            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
+                            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
                             project.
                         </p>
                     </td>
@@ -1095,7 +1095,7 @@
                                 include-lines="1-13"/>
                     <p>
                         For the full example, see the
-                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express/8_middleware/app.js">8_middleware</a>
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/8_middleware/app.js">8_middleware</a>
                         project.
                     </p>
                 </td>
@@ -1115,7 +1115,7 @@
                                 include-lines="23-29"/>
                     <p>
                         For the full example, see the
-                        <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/migrating-express-ktor/8_middleware/src/main/kotlin/com/example/Application.kt">8_middleware</a>
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/8_middleware/src/main/kotlin/com/example/Application.kt">8_middleware</a>
                         project.
                     </p>
                 </td>

--- a/topics/server-auth.md
+++ b/topics/server-auth.md
@@ -220,7 +220,7 @@ function. This function accepts two optional parameters:
    ```
 
 > For the full example, see
-> [auth-form-session-nested](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-form-session-nested).
+> [auth-form-session-nested](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/auth-form-session-nested).
 
 
 

--- a/topics/server-auto-reload.topic
+++ b/topics/server-auto-reload.topic
@@ -9,8 +9,8 @@
     <tldr>
         <p>
             <b>Code examples</b>:
-            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/autoreload-engine-main">autoreload-engine-main</a>,
-            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/autoreload-embedded-server">autoreload-embedded-server</a>
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/autoreload-engine-main">autoreload-engine-main</a>,
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/autoreload-embedded-server">autoreload-embedded-server</a>
         </p>
     </tldr>
 
@@ -177,7 +177,7 @@
                 </tabs>
 
                 <p>
-                    You can find the full example here: <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/autoreload-engine-main">autoreload-engine-main</a>.
+                    You can find the full example here: <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/autoreload-engine-main">autoreload-engine-main</a>.
                 </p>
             </li>
             <li>
@@ -190,7 +190,7 @@
                             include-lines="9-20"/>
                 <p>
                     For the full example, see
-                    <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/autoreload-embedded-server">
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/autoreload-embedded-server">
                         autoreload-embedded-server
                     </a>
                     .

--- a/topics/server-basic-auth.md
+++ b/topics/server-basic-auth.md
@@ -9,7 +9,7 @@
 <b>Required dependencies</b>: <code>io.ktor:%artifact_name%</code>
 </p>
 <p>
-<b>Code examples</b>: <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-basic">auth-basic</a>, <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-basic-hash-table">auth-basic-hash-table</a>
+<b>Code examples</b>: <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/auth-basic">auth-basic</a>, <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/auth-basic-hash-table">auth-basic-hash-table</a>
 </p>
 <include from="lib.topic" element-id="native_server_supported"/>
 </tldr>

--- a/topics/server-caching-headers.md
+++ b/topics/server-caching-headers.md
@@ -33,7 +33,7 @@ The [CachingHeaders](https://api.ktor.io/ktor-server-caching-headers/io.ktor.ser
 After installing `%plugin_name%`, you can [configure](#configure) caching settings for various content types.
 
 ## Configure caching {id="configure"}
-To configure the `%plugin_name%` plugin, you need to define the [options](https://api.ktor.io/ktor-server-caching-headers/io.ktor.server.plugins.cachingheaders/-caching-headers-config/options.html) function to provide specified caching options for a given `ApplicationCall` and content type. The code snippet from the [caching-headers](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/caching-headers) example shows how to add the `Cache-Control` header with the `max-age` option for a plain text and HTML:
+To configure the `%plugin_name%` plugin, you need to define the [options](https://api.ktor.io/ktor-server-caching-headers/io.ktor.server.plugins.cachingheaders/-caching-headers-config/options.html) function to provide specified caching options for a given `ApplicationCall` and content type. The code snippet from the [caching-headers](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/caching-headers) example shows how to add the `Cache-Control` header with the `max-age` option for a plain text and HTML:
 
 ```kotlin
 ```

--- a/topics/server-call-id.md
+++ b/topics/server-call-id.md
@@ -98,7 +98,7 @@ This means that call IDs containing capital letters won't pass verification. If 
 ```
 {src="snippets/call-id/src/main/kotlin/com/example/Application.kt" include-lines="13,15-18"}
 
-You can find the full example here: [call-id](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/call-id).
+You can find the full example here: [call-id](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/call-id).
 
 
 
@@ -112,7 +112,7 @@ After [retrieving](#retrieve)/[generating](#generate) a call ID, you can send it
    ```
   {src="snippets/call-id/src/main/kotlin/com/example/Application.kt" include-lines="13-14,18"}
 
-  You can find the full example here: [call-id](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/call-id).
+  You can find the full example here: [call-id](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/call-id).
 
 * The `replyToHeader` function sends a call ID in the specified header:
    ```kotlin
@@ -142,4 +142,4 @@ This key can be passed to a [logger configuration](server-logging.md#configure-l
 ```
 {style="block" src="snippets/call-id/src/main/resources/logback.xml" include-lines="2-6"}
 
-You can find the full example here: [call-id](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/call-id).
+You can find the full example here: [call-id](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/call-id).

--- a/topics/server-call-logging.md
+++ b/topics/server-call-logging.md
@@ -66,7 +66,7 @@ how to log a response status, a request HTTP method, and the `User-Agent` header
 {src="snippets/logging/src/main/kotlin/com/example/Application.kt" include-lines="14,19-25"}
 
 You can find the full example
-here: [logging](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/logging).
+here: [logging](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/logging).
 
 ### Put call parameters in MDC {id="mdc"}
 

--- a/topics/server-compression.md
+++ b/topics/server-compression.md
@@ -99,7 +99,7 @@ all text subtypes using `deflate`:
 {src="snippets/compression/src/main/kotlin/compression/Application.kt" include-lines="12-13,15-19,21-25"}
 
 You can find the full example
-here: [compression](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/compression).
+here: [compression](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/compression).
 
 ### Configure response size {id="configure_response_size"}
 

--- a/topics/server-conditional-headers.md
+++ b/topics/server-conditional-headers.md
@@ -39,4 +39,4 @@ The code snippet below shows how to add a `Etag` and `Last-Modified` headers for
 ```
 {src="snippets/conditional-headers/src/main/kotlin/com/example/Application.kt" include-lines="16-27"}
 
-You can find the full example here: [conditional-headers](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/conditional-headers).
+You can find the full example here: [conditional-headers](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/conditional-headers).

--- a/topics/server-configuration-code.topic
+++ b/topics/server-configuration-code.topic
@@ -205,7 +205,7 @@
 
         <p>
             For the complete example, see
-            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/embedded-server-multiple-connectors">
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server-multiple-connectors">
                 embedded-server-multiple-connectors
             </a>.
         </p>

--- a/topics/server-configuration-file.topic
+++ b/topics/server-configuration-file.topic
@@ -605,7 +605,7 @@
                     include-lines="3-6,9-20"/>
         <p>
             You can find the full example here:
-            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main-custom-environment">
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main-custom-environment">
                 engine-main-custom-environment
             </a>.
         </p>

--- a/topics/server-cors.md
+++ b/topics/server-cors.md
@@ -61,7 +61,7 @@ To allow such a request on the backend side, you need to configure the `CORS` pl
 {src="snippets/cors/src/main/kotlin/com/example/Application.kt" include-lines="47-50"}
 
 You can find the full example
-here: [cors](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/cors).
+here: [cors](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/cors).
 
 ### Hosts {id="hosts"}
 

--- a/topics/server-create-and-configure.topic
+++ b/topics/server-create-and-configure.topic
@@ -11,9 +11,9 @@
     <tldr>
         <p>
             <b>Code examples</b>:
-            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/embedded-server">embedded-server</a>,
-            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main">engine-main</a>,
-            <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main-yaml">engine-main-yaml</a>
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server">embedded-server</a>,
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main">engine-main</a>,
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main-yaml">engine-main-yaml</a>
         </p>
     </tldr>
 
@@ -102,7 +102,7 @@
             />
             <p>
                 For the full example, see
-                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/embedded-server">
+                <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server">
                     embedded-server
                 </a>
                 .
@@ -143,11 +143,11 @@
             </note>
             <p>
                 For the full examples, see
-                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main">
+                <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main">
                     engine-main
                 </a>
                 and
-                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main-yaml">
+                <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main-yaml">
                     engine-main-yaml
                 </a>
                 .

--- a/topics/server-css-dsl.md
+++ b/topics/server-css-dsl.md
@@ -51,4 +51,4 @@ Finally, you can use the specified CSS for an HTML document created with [HTML D
 ```
 {src="snippets/css-dsl/src/main/kotlin/com/example/Application.kt" include-lines="13-24"}
 
-You can find the full example here: [css-dsl](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/css-dsl).
+You can find the full example here: [css-dsl](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/css-dsl).

--- a/topics/server-data-conversion.md
+++ b/topics/server-data-conversion.md
@@ -95,4 +95,4 @@ The conversion service can then be called manually to retrieve the encoded and d
 {src="snippets/data-conversion/src/main/kotlin/dataconversion/Application.kt" include-lines="38-39"}
 
 For the full example,
-see [%example_name%](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/%example_name%)
+see [%example_name%](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%)

--- a/topics/server-double-receive.md
+++ b/topics/server-double-receive.md
@@ -46,7 +46,7 @@ For example, you can enable logging of a request body using the [CallLogging](se
 ```
 {src="snippets/double-receive/src/main/kotlin/com/example/Application.kt" include-lines="25-28"}
 
-You can find the full example here: [double-receive](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/double-receive).
+You can find the full example here: [double-receive](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/double-receive).
 
 
 ## Configure %plugin_name% {id="configure"}

--- a/topics/server-events.md
+++ b/topics/server-events.md
@@ -73,7 +73,7 @@ In this example, you can see how to handle the `ApplicationStopped` event:
 
 {src="snippets/events/src/main/kotlin/com/example/Application.kt" include-lines="11,16-21,30"}
 
-For the full example, see [events](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/events).
+For the full example, see [events](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/events).
 
 ## Handle events in a custom plugin {id="handle-events-plugin"}
 
@@ -87,7 +87,7 @@ and `ApplicationStopped` events:
 {src="snippets/events/src/main/kotlin/com/example/plugins/ApplicationMonitoringPlugin.kt" include-lines="3-17,23"}
 
 You can find the full example
-here: [events](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/events).
+here: [events](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/events).
 
 ## Custom events {id="custom-events"}
 
@@ -120,4 +120,4 @@ status code for a resource.
    ```
    {src="snippets/events/src/main/kotlin/com/example/Application.kt" include-lines="11-12,22-24,30"}
 
-For the full example, see [events](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/events).
+For the full example, see [events](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/events).

--- a/topics/server-fatjar.md
+++ b/topics/server-fatjar.md
@@ -43,4 +43,4 @@ The Ktor plugin provides the following tasks for creating and running fat JARs:
 - `buildFatJar`: builds a combined JAR of a project and runtime dependencies. You should see the `***-all.jar` file in the `build/libs` directory when this build completes.
 - `runFatJar`: builds a fat JAR of a project and runs it.
 
-> To learn how to minimize the generated JAR using ProGuard, refer to the [proguard](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/proguard) sample.
+> To learn how to minimize the generated JAR using ProGuard, refer to the [proguard](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/proguard) sample.

--- a/topics/server-form-based-auth.md
+++ b/topics/server-form-based-auth.md
@@ -10,8 +10,8 @@
 </p>
 <p>
 <b>Code examples</b>:
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-form-html-dsl">auth-form-html-dsl</a>,
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-form-session">auth-form-session</a>
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/auth-form-html-dsl">auth-form-html-dsl</a>,
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/auth-form-session">auth-form-session</a>
 </p>
 <include from="lib.topic" element-id="native_server_supported"/>
 </tldr>

--- a/topics/server-forward-headers.md
+++ b/topics/server-forward-headers.md
@@ -93,7 +93,7 @@ The table below shows the values of different properties exposed by `call.reques
 | `origin.remoteHost`    | _proxy_                  | _client_              |
 | `origin.remotePort`    | _32864_                  | _32864_               |
 
-> You can find the full example here: [forwarded-header](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/forwarded-header).
+> You can find the full example here: [forwarded-header](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/forwarded-header).
 
 
 ## Configure ForwardedHeaders {id="configure"}

--- a/topics/server-hsts.md
+++ b/topics/server-hsts.md
@@ -45,4 +45,4 @@ You can also provide different HSTS configurations for different hosts using `wi
 ```
 {src="snippets/ssl-engine-main-hsts/src/main/kotlin/com/example/Application.kt" include-lines="11-17"}
 
-You can find the full example here: [ssl-engine-main-hsts](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/ssl-engine-main-hsts).
+You can find the full example here: [ssl-engine-main-hsts](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/ssl-engine-main-hsts).

--- a/topics/server-html-dsl.md
+++ b/topics/server-html-dsl.md
@@ -74,7 +74,7 @@ The following example shows how to respond with an HTML form used to collect [cr
 </tab>
 </tabs>
 
-For the full example, see [auth-form-html-dsl](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-form-html-dsl).
+For the full example, see [auth-form-html-dsl](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/auth-form-html-dsl).
 
 > To learn more about receiving form parameters on the server side, see [](server-requests.md#form_parameters).
 > 
@@ -125,7 +125,7 @@ In addition to generating plain HTML, Ktor provides a template engine that can b
     
 
 ### Example {id="example"}
-Let's see on the [example](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/html-templates) of how to create a hierarchical layout using templates. Imagine we have the following HTML:
+Let's see on the [example](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/html-templates) of how to create a hierarchical layout using templates. Imagine we have the following HTML:
 ```html
 <body>
 <h1>Ktor</h1>
@@ -184,4 +184,4 @@ Let's implement these layouts step-by-step:
    ```
    {src="snippets/html-templates/src/main/kotlin/com/example/Application.kt" include-lines="12-30"}
 
-You can find the full example here: [html-templates](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/html-templates).
+You can find the full example here: [html-templates](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/html-templates).

--- a/topics/server-http-request-lifecycle.md
+++ b/topics/server-http-request-lifecycle.md
@@ -56,7 +56,7 @@ work:
 > [Coroutine cancellation](https://kotlinlang.org/docs/cancellation-and-timeouts.html).
 {style="note"}
 
-> For the full example, see [%example_name%](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/%example_name%).
+> For the full example, see [%example_name%](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%).
 
 ## Limitations
 

--- a/topics/server-http2.md
+++ b/topics/server-http2.md
@@ -4,7 +4,7 @@
 
 <tldr>
 <p>
-<b>Code examples</b>: <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/http2-netty">http2-netty</a>, <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/http2-jetty">http2-jetty</a>
+<b>Code examples</b>: <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/http2-netty">http2-netty</a>, <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/http2-jetty">http2-jetty</a>
 </p>
 </tldr>
 
@@ -62,7 +62,7 @@ Since ALPN APIs are supported starting with Java 8, the Jetty engine doesn't req
 2. Add an SSL configuration as described in [](#ssl_certificate).
 3. Configure `sslPort`.
 
-The [http2-jetty](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/http2-jetty) runnable example demonstrates HTTP/2 support for Jetty.
+The [http2-jetty](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/http2-jetty) runnable example demonstrates HTTP/2 support for Jetty.
 
 ### Netty {id="netty"}
 
@@ -74,7 +74,7 @@ The example below shows how to add a native implementation (statically linked Bo
 {src="snippets/http2-netty/build.gradle.kts" include-lines="20-28,34-39"}
 
 `tc.native.classifier` should be one of the following: `linux-x86_64`, `osx-x86_64`, or `windows-x86_64`. 
-The [http2-netty](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/http2-netty) runnable example demonstrates how to enable HTTP/2 support for Netty.
+The [http2-netty](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/http2-netty) runnable example demonstrates how to enable HTTP/2 support for Netty.
 
 #### HTTP/2 without TLS
 

--- a/topics/server-https-redirect.md
+++ b/topics/server-https-redirect.md
@@ -41,4 +41,4 @@ The code snippet below shows how to configure the desired HTTPS port and return 
 ```
 {src="snippets/ssl-engine-main-redirect/src/main/kotlin/com/example/Application.kt" include-lines="11-14"}
 
-You can find the full example here: [ssl-engine-main-redirect](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/ssl-engine-main-redirect).
+You can find the full example here: [ssl-engine-main-redirect](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/ssl-engine-main-redirect).

--- a/topics/server-integrate-database.topic
+++ b/topics/server-integrate-database.topic
@@ -12,8 +12,8 @@
             <b>Used plugins</b>: <a href="server-routing.md"/>,<a href="server-static-content.md">Static Content</a>,
             <a href="server-serialization.md">Content Negotiation</a>, <a href="server-status-pages.md"/>,
             <a href="server-serialization.md">kotlinx.serialization</a>,
-            <a href="https://github.com/ktorio/ktor-plugin-registry/blob/main/plugins/server/org.jetbrains/exposed/2.2/documentation.md">Exposed</a>,
-            <a href="https://github.com/ktorio/ktor-plugin-registry/blob/main/plugins/server/org.jetbrains/postgres/2.2/documentation.md">Postgres</a>
+            <a href="https://github.com/ktorio/ktor-plugin-registry/tree/main/repository/org.jetbrains/server-exposed">Exposed</a>,
+            <a href="https://github.com/ktorio/ktor-plugin-registry/tree/main/repository/org.jetbrains/server-postgres">Postgres</a>
         </p>
     </tldr>
     <card-summary>

--- a/topics/server-jwt.md
+++ b/topics/server-jwt.md
@@ -11,8 +11,8 @@
 </p>
 <p>
 <b>Code examples</b>: 
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-jwt-hs256">auth-jwt-hs256</a>, 
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-jwt-rs256">auth-jwt-rs256</a>
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/auth-jwt-hs256">auth-jwt-hs256</a>, 
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/auth-jwt-rs256">auth-jwt-rs256</a>
 </p>
 <include from="lib.topic" element-id="native_server_not_supported"/>
 </tldr>
@@ -103,7 +103,7 @@ In this section, we'll see how to use JSON web tokens in a server Ktor applicati
 * Using `HS256` with a specified shared secret. 
 * Using `RS256` with a public/private key pair.
 
-You can find complete projects here: [auth-jwt-hs256](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-jwt-hs256), [auth-jwt-rs256](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-jwt-rs256).
+You can find complete projects here: [auth-jwt-hs256](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/auth-jwt-hs256), [auth-jwt-rs256](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/auth-jwt-rs256).
 
 ### Step 1: Configure JWT settings {id="jwt-settings"}
 

--- a/topics/server-ldap.md
+++ b/topics/server-ldap.md
@@ -108,6 +108,6 @@ After configuring LDAP, you can protect specific resources in our application us
 ```
 {src="snippets/auth-ldap/src/main/kotlin/com/example/Application.kt" include-lines="17-23"}
 
-You can find the complete runnable example here: [auth-ldap](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-ldap).
+You can find the complete runnable example here: [auth-ldap](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/auth-ldap).
 
 > Bear in mind that current LDAP implementation is synchronous.

--- a/topics/server-logging.md
+++ b/topics/server-logging.md
@@ -51,7 +51,7 @@ If you want to output logs to a file, you can use the `FILE` appender.
 ```
 {style="block" src="snippets/logging/src/main/resources/logback-fileAppender.xml"}
 
-You can find the full example here: [logging](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/logging).
+You can find the full example here: [logging](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/logging).
 
 
 

--- a/topics/server-method-override.md
+++ b/topics/server-method-override.md
@@ -53,5 +53,5 @@ To handle such requests using the `delete` [route handler](server-routing.md#def
 ```
 {src="snippets/json-kotlinx-method-override/src/main/kotlin/com/example/Application.kt"}
 
-You can find the full example here: [json-kotlinx-method-override](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/json-kotlinx-method-override).
+You can find the full example here: [json-kotlinx-method-override](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/json-kotlinx-method-override).
 

--- a/topics/server-metrics-dropwizard.md
+++ b/topics/server-metrics-dropwizard.md
@@ -52,7 +52,7 @@ For example, to output the metrics every 10 seconds, you would:
 ```
 {src="snippets/dropwizard-metrics/src/main/kotlin/com/example/MetricsApplication.kt" include-lines="12-18,25"}
 
-You can find the full example here: [dropwizard-metrics](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/dropwizard-metrics).
+You can find the full example here: [dropwizard-metrics](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/dropwizard-metrics).
 
 If you run the application and open [http://0.0.0.0:8080](http://0.0.0.0:8080), the output will look like this:
 
@@ -75,7 +75,7 @@ The JMX reporter allows you to expose all the metrics to JMX, allowing you to vi
 ```
 {src="snippets/dropwizard-metrics/src/main/kotlin/com/example/MetricsApplication.kt" include-lines="12,19-23,25"}
 
-You can find the full example here: [dropwizard-metrics](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/dropwizard-metrics).
+You can find the full example here: [dropwizard-metrics](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/dropwizard-metrics).
 
 If you run the application and connect to its process using the [JConsole](https://docs.oracle.com/en/java/javase/17/management/using-jconsole.html), metrics will look like this:
 
@@ -122,4 +122,4 @@ In addition to HTTP metrics, Ktor exposes a set of metrics for monitoring the JV
 ```
 {src="snippets/dropwizard-metrics/src/main/kotlin/com/example/MetricsApplication.kt" include-lines="12,24-25"}
 
-You can find the full example here: [dropwizard-metrics](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/dropwizard-metrics).
+You can find the full example here: [dropwizard-metrics](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/dropwizard-metrics).

--- a/topics/server-metrics-micrometer.md
+++ b/topics/server-metrics-micrometer.md
@@ -104,4 +104,4 @@ If you use Prometheus as a monitoring system, you need to expose an HTTP endpoin
    ```
    {src="snippets/micrometer-metrics/src/main/kotlin/com/example/Application.kt" include-lines="15-18,32-33,38-42"}
 
-   You can find the full example here: [micrometer-metrics](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/micrometer-metrics).
+   You can find the full example here: [micrometer-metrics](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/micrometer-metrics).

--- a/topics/server-modules.md
+++ b/topics/server-modules.md
@@ -3,8 +3,8 @@
 <tldr>
 <p>
 <b>Code examples</b>: 
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/embedded-server-modules">embedded-server-modules</a>, 
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main-modules">engine-main-modules</a>
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server-modules">embedded-server-modules</a>, 
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main-modules">engine-main-modules</a>
 </p>
 </tldr>
 
@@ -47,7 +47,7 @@ pass a reference to this module as the `module` parameter:
 ```
 {src="snippets/embedded-server-modules/src/main/kotlin/com/example/Application.kt"}
 
-You can find the full example here: [embedded-server-modules](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/embedded-server-modules).
+You can find the full example here: [embedded-server-modules](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server-modules).
 
 
 
@@ -94,7 +94,7 @@ A fully qualified module name includes a fully qualified name of the class and a
 </tab>
 </tabs>
 
-You can find the full example here: [engine-main-modules](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main-modules).
+You can find the full example here: [engine-main-modules](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main-modules).
 
 
 ## Module dependencies

--- a/topics/server-native.md
+++ b/topics/server-native.md
@@ -41,7 +41,7 @@ Specify the required native targets and [declare a native binary](https://kotlin
 ```
 {src="snippets/embedded-server-native/build.gradle.kts" include-lines="16-32"}
 
-You can find the full example here: [embedded-server-native](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/embedded-server-native).
+You can find the full example here: [embedded-server-native](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server-native).
 
 ## Create a server {id="create-server"}
 

--- a/topics/server-oauth.md
+++ b/topics/server-oauth.md
@@ -83,7 +83,7 @@ For example, to install an `oauth` provider with the name "auth-oauth-google" it
 
 This section demonstrates how to configure the `oauth` provider for authorizing users of your application using Google.
 For the complete runnable example,
-see [auth-oauth-google](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-oauth-google).
+see [auth-oauth-google](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/auth-oauth-google).
 
 ### Prerequisites: Create authorization credentials {id="authorization-credentials"}
 
@@ -197,4 +197,4 @@ Then, you can call the function within a `get` route to retrieve a user's inform
 {src="snippets/auth-oauth-google/src/main/kotlin/com/example/oauth/google/Application.kt" include-lines="104-110"}
 
 For the complete runnable example,
-see [auth-oauth-google](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-oauth-google). 
+see [auth-oauth-google](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/auth-oauth-google). 

--- a/topics/server-partial-content.md
+++ b/topics/server-partial-content.md
@@ -12,9 +12,9 @@
 </p>
 <p>
 <b>Server example</b>:
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/download-file">download-file</a>,
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/download-file">download-file</a>,
 <b>client example</b>:
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/client-download-file-range">client-download-file-range</a>
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-download-file-range">client-download-file-range</a>
 </p>
 <include from="lib.topic" element-id="native_server_supported"/>
 </tldr>

--- a/topics/server-plugins.md
+++ b/topics/server-plugins.md
@@ -96,7 +96,7 @@ install(Sessions) {
 
 ### Install Plugins to specific routes {id="install-route"}
 
-In Ktor, you can install plugins not only globally but also to specific [routes](server-routing.md). This might be useful if you need different plugin configurations for different application resources. For instance, the [example](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/caching-headers-routes) below shows how to add the specified [caching header](server-caching-headers.md) for the `/index` route:
+In Ktor, you can install plugins not only globally but also to specific [routes](server-routing.md). This might be useful if you need different plugin configurations for different application resources. For instance, the [example](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/caching-headers-routes) below shows how to add the specified [caching header](server-caching-headers.md) for the `/index` route:
 
 ```kotlin
 ```

--- a/topics/server-rate-limit.md
+++ b/topics/server-rate-limit.md
@@ -147,4 +147,4 @@ for which the `429 Too Many Requests` response was sent.
 {src="snippets/rate-limit/src/main/kotlin/com/example/Application.kt"}
 
 
-You can find the full example here: [rate-limit](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/rate-limit).
+You can find the full example here: [rate-limit](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/rate-limit).

--- a/topics/server-request-validation.md
+++ b/topics/server-request-validation.md
@@ -85,7 +85,7 @@ You can handle `RequestValidationException` using the [StatusPages](server-statu
 ```
 {src="snippets/request-validation/src/main/kotlin/com/example/Application.kt" include-lines="44-48"}
 
-You can find the full example here: [request-validation](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/request-validation).
+You can find the full example here: [request-validation](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/request-validation).
 
 
 ## Example: Validating object properties {id="example-object"}

--- a/topics/server-requests.md
+++ b/topics/server-requests.md
@@ -121,7 +121,7 @@ You can receive the body of this request as an object of the specified type in o
 >
 {style="tip"}
 
-> For the full example, see [post-raw-data](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/post-raw-data).
+> For the full example, see [post-raw-data](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/post-raw-data).
 
 
 ### Objects {id="objects"}
@@ -150,7 +150,7 @@ You can obtain parameter values in code as follows:
 ```
 {src="snippets/post-form-parameters/src/main/kotlin/formparameters/Application.kt" include-lines="12-16"}
 
-> For the full example, see [post-form-parameters](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/post-form-parameters).
+> For the full example, see [post-form-parameters](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/post-form-parameters).
 
 ### Multipart form data {id="form_data"}
 
@@ -225,4 +225,4 @@ Once the form processing is complete, each part is disposed of using the `.dispo
 {src="snippets/upload-file/src/main/kotlin/uploadfile/UploadFile.kt" include-lines="33"}
 
 > To learn how to run this sample, see
-> [upload-file](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/upload-file).
+> [upload-file](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/upload-file).

--- a/topics/server-resources.md
+++ b/topics/server-resources.md
@@ -108,7 +108,7 @@ Let's summarize the examples above and create the `Articles` resource for CRUD o
 
 This resource can be used to list all articles, post a new article, edit it, and so on. We'll see how to [define route handlers](#define_route) for this resource in the next chapter.
 
-> You can find the full example here: [resource-routing](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/resource-routing).
+> You can find the full example here: [resource-routing](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/resource-routing).
 
 
 
@@ -166,7 +166,7 @@ Here are several tips on handling requests for each endpoint:
 
    This route handler deletes an article with the specified identifier.
 
-You can find the full example here: [resource-routing](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/resource-routing).
+You can find the full example here: [resource-routing](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/resource-routing).
 
 
 ## Build links from resources {id="resource_links"}
@@ -209,4 +209,4 @@ The example below shows how to add links built from resources to the HTML respon
 ```
 {src="snippets/resource-routing/src/main/kotlin/resourcerouting/Application.kt" include-lines="62-87"}
 
-You can find the full example here: [resource-routing](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/resource-routing).
+You can find the full example here: [resource-routing](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/resource-routing).

--- a/topics/server-responses.md
+++ b/topics/server-responses.md
@@ -76,7 +76,7 @@ function to pass a data object in a response:
 ```
 {src="snippets/json-kotlinx/src/main/kotlin/jsonkotlinx/Application.kt" include-lines="32-36"}
 
-For the full example, see [json-kotlinx](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/json-kotlinx).
+For the full example, see [json-kotlinx](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/json-kotlinx).
 
 [//]: # (TODO: Check link for LocalPathFile)
 
@@ -102,7 +102,7 @@ Note that this sample uses two plugins:
 - [`AutoHeadResponse`](server-autoheadresponse.md) provides the ability to automatically respond to a ` HEAD ` request for every route that has a `GET` defined. This allows the client application to determine the file size by reading the `Content-Length` header value.
 
 For the full code sample,
-see [download-file](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/download-file).
+see [download-file](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/download-file).
 
 ### Resource
 

--- a/topics/server-routing.md
+++ b/topics/server-routing.md
@@ -295,7 +295,7 @@ fun Route.totalizeOrderRoute() {
 ```
 
 For the full example demonstrating this approach,
-see [legacy-interactive-website](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/legacy-interactive-website).
+see [legacy-interactive-website](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/legacy-interactive-website).
 
 > For our application to scale when it comes to maintainability, it is recommended to follow certain [structuring patterns](server-routing-organization.md).
 

--- a/topics/server-run.md
+++ b/topics/server-run.md
@@ -26,7 +26,7 @@ Running a Ktor application depends on the way you used to [create a server](serv
 ### Starting EngineMain: Gradle and Maven specifics {id="gradle-maven"}
 
 If you use `EngineMain` to create a server, you need to specify the `main` function for starting a server with the desired [engine](server-engines.md).
-The [example](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main) below demonstrates the `main` function used to run a server with the Netty engine:
+The [example](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main) below demonstrates the `main` function used to run a server with the Netty engine:
 
 ```kotlin
 ```

--- a/topics/server-serialization.md
+++ b/topics/server-serialization.md
@@ -320,7 +320,7 @@ The `Content-Type` of the request will be used to choose a [serializer](#configu
 
 
 
-You can find the full example here: [json-kotlinx](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/json-kotlinx).
+You can find the full example here: [json-kotlinx](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/json-kotlinx).
 
 ### Send data {id="send_data"}
 To pass a data object in a response, you can use the `respond` method:
@@ -328,7 +328,7 @@ To pass a data object in a response, you can use the `respond` method:
 ```
 {src="snippets/json-kotlinx/src/main/kotlin/jsonkotlinx/Application.kt" include-lines="32-36"}
 
-In this case, Ktor uses the `Accept` header to choose the required [serializer](#configure_serializer). You can find the full example here: [json-kotlinx](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/json-kotlinx).
+In this case, Ktor uses the `Accept` header to choose the required [serializer](#configure_serializer). You can find the full example here: [json-kotlinx](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/json-kotlinx).
 
 
 

--- a/topics/server-server-sent-events.topic
+++ b/topics/server-server-sent-events.topic
@@ -125,7 +125,7 @@
             <code-block lang="kotlin" src="snippets/server-sse/src/main/kotlin/com/example/Application.kt"
                         include-lines="23-30,53"/>
             <p>For the full example, see
-                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/server-sse">server-sse</a>.
+                <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/server-sse">server-sse</a>.
             </p>
         </chapter>
         <chapter title="SSE Heartbeat" id="heartbeat">
@@ -164,7 +164,7 @@
                 placed in the <code>data</code> field of a <code>ServerSentEvent</code>.
             </p>
             <p>For the full example, see
-                <a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/server-sse">server-sse</a>.
+                <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/server-sse">server-sse</a>.
             </p>
         </chapter>
     </chapter>

--- a/topics/server-serving-spa.md
+++ b/topics/server-serving-spa.md
@@ -88,4 +88,4 @@ To serve this application, the following configuration is used:
 - `defaultPage`: Specifies `main.html` as a default resource to serve.
 - `ignoreFiles`: Ignores paths that contain `.txt` at the end.
 
-You can find the full example here: [single-page-application](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/single-page-application).
+You can find the full example here: [single-page-application](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/single-page-application).

--- a/topics/server-session-auth.md
+++ b/topics/server-session-auth.md
@@ -63,7 +63,7 @@ information about this user to a cookie session, and then authorize this user on
 provider.
 
 > For the complete example, see
-> [auth-form-session](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-form-session).
+> [auth-form-session](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/auth-form-session).
 
 ### Step 1: Create a data class {id="data-class"}
 
@@ -135,4 +135,4 @@ using the `call.principal()` function inside a route handler:
 {src="snippets/auth-form-session/src/main/kotlin/com/example/Application.kt" include-lines="77-83"}
 
 > For the full example, see
-> [auth-form-session](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-form-session).
+> [auth-form-session](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/auth-form-session).

--- a/topics/server-sessions.md
+++ b/topics/server-sessions.md
@@ -12,9 +12,9 @@
 <b>Required dependencies</b>: <code>io.ktor:%artifact_name%</code>
 </p>
 <p><b>Code examples</b>:
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-cookie-client">session-cookie-client</a>,
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-cookie-server">session-cookie-server</a>,
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-header-server">session-header-server</a>
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/session-cookie-client">session-cookie-client</a>,
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/session-cookie-server">session-cookie-server</a>,
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/session-header-server">session-header-server</a>
 </p>
 <include from="lib.topic" element-id="native_server_supported"/>
 </tldr>
@@ -135,7 +135,7 @@ Ktor allows you to store session data [on the server](#client_server) and pass o
 ```
 {src="snippets/session-cookie-server/src/main/kotlin/com/example/Application.kt" include-lines="16,19"}
 
-You can find the full example here: [session-cookie-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-cookie-server).
+You can find the full example here: [session-cookie-server](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/session-cookie-server).
 
 > Note that `SessionStorageMemory` is intended for development only.
 
@@ -146,7 +146,7 @@ You can find the full example here: [session-cookie-server](https://github.com/k
 ```
 {src="snippets/session-header-server/src/main/kotlin/com/example/Application.kt" include-lines="17,19"}
 
-You can find the full example here: [session-header-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-header-server).
+You can find the full example here: [session-header-server](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/session-header-server).
 
 ### Custom storage {id="custom_storage"}
 
@@ -223,7 +223,7 @@ When you need to clear a session for any reason (for example, when a user logs o
 ```
 {src="snippets/session-cookie-client/src/main/kotlin/cookieclient/Application.kt" include-lines="39-42"}
 
-You can find the full example here: [session-cookie-client](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-cookie-client).
+You can find the full example here: [session-cookie-client](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/session-cookie-client).
 
 ## Deferred session retrieval
 
@@ -241,9 +241,9 @@ System.setProperty("io.ktor.server.sessions.deferred", "true")
 
 The runnable examples below demonstrate how to use the `%plugin_name%` plugin:
 
-- [session-cookie-client](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-cookie-client) shows how to pass [signed and encrypted](#sign_encrypt_session) session payload to the [client](#client_server) using [cookies](#cookie).
-- [session-cookie-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-cookie-server) shows how to keep session payload in a [server memory](#in_memory_storage) and pass a [signed](#sign_session) session ID to the client using [cookies](#cookie).
-- [session-header-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-header-server) shows how to keep session payload on a server in a [directory storage](#directory_storage) and pass [signed](#sign_session) session ID to the client using a [custom header](#header).
+- [session-cookie-client](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/session-cookie-client) shows how to pass [signed and encrypted](#sign_encrypt_session) session payload to the [client](#client_server) using [cookies](#cookie).
+- [session-cookie-server](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/session-cookie-server) shows how to keep session payload in a [server memory](#in_memory_storage) and pass a [signed](#sign_session) session ID to the client using [cookies](#cookie).
+- [session-header-server](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/session-header-server) shows how to keep session payload on a server in a [directory storage](#directory_storage) and pass [signed](#sign_session) session ID to the client using a [custom header](#header).
 
 
 

--- a/topics/server-shutdown-url.md
+++ b/topics/server-shutdown-url.md
@@ -49,4 +49,4 @@ the `install` function and use the `shutDownUrl` property:
 {src="snippets/shutdown-url/src/main/kotlin/com/example/Application.kt" include-lines="11-14"}
 
 For the full example,
-see [shutdown-url](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/shutdown-url).
+see [shutdown-url](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/shutdown-url).

--- a/topics/server-sockets.md
+++ b/topics/server-sockets.md
@@ -10,9 +10,9 @@
 <b>Required dependencies</b>: <code>io.ktor:ktor-network</code>, <code>io.ktor:ktor-network-tls</code>
 </p>
 <p><b>Code examples</b>:
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/sockets-server">sockets-server</a>,
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/sockets-client">sockets-client</a>,
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/sockets-client-tls">sockets-client-tls</a>
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/sockets-server">sockets-server</a>,
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/sockets-client">sockets-client</a>,
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/sockets-client-tls">sockets-client-tls</a>
 </p>
 <include from="lib.topic" element-id="native_server_supported"/>
 </tldr>
@@ -109,7 +109,7 @@ A code sample below demonstrates how to use sockets on the server side:
 ```
 {src="snippets/sockets-server/src/main/kotlin/com/example/Application.kt"}
 
-You can find the full example here: [sockets-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/sockets-server).
+You can find the full example here: [sockets-server](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/sockets-server).
 
 
 ## Client {id="client"}
@@ -142,7 +142,7 @@ The `tls` function allows you to adjust TLS parameters provided by [TLSConfigBui
 ```
 {src="snippets/sockets-client-tls/src/main/kotlin/com/example/Application.kt" include-lines="14-21"}
 
-You can find the full example here: [sockets-client-tls](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/sockets-client-tls).
+You can find the full example here: [sockets-client-tls](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/sockets-client-tls).
 
 
 ### Receive data {id="client_receive"}
@@ -193,4 +193,4 @@ A code sample below demonstrates how to use sockets on the client side:
 ```
 {src="snippets/sockets-client/src/main/kotlin/com/example/Application.kt"}
 
-You can find the full example here: [sockets-client](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/sockets-client).
+You can find the full example here: [sockets-client](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/sockets-client).

--- a/topics/server-ssl.md
+++ b/topics/server-ssl.md
@@ -9,8 +9,8 @@
 </p>
 <p>
 <b>Code examples</b>: 
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/ssl-engine-main">ssl-engine-main</a>, 
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/ssl-embedded-server">ssl-embedded-server</a>
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/ssl-engine-main">ssl-engine-main</a>, 
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/ssl-embedded-server">ssl-embedded-server</a>
 </p>
 </tldr>
 
@@ -49,7 +49,7 @@ The code snippet below shows how to generate a certificate and save it to a keys
 
 Since Ktor requires a certificate when it starts, you have to create a certificate before starting the server.
 You can find the full example
-here: [ssl-embedded-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/ssl-embedded-server).
+here: [ssl-embedded-server](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/ssl-embedded-server).
 
 ### Generate a certificate using keytool {id="self-signed-keytool"}
 
@@ -133,7 +133,7 @@ following [properties](server-configuration-file.topic#predefined-properties):
    </tabs>
 
 For the full example,
-see [ssl-engine-main](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/ssl-engine-main).
+see [ssl-engine-main](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/ssl-engine-main).
 
 ### embeddedServer {id="embedded-server"}
 
@@ -150,4 +150,4 @@ using [sslConnector](https://api.ktor.io/ktor-server-core/io.ktor.server.engine/
 {src="snippets/ssl-embedded-server/src/main/kotlin/com/example/Application.kt" include-lines="3-41"}
 
 For the full example,
-see [ssl-embedded-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/ssl-embedded-server).
+see [ssl-embedded-server](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/ssl-embedded-server).

--- a/topics/server-static-content.md
+++ b/topics/server-static-content.md
@@ -4,9 +4,9 @@
 
 <tldr>
 <p><b>Code examples</b>:
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/static-files">static-files</a>,
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/static-resources">static-resources</a>,
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/static-zip">static-zip</a>
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/static-files">static-files</a>,
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/static-resources">static-resources</a>,
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/static-zip">static-zip</a>
 </p>
 </tldr>
 
@@ -38,7 +38,7 @@ directory.
 Ktor recursively serves up any file from `files` as long as a URL path and a physical filename match.
 
 For the full example,
-see [static-files](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/static-files).
+see [static-files](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/static-files).
 
 ## ZIP files {id="zipped"}
 
@@ -60,7 +60,7 @@ directory, the ZIP file system is reloaded on the next request. This ensures tha
 up to date without requiring a server restart.
 
 For the full example,
-see [static-zip](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/static-zip).
+see [static-zip](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/static-zip).
 
 ## Resources {id="resources"}
 
@@ -78,7 +78,7 @@ In this case, Ktor recursively serves up any file from the `static` package as l
 match.
 
 For the full example,
-see [static-resources](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/static-resources).
+see [static-resources](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/static-resources).
 
 ## Additional configuration {id="configuration"}
 

--- a/topics/server-status-pages.md
+++ b/topics/server-status-pages.md
@@ -76,5 +76,5 @@ The `statusFile` handler allows you to serve HTML pages based on the status code
 
 The `statusFile` handler replaces any `#` character with the value of the status code within the list of configured statuses.
 
-> You can find the full example here: [status-pages](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/status-pages).
+> You can find the full example here: [status-pages](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/status-pages).
 

--- a/topics/server-testing.md
+++ b/topics/server-testing.md
@@ -65,7 +65,7 @@ The following example tests a simple Ktor application that responds to `GET /` r
 </tab>
 </tabs>
 
-> For the complete code example, see [engine-main](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main).
+> For the complete code example, see [engine-main](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main).
 
 ## Set up a JUnit test class {id="junit-test-class"}
 
@@ -174,7 +174,7 @@ The following example adds the `/login-test` endpoint used to initialize a user 
 ```
 {src="snippets/auth-oauth-google/src/test/kotlin/ApplicationTest.kt" include-lines="18,31-35,51"}
    
-> For a complete test example, see [auth-oauth-google](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-oauth-google).
+> For a complete test example, see [auth-oauth-google](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/auth-oauth-google).
 
 ### Customize the environment {id="environment"}
 
@@ -205,7 +205,7 @@ The following example simulates a JSON response from a Google API:
 ```
 {src="snippets/auth-oauth-google/src/test/kotlin/ApplicationTest.kt" include-lines="17-18,36-47,51"}
 
-> For the full test example, see [auth-oauth-google](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/auth-oauth-google).
+> For the full test example, see [auth-oauth-google](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/auth-oauth-google).
 
 ## Configure a client {id="configure-client"}
 
@@ -229,7 +229,7 @@ The following example tests the `/customer` endpoint that handles `POST` request
 ```
 {src="snippets/json-kotlinx/src/test/kotlin/jsonkotlinx/ApplicationTest.kt" include-lines="31-44,47"}
 
-> For the complete test example, see [json-kotlinx](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/json-kotlinx).
+> For the complete test example, see [json-kotlinx](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/json-kotlinx).
 
 ## Assert results {id="assert"}
 
@@ -271,7 +271,7 @@ function:
 </tab>
 </tabs>
 
-> For the full code example, see [post-form-parameters](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/post-form-parameters).
+> For the full code example, see [post-form-parameters](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/post-form-parameters).
 
 #### Multipart form data {id="multipart-form-data"}
 
@@ -295,7 +295,7 @@ You can use the `multipart/form-data` content type to build multipart form data 
 </tab>
 </tabs>
 
-> For the full code example, see [upload-file](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/upload-file).
+> For the full code example, see [upload-file](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/upload-file).
 
 ### Send JSON data {id="json-data"}
 
@@ -323,7 +323,7 @@ using the `setBody()` function.
 </tab>
 </tabs>
 
-> For the full example, see [json-kotlinx](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/json-kotlinx).
+> For the full example, see [json-kotlinx](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/json-kotlinx).
 
 ## Preserve cookies during testing {id="preserving-cookies"}
 
@@ -350,7 +350,7 @@ In the following example, the reload count increases after each request due to c
 </tab>
 </tabs>
 
-> For the full example, see [session-cookie-client](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/session-cookie-client).
+> For the full example, see [session-cookie-client](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/session-cookie-client).
 
 ## Test HTTPS {id="https"}
 
@@ -360,7 +360,7 @@ To test an [HTTPS endpoint](server-ssl.md), set the request protocol using the [
 ```
 {src="snippets/ssl-engine-main/src/test/kotlin/ApplicationTest.kt" include-symbol="testRoot"}
 
-> For the full example, see [ssl-engine-main](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/ssl-engine-main).
+> For the full example, see [ssl-engine-main](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/ssl-engine-main).
 
 ## Test WebSockets {id="testing-ws"}
 
@@ -381,5 +381,5 @@ In the example below, the HTTP client makes a test request to the `TestServer`:
 ```
 {src="snippets/embedded-server/src/test/kotlin/EmbeddedServerTest.kt"}
 
-> For complete end-to-end testing examples, see [embedded-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/embedded-server)
-> and [e2e](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/e2e).
+> For complete end-to-end testing examples, see [embedded-server](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server)
+> and [e2e](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/e2e).

--- a/topics/server-thymeleaf.md
+++ b/topics/server-thymeleaf.md
@@ -62,6 +62,6 @@ The example below shows how to reload Thymeleaf templates automatically when [de
 ```
 {src="snippets/thymeleaf-auto-reload/src/main/kotlin/com/example/Application.kt"}
 
-You can find the complete example here: [thymeleaf-auto-reload](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/thymeleaf-auto-reload).
+You can find the complete example here: [thymeleaf-auto-reload](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/thymeleaf-auto-reload).
 
 

--- a/topics/server-war.md
+++ b/topics/server-war.md
@@ -5,9 +5,9 @@
 <tldr>
 <p>
 <b>Code examples</b>: 
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/jetty-war">jetty-war</a>, 
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/tomcat-war">tomcat-war</a>,
-<a href="https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/tomcat-war-ssl">tomcat-war-ssl</a>
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/jetty-war">jetty-war</a>, 
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/tomcat-war">tomcat-war</a>,
+<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/tomcat-war-ssl">tomcat-war-ssl</a>
 </p>
 </tldr>
 
@@ -36,7 +36,7 @@ engine, which delegates control of your application to the servlet container.
 > When running inside a servlet container, Ktor [connection and SSL settings defined in a configuration file](server-configuration-file.topic)
 > are not applied.
 > 
-> For configuring SSL in Tomcat, see the [tomcat-war-ssl](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/tomcat-war-ssl) sample.
+> For configuring SSL in Tomcat, see the [tomcat-war-ssl](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/tomcat-war-ssl) sample.
 > 
 {style="note"}
 
@@ -136,7 +136,7 @@ To apply the plugin, open your <path>build.gradle.kts</path> file and add the fo
 ## Run the application {id="run"}
 
 You can run a servlet application with the [configured Gretty plugin](#configure-gretty) by using the `run` task. For example, to run
-the [`jetty-war`](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/jetty-war) sample project, run the following command:
+the [`jetty-war`](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/jetty-war) sample project, run the following command:
 
 ```Bash
 ./gradlew :jetty-war:run
@@ -144,7 +144,7 @@ the [`jetty-war`](https://github.com/ktorio/ktor-documentation/tree/%ktor_versio
 
 ## Generate and deploy a WAR archive {id="generate-war"}
 
-To generate a WAR archive using the [`War`](#configure-war) plugin, run the `war` task. For the [`jetty-war`](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/jetty-war) sample
+To generate a WAR archive using the [`War`](#configure-war) plugin, run the `war` task. For the [`jetty-war`](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/jetty-war) sample
 project, the command looks as follows:
 
 ```Bash
@@ -175,4 +175,4 @@ The following `Dockerfile` example shows how to run the generated WAR file insid
 </tab>
 </tabs>
 
-For the complete examples, see [jetty-war](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/jetty-war) and [tomcat-war](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/tomcat-war).
+For the complete examples, see [jetty-war](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/jetty-war) and [tomcat-war](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/tomcat-war).

--- a/topics/server-webjars.md
+++ b/topics/server-webjars.md
@@ -58,4 +58,4 @@ For instance, if you've installed the `org.webjars:bootstrap` dependency, you ca
 
 Note that `%plugin_name%` allows you to change the versions of the dependencies without changing the path used to load them.
 
-> You can find the full example here: [webjars](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/webjars).
+> You can find the full example here: [webjars](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/webjars).

--- a/topics/server-websocket-serialization.md
+++ b/topics/server-websocket-serialization.md
@@ -127,4 +127,4 @@ To pass a data object in a text frame using a [specified format](#configure_seri
 ```
 {src="snippets/server-websockets-serialization/src/main/kotlin/com/example/Application.kt" include-lines="20-22"}
 
-> You can find the full example here: [server-websockets-serialization](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/server-websockets-serialization).
+> You can find the full example here: [server-websockets-serialization](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/server-websockets-serialization).

--- a/topics/server-websockets.md
+++ b/topics/server-websockets.md
@@ -125,7 +125,7 @@ The example below shows how to create the `echo` WebSocket endpoint to handle a 
 {src="snippets/server-websockets/src/main/kotlin/com/example/Application.kt" include-lines="19,24-36"}
 
 For the full example,
-see [server-websockets](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/server-websockets).
+see [server-websockets](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/server-websockets).
 
 ### Example: Handle multiple sessions {id="handle-multiple-session"}
 
@@ -156,7 +156,7 @@ connections. This approach scales well for applications with many concurrent Web
 reactive way to handle message broadcasting.
 
 For the full example,
-see [server-websockets-sharedflow](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/server-websockets-sharedflow).
+see [server-websockets-sharedflow](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/server-websockets-sharedflow).
 
 ## The WebSocket API and Ktor {id="websocket-api"}
 

--- a/topics/sevalla.md
+++ b/topics/sevalla.md
@@ -6,9 +6,9 @@
 
 In this tutorial, you will learn how to prepare and deploy a Ktor application to [Sevalla](https://sevalla.com/). You can use one of the following initial projects, depending on the way used to [create a Ktor server](server-create-and-configure.topic):
 
-* [embedded-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/embedded-server)
+* [embedded-server](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server)
 
-* [Engine-main](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main)
+* [Engine-main](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main)
 
 ## Prerequisites {id="prerequisites"}
 
@@ -19,8 +19,8 @@ Before starting this tutorial, you need to [create a Sevalla account](https://se
 To open a sample application, follow the steps below:
 
 1. Clone the [Ktor documentation repository](https://github.com/ktorio/ktor-documentation).
-2. Open the [codeSnippets](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets) project.
-3. Open the [embedded-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/embedded-server) or [engine-main](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main) sample, which demonstrates two different approaches to setting up a Ktor server — either by configuring it directly in code or through an external configuration file. The only difference in deploying these projects is how to specify a port used to listen for incoming requests.
+2. Open the [codeSnippets](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets) project.
+3. Open the [embedded-server](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server) or [engine-main](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main) sample, which demonstrates two different approaches to setting up a Ktor server — either by configuring it directly in code or through an external configuration file. The only difference in deploying these projects is how to specify a port used to listen for incoming requests.
 
 ## Prepare the application {id="prepare-app"}
 
@@ -28,7 +28,7 @@ To open a sample application, follow the steps below:
 
 Sevalla injects a random port using the `PORT` environment variable. Your application must be configured to listen on that port.
 
-If you've chosen the [embedded-server](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/embedded-server) sample with server configuration specified in code, you can obtain the environment variable value using `System.getenv()`. Open the <path>Application.kt</path> file placed in the <path>src/main/kotlin/com/example</path> folder and change the port parameter value of the `embeddedServer()` function as shown below:
+If you've chosen the [embedded-server](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server) sample with server configuration specified in code, you can obtain the environment variable value using `System.getenv()`. Open the <path>Application.kt</path> file placed in the <path>src/main/kotlin/com/example</path> folder and change the port parameter value of the `embeddedServer()` function as shown below:
 
 ```kotlin
 fun main() {
@@ -39,7 +39,7 @@ fun main() {
 }
 ```
 
-If you've chosen the [engine-main](https://github.com/ktorio/ktor-documentation/tree/%ktor_version%/codeSnippets/snippets/engine-main) sample with server configuration specified in the <path>application.conf</path> file, you can assign the environment variable to the port parameter by using the `${ENV}` syntax. Open the <path>application.conf</path> file placed in <path>src/main/resources</path> and update it as shown below:
+If you've chosen the [engine-main](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main) sample with server configuration specified in the <path>application.conf</path> file, you can assign the environment variable to the port parameter by using the `${ENV}` syntax. Open the <path>application.conf</path> file placed in <path>src/main/resources</path> and update it as shown below:
 
 ```hocon
 ktor {

--- a/topics/tutorial-first-steps-with-kotlin-rpc.topic
+++ b/topics/tutorial-first-steps-with-kotlin-rpc.topic
@@ -23,7 +23,7 @@
         <p>
             <b>Used plugins</b>: <a href="server-routing.md">Routing</a>,
             <a href="https://kotlinlang.org/api/kotlinx.serialization/">kotlinx.serialization</a>,
-            <a href="https://github.com/Kotlin/kotlinx-rpc">kotlinx.rpc</a>
+            <a href="https://kotlin.github.io/kotlinx-rpc/get-started.html">kotlinx.rpc</a>
         </p>
     </tldr>
     <p>
@@ -366,7 +366,7 @@
             <p>
                 You now have all the code necessary to run the application, but at the moment, it would not even
                 compile, never mind execute.
-                You can use Ktor Project Generator with the <a href="https://start.ktor.io/p/kotlinx-rpc">kotlinx.rpc</a> plugin,
+                You can use Ktor Project Generator with the <a href="https://kotlin.github.io/kotlinx-rpc/get-started.html">kotlinx.rpc</a> plugin,
                 or you can configure the build file manually.
                 And this is not too complex either.
             </p>


### PR DESCRIPTION
- Remove `%ktor_version%` from GH links as the patch release branches will be removed from now on. If specifying a version is necessary, we can use tags instead.
- Point kotlinx.rpc links to the official docs instead GH or nonexistent generator page.
- Remove nonexistent link in FAQ.
- Fix broken topic links.

Fixes:
[KTOR-9525](https://youtrack.jetbrains.com/issue/KTOR-9525)