### PR TITLE
KTOR-9514 Add docs for custom JSON schemas

### DIFF
--- a/topics/openapi-spec-generation.md
+++ b/topics/openapi-spec-generation.md
@@ -385,7 +385,7 @@ allows most common data models to be documented without extra effort.
 ### Customize schemas with annotations
 
 You can override automatically generated JSON schema fields by adding [`@JsonSchema`](https://api.ktor.io/ktor-openapi-schema/io.ktor.openapi/-json-schema/index.html)
-annotations to your data classes. This allows you to add descriptions, mark fields as required, and more:
+annotations to your data classes. This allows you to add descriptions, mark properties as required, and more:
 
 ```kotlin
 @JsonSchema.Description("Represents a news article")
@@ -430,6 +430,16 @@ ReflectionJsonSchemaInference(object : SchemaReflectionAdapter {
     }
 })
 ```
+
+### Provide custom schemas {id="custom-schemas"}
+
+If automatic schema inference or annotations are not sufficient, you can construct JSON schemas manually using the
+[`JsonSchema`](https://api.ktor.io/ktor-openapi-schema/io.ktor.openapi/-json-schema/index.html) class.
+
+This allows you to define all supported schema properties explicitly, such as types, formats, nested structures, or
+advanced constructs such as `prefixItems` for tuple-like array definitions.
+
+For the full list of available properties, see the [`JsonSchema` API documentation](https://api.ktor.io/ktor-openapi-schema/io.ktor.openapi/-json-schema/index.html).
 
 ## Generate and serve the specification
 

--- a/topics/whats-new-350.md
+++ b/topics/whats-new-350.md
@@ -79,11 +79,3 @@ install(Authentication) {
   }
 }
 ```
-
-### OpenAPI: JSON schema `prefixItems` support
-
-OpenAPI JSON schema now supports the `prefixItems` property when defining custom schemas. This allows defining tuple-like
-array structures where each position can have its own schema.
-
-The property is available through the [`JsonSchema`](https://api.ktor.io/ktor-openapi-schema/io.ktor.openapi/-json-schema/index.html)
-class and can be used when [manually constructing JSON schemas](openapi-spec-generation.md#custom-schemas).

--- a/topics/whats-new-350.md
+++ b/topics/whats-new-350.md
@@ -79,3 +79,11 @@ install(Authentication) {
   }
 }
 ```
+
+### OpenAPI: JSON schema `prefixItems` support
+
+OpenAPI JSON schema now supports the `prefixItems` property when defining custom schemas. This allows defining tuple-like
+array structures where each position can have its own schema.
+
+The property is available through the [`JsonSchema`](https://api.ktor.io/ktor-openapi-schema/io.ktor.openapi/-json-schema/index.html)
+class and can be used when [manually constructing JSON schemas](openapi-spec-generation.md#custom-schemas).


### PR DESCRIPTION
Description:

- Add a new section in OpenAPI docs for providing custom JSON schemas
- Add a what's new entry  for the `prefixItems` property support
- Add links to the `JsonSchema` API docs


Related issue:
[KTOR-9514](https://youtrack.jetbrains.com/issue/KTOR-9514) 