### PR TITLE
KTOR-9557 and KTOR-9560 Add docs for custom DNS in the OkHttp and Apache5 engines

### DIFF
--- a/topics/whats-new-350.md
+++ b/topics/whats-new-350.md
@@ -188,12 +188,17 @@ install(Sessions) {
 
 ## Ktor Client
 
-### Custom DNS resolvers in the OkHttp engine
+### Custom DNS resolvers in the OkHttp and Apache5 engines
 
-Ktor 3.5.0 adds first-class support for configuring custom DNS resolvers in the OkHttp client engine.
+Ktor 3.5.0 adds first-class support for configuring custom DNS resolvers in the OkHttp and Apache5 client engines.
 
-Previously, configuring a custom DNS implementation required using the `OkHttpConfig.config()` function to access the
-underlying OkHttp client builder. Ktor now exposes a dedicated `OkHttpConfig.dns` property:
+Previously, you configured custom DNS resolution by accessing engine-specific internals, such as `config {}` in OkHttp 
+or `configureConnectionManager { setDnsResolver(...) }` in Apache5. Ktor now exposes dedicated configuration properties
+on each engine to provide a consistent and type-safe API.
+
+#### OkHttp
+
+You can now configure a custom DNS resolver in OkHttp using the `OkHttpConfig.dns` property:
 
 ```kotlin
 HttpClient(OkHttp) {
@@ -204,3 +209,18 @@ HttpClient(OkHttp) {
 ```
 
 If you do not configure the `dns` property, the OkHttp engine continues to use OkHttp’s default `Dns.SYSTEM` resolver.
+
+#### Apache5
+
+You can now configure a custom DNS resolver in Apache5 using the `Apache5EngineConfig.dnsResolver` property:
+
+```kotlin
+HttpClient(Apache5) {
+    engine {
+        dnsResolver = SystemDefaultDnsResolver.INSTANCE
+    }
+}
+```
+
+If the `dnsResolver` property is not configured, the Apache5 engine continues to use the Apache client’s default DNS
+resolver.

--- a/topics/whats-new-350.md
+++ b/topics/whats-new-350.md
@@ -185,3 +185,22 @@ install(Sessions) {
     }
 }
 ```
+
+## Ktor Client
+
+### Custom DNS resolvers in the OkHttp engine
+
+Ktor 3.5.0 adds first-class support for configuring custom DNS resolvers in the OkHttp client engine.
+
+Previously, configuring a custom DNS implementation required using the `OkHttpConfig.config()` function to access the
+underlying OkHttp client builder. Ktor now exposes a dedicated `OkHttpConfig.dns` property:
+
+```kotlin
+HttpClient(OkHttp) {
+    engine {
+        dns = Dns { hostname -> listOf(InetAddress.getByName("127.0.0.1")) }
+    }
+}
+```
+
+If you do not configure the `dns` property, the OkHttp engine continues to use OkHttp’s default `Dns.SYSTEM` resolver.


### PR DESCRIPTION
[KTOR-9557](https://youtrack.jetbrains.com/issue/KTOR-9557) Documentation for DNS configuration for OkHttp client engine
[KTOR-9560](https://youtrack.jetbrains.com/issue/KTOR-9560) Documentation for DNS configuration for the Apache5 client