### PR TITLE
KTOR-7600 Fix broken /free-api link in rate-limit README

### DIFF
--- a/codeSnippets/snippets/rate-limit/README.md
+++ b/codeSnippets/snippets/rate-limit/README.md
@@ -12,7 +12,7 @@ To run a sample, execute the following command in a repository's root directory:
 
 Then, open and refresh one of the following pages to test rate limiting:
 - [http://localhost:8080/](http://localhost:8080/)
-- [http://localhost:8080/free-api](http://localhost:8080/free-api)
+- [http://localhost:8080/public-api](http://localhost:8080/public-api)
 - [http://localhost:8080/protected-api?login=jetbrains](http://localhost:8080/protected-api?login=jetbrains)
 
 For the latest endpoint, you can change the `login` query parameter to another value to see how a request weight affects rate limiting.


### PR DESCRIPTION
[KTOR-7600](https://youtrack.jetbrains.com/issue/KTOR-7600) (item 2)

`Application.kt` defines `/public-api` (under `RateLimitName("public")`), not `/free-api`, so the URL listed in the README returns 404.

Items 1 and 3 from the ticket are not addressed here — left a note on YouTrack with my findings.