### PR TITLE
KTOR-8228 Use yyyy instead of YYYY in logback date pattern

### DIFF
--- a/codeSnippets/snippets/logging/src/main/resources/logback-fileAppender.xml
+++ b/codeSnippets/snippets/logging/src/main/resources/logback-fileAppender.xml
@@ -3,7 +3,7 @@
         <file>testFile.log</file>
         <append>true</append>
         <encoder>
-            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
     <root level="trace">

--- a/codeSnippets/snippets/logging/src/main/resources/logback.xml
+++ b/codeSnippets/snippets/logging/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
     <root level="trace">


### PR DESCRIPTION
[KTOR-8228](https://youtrack.jetbrains.com/issue/KTOR-8228)

The logback configs included by the [server-logging](https://ktor.io/docs/server-logging.html) docs page used `YYYY-MM-dd` (ISO week-based year). Switch to `yyyy-MM-dd` (calendar year), which is what the issue reporter requested.

Other snippets in the repo also use `YYYY` but are out of scope for this issue.