### PR TITLE
Fix wording on property delegation in DI

### DIFF
--- a/topics/server-di-dependency-resolution.md
+++ b/topics/server-di-dependency-resolution.md
@@ -18,7 +18,7 @@ or [direct resolution](#direct-resolution).
 
 ### Use property delegation {id="property-delegation"}
 
-When using property delegation, the dependency is resolved lazily when the property is first accessed:
+When using property delegation, the dependency will only be resolved during the startup validation phase:
 
 ```kotlin
 val service: GreetingService by dependencies


### PR DESCRIPTION
The lazy evaluation behaviour was later changed to ensure that all declarations are checked during the startup phase.  Discovered this after [a comment from a user](https://youtrack.jetbrains.com/issue/KTOR-8329/Dependencies-should-be-validated-on-startup#focus=Comments-27-14006857.0-0).