### PR TITLE
KTOR-9512 Docs for sending session data only when modified

### DIFF
--- a/topics/server-sessions.md
+++ b/topics/server-sessions.md
@@ -111,6 +111,21 @@ On the client side, you need to append this header to each request to get sessio
 > }
 > ```
 
+### Send session data only when modified {id="send_only_if_modified"}
+
+By default, Ktor sends session data on every response, even if it hasn't changed.
+
+To send session data only when it is modified, enable the `sendOnlyIfModified` flag in the session configuration:
+
+```kotlin
+install(Sessions) {
+    cookie<MySession>("SESSION") {
+        sendOnlyIfModified = true
+    }
+}
+```
+
+This option is available for both [cookie](#cookie) and [header-based](#header) sessions.
 
 ## Store session payload: Client vs Server {id="client_server"}
 

--- a/topics/whats-new-350.md
+++ b/topics/whats-new-350.md
@@ -119,3 +119,19 @@ To help prevent future regressions, our JavaScript test infrastructure now targe
 > * [Support for ES2015 features](https://kotlinlang.org/docs/js-project-setup.html#support-for-es2015-features)
 >
 {style="tip"}
+
+### Send session cookies only when modified
+
+Ktor 3.5.0 introduces a new option for the [Sessions](server-sessions.md) plugin that sends session data only
+when it changes (for example, the `Set-Cookie` header for cookie-based sessions).
+
+By default, session data is sent on every response to preserve existing behavior. To send it only when modified, enable
+the `sendOnlyIfModified` flag in the session cookie configuration:
+
+```kotlin
+install(Sessions) {
+    cookie<MySession>("SESSION") {
+        sendOnlyIfModified = true
+    }
+}
+```


### PR DESCRIPTION
Description:

Add documentation for sending session data only when modified:

- add a "what's new" entry
- add a new section in server-sessions


Related issue:

[KTOR-9512](https://youtrack.jetbrains.com/issue/KTOR-9512) 