### PR TITLE
KTOR-9721 Swagger UI and OpenAPI docs need 3.1 compatibility updates

### DIFF
--- a/codeSnippets/snippets/json-kotlinx-openapi/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/json-kotlinx-openapi/src/main/kotlin/com/example/Application.kt
@@ -51,7 +51,7 @@ fun Application.main() {
         }
 
         swaggerUI(path = "swagger", swaggerFile = "openapi/documentation.yaml") {
-            version = "4.15.5"
+            version = "5.31.0"
         }
         openAPI(path="openapi", swaggerFile = "openapi/documentation.yaml") {
             codegen = StaticHtmlCodegen()

--- a/topics/server-openapi.md
+++ b/topics/server-openapi.md
@@ -98,6 +98,12 @@ application.
 By default, documentation is rendered using `StaticHtml2Codegen`. You can customize the renderer inside the `openAPI {}`
 block:
 
+> `StaticHtmlCodegen` and `StaticHtml2Codegen` support only OpenAPI 3.0.x documents. Using them with OpenAPI 3.1 documents may
+> produce incomplete or incorrect HTML. For OpenAPI 3.1, use the [`swaggerUI()`](server-swagger-ui.md) function with Swagger UI
+> 5.x. If you need to keep using the OpenAPI plugin's HTML renderer, keep the specification at OpenAPI 3.0.3.
+>
+{style="note"}
+
 ```kotlin
 ```
 {src="snippets/json-kotlinx-openapi/src/main/kotlin/com/example/Application.kt" include-lines="40,56-58,59"}

--- a/topics/server-swagger-ui.md
+++ b/topics/server-swagger-ui.md
@@ -82,11 +82,16 @@ the application.
 
 ## Configure Swagger UI
 
-You can customize Swagger UI within the `swaggerUI {}` block, for example, by specifying a custom Swagger UI version:
+You can customize Swagger UI within the `swaggerUI {}` block, for example, by overriding the default Swagger UI
+version:
 
 ```kotlin
 ```
 {src="snippets/json-kotlinx-openapi/src/main/kotlin/com/example/Application.kt" include-lines="40,53-55,59"}
+
+> Swagger UI 5.x is required for OpenAPI 3.1.x documents, while Swagger UI 4.x only supports OpenAPI 3.0.x.
+>
+{style="note"}
 
 ## Configure CORS {id="configure-cors"}
 


### PR DESCRIPTION
See [KTOR-9721](https://youtrack.jetbrains.com/issue/KTOR-9721) Swagger UI and OpenAPI docs need 3.1 compatibility updates