### PR TITLE
fix: remove outdated XML serialization note for `jsNode` target

### DIFF
--- a/topics/client-serialization.md
+++ b/topics/client-serialization.md
@@ -79,9 +79,6 @@ To serialize/deserialize XML, add the `ktor-serialization-kotlinx-xml` in the bu
 <var name="artifact_name" value="ktor-serialization-kotlinx-xml"/>
 <include from="lib.topic" element-id="add_ktor_artifact"/>
 
-> Note that XML serialization [is not supported on `jsNode` target](https://github.com/pdvrieze/xmlutil/issues/83).
-{style="note"}
-
 #### CBOR {id="add_cbor_dependency"}
 
 To serialize/deserialize CBOR, add the `ktor-serialization-kotlinx-cbor` in the build script:

--- a/topics/server-serialization.md
+++ b/topics/server-serialization.md
@@ -84,9 +84,6 @@ To serialize/deserialize XML, add the `ktor-serialization-kotlinx-xml` in the bu
 <var name="artifact_name" value="ktor-serialization-kotlinx-xml"/>
 <include from="lib.topic" element-id="add_ktor_artifact"/>
 
-> Note that XML serialization [is not supported on `jsNode` target](https://github.com/pdvrieze/xmlutil/issues/83).
-{style="note"}
-
 #### CBOR {id="add_cbor_dependency"}
 
 To serialize/deserialize CBOR, add the `ktor-serialization-kotlinx-cbor` in the build script:


### PR DESCRIPTION
The nodeJS target has been available since 3.5.0 hereby it removes the outdated note from the documentation