### PR TITLE
Use Ktor version catalog in code snippets

### DIFF
--- a/codeSnippets/settings.gradle.kts
+++ b/codeSnippets/settings.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage") // Added for dependencyResolutionManagement.repositories
+
 pluginManagement {
     repositories {
         gradlePluginPortal()
@@ -9,6 +11,17 @@ pluginManagement {
             if (requested.id.id.startsWith("com.google.cloud.tools.appengine")) {
                 useModule("com.google.cloud.tools:appengine-gradle-plugin:${requested.version}")
             }
+        }
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+    versionCatalogs {
+        create("ktorLibs") {
+            from("io.ktor:ktor-version-catalog:${providers.gradleProperty("ktor_version").get()}")
         }
     }
 }

--- a/codeSnippets/snippets/auth-basic-hash-table/build.gradle.kts
+++ b/codeSnippets/snippets/auth-basic-hash-table/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,10 +17,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-auth:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.auth)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/auth-basic/build.gradle.kts
+++ b/codeSnippets/snippets/auth-basic/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -17,9 +16,9 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-auth:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.auth)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")}

--- a/codeSnippets/snippets/auth-bearer/build.gradle.kts
+++ b/codeSnippets/snippets/auth-bearer/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,10 +17,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-auth:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.auth)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/auth-digest/build.gradle.kts
+++ b/codeSnippets/snippets/auth-digest/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,13 +17,13 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-auth:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.auth)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
-    testImplementation("io.ktor:ktor-client-auth:$ktor_version")
+    testImplementation(ktorLibs.client.auth)
 }
 
 kotlin {

--- a/codeSnippets/snippets/auth-form-html-dsl/build.gradle.kts
+++ b/codeSnippets/snippets/auth-form-html-dsl/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,11 +17,11 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-auth:$ktor_version")
-    implementation("io.ktor:ktor-server-html-builder:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.auth)
+    implementation(ktorLibs.server.htmlBuilder)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/auth-form-session-nested/build.gradle.kts
+++ b/codeSnippets/snippets/auth-form-session-nested/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -19,13 +18,13 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-auth:$ktor_version")
-    implementation("io.ktor:ktor-server-sessions:$ktor_version")
-    implementation("io.ktor:ktor-server-html-builder:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.auth)
+    implementation(ktorLibs.server.sessions)
+    implementation(ktorLibs.server.htmlBuilder)
+    implementation(ktorLibs.serialization.kotlinx.json)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/auth-form-session/build.gradle.kts
+++ b/codeSnippets/snippets/auth-form-session/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -19,13 +18,13 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-auth:$ktor_version")
-    implementation("io.ktor:ktor-server-sessions:$ktor_version")
-    implementation("io.ktor:ktor-server-html-builder:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.auth)
+    implementation(ktorLibs.server.sessions)
+    implementation(ktorLibs.server.htmlBuilder)
+    implementation(ktorLibs.serialization.kotlinx.json)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
 }

--- a/codeSnippets/snippets/auth-jwt-hs256/build.gradle.kts
+++ b/codeSnippets/snippets/auth-jwt-hs256/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -23,15 +22,15 @@ tasks.withType<Test> {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-auth:$ktor_version")
-    implementation("io.ktor:ktor-server-auth-jwt:$ktor_version")
-    implementation("io.ktor:ktor-server-content-negotiation:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
-    implementation("io.ktor:ktor-server-config-yaml:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.auth)
+    implementation(ktorLibs.server.auth.jwt)
+    implementation(ktorLibs.server.contentNegotiation)
+    implementation(ktorLibs.serialization.kotlinx.json)
+    implementation(ktorLibs.server.config.yaml)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test:$kotlin_version")
-    testImplementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
+    testImplementation(ktorLibs.client.contentNegotiation)
 }

--- a/codeSnippets/snippets/auth-jwt-rs256/build.gradle.kts
+++ b/codeSnippets/snippets/auth-jwt-rs256/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -19,11 +18,11 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-auth:$ktor_version")
-    implementation("io.ktor:ktor-server-auth-jwt:$ktor_version")
-    implementation("io.ktor:ktor-server-content-negotiation:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.auth)
+    implementation(ktorLibs.server.auth.jwt)
+    implementation(ktorLibs.server.contentNegotiation)
+    implementation(ktorLibs.serialization.kotlinx.json)
     implementation("ch.qos.logback:logback-classic:$logback_version")
 }

--- a/codeSnippets/snippets/auth-ldap/build.gradle.kts
+++ b/codeSnippets/snippets/auth-ldap/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,9 +17,9 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-auth:$ktor_version")
-    implementation("io.ktor:ktor-server-auth-ldap:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.auth)
+    implementation(ktorLibs.server.auth.ldap)
     implementation("ch.qos.logback:logback-classic:$logback_version")
 }

--- a/codeSnippets/snippets/auth-oauth-google/build.gradle.kts
+++ b/codeSnippets/snippets/auth-oauth-google/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -19,17 +18,17 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-auth:$ktor_version")
-    implementation("io.ktor:ktor-server-sessions:$ktor_version")
-    implementation("io.ktor:ktor-server-html-builder:$ktor_version")
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.auth)
+    implementation(ktorLibs.server.sessions)
+    implementation(ktorLibs.server.htmlBuilder)
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.contentNegotiation)
+    implementation(ktorLibs.serialization.kotlinx.json)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
-    testImplementation("io.ktor:ktor-server-content-negotiation:$ktor_version")
+    testImplementation(ktorLibs.server.contentNegotiation)
 }

--- a/codeSnippets/snippets/autohead/build.gradle.kts
+++ b/codeSnippets/snippets/autohead/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,10 +17,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-auto-head-response:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.autoHeadResponse)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test:$kotlin_version")
 }

--- a/codeSnippets/snippets/autoreload-embedded-server/build.gradle.kts
+++ b/codeSnippets/snippets/autoreload-embedded-server/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val junit_version: String by project
@@ -20,7 +19,7 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
 }

--- a/codeSnippets/snippets/autoreload-engine-main/build.gradle.kts
+++ b/codeSnippets/snippets/autoreload-engine-main/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val junit_version: String by project
@@ -19,11 +18,11 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    implementation("io.ktor:ktor-server-config-yaml:$ktor_version")
+    implementation(ktorLibs.server.config.yaml)
     testImplementation("junit:junit:$junit_version")
     testImplementation("com.typesafe:config:1.4.8")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
 }

--- a/codeSnippets/snippets/aws-elastic-beanstalk/build.gradle.kts
+++ b/codeSnippets/snippets/aws-elastic-beanstalk/build.gradle.kts
@@ -3,7 +3,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.5.2"
+    alias(ktorLibs.plugins.ktor)
 }
 
 application {
@@ -18,9 +18,9 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
-    implementation("io.ktor:ktor-server-core-jvm")
-    implementation("io.ktor:ktor-server-netty-jvm")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/caching-headers/build.gradle.kts
+++ b/codeSnippets/snippets/caching-headers/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,11 +17,11 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-caching-headers:$ktor_version")
-    implementation("io.ktor:ktor-server-html-builder:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.cachingHeaders)
+    implementation(ktorLibs.server.htmlBuilder)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/call-id/build.gradle.kts
+++ b/codeSnippets/snippets/call-id/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,9 +17,9 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-call-logging:$ktor_version")
-    implementation("io.ktor:ktor-server-call-id:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.callLogging)
+    implementation(ktorLibs.server.callId)
     implementation("ch.qos.logback:logback-classic:$logback_version")
 }

--- a/codeSnippets/snippets/client-auth-basic/build.gradle.kts
+++ b/codeSnippets/snippets/client-auth-basic/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -18,10 +17,10 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
-    implementation("io.ktor:ktor-client-auth:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.logging)
+    implementation(ktorLibs.client.auth)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     implementation(project(":auth-basic"))
     implementation(project(":e2e"))

--- a/codeSnippets/snippets/client-auth-digest/build.gradle.kts
+++ b/codeSnippets/snippets/client-auth-digest/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -18,10 +17,10 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
-    implementation("io.ktor:ktor-client-auth:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.logging)
+    implementation(ktorLibs.client.auth)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     implementation(project(":auth-digest"))
     implementation(project(":e2e"))

--- a/codeSnippets/snippets/client-auth-oauth-google/build.gradle.kts
+++ b/codeSnippets/snippets/client-auth-oauth-google/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -23,15 +22,15 @@ tasks.named<JavaExec>("run") {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-auth:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
-    implementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.auth)
+    implementation(ktorLibs.client.logging)
+    implementation(ktorLibs.client.contentNegotiation)
+    implementation(ktorLibs.serialization.kotlinx.json)
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation("junit:junit:$junit_version")
-    testImplementation("io.ktor:ktor-client-mock:$ktor_version")
+    testImplementation(ktorLibs.client.mock)
 }

--- a/codeSnippets/snippets/client-bom-remover/build.gradle.kts
+++ b/codeSnippets/snippets/client-bom-remover/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -18,9 +17,9 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-bom-remover:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.bomRemover)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     implementation(project(":compression"))
     implementation(project(":e2e"))

--- a/codeSnippets/snippets/client-caching/build.gradle.kts
+++ b/codeSnippets/snippets/client-caching/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -18,9 +17,9 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.logging)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     implementation(project(":caching-headers"))
     implementation(project(":e2e"))

--- a/codeSnippets/snippets/client-call-id/build.gradle.kts
+++ b/codeSnippets/snippets/client-call-id/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -18,14 +17,14 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-call-id:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.callId)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-call-logging:$ktor_version")
-    implementation("io.ktor:ktor-server-call-id:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.callLogging)
+    implementation(ktorLibs.server.callId)
     implementation(project(":e2e"))
     testImplementation("junit:junit:$junit_version")
     testImplementation("org.hamcrest:hamcrest:$hamcrest_version")

--- a/codeSnippets/snippets/client-configure-request/build.gradle.kts
+++ b/codeSnippets/snippets/client-configure-request/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -18,9 +17,9 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.logging)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation("junit:junit:$junit_version")
     testImplementation("org.hamcrest:hamcrest:$hamcrest_version")

--- a/codeSnippets/snippets/client-content-encoding/build.gradle.kts
+++ b/codeSnippets/snippets/client-content-encoding/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -18,9 +17,9 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-encoding:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.encoding)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     implementation(project(":compression"))
     implementation(project(":e2e"))

--- a/codeSnippets/snippets/client-cookies/build.gradle.kts
+++ b/codeSnippets/snippets/client-cookies/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -18,9 +17,9 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.logging)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     implementation(project(":session-cookie-client"))
     implementation(project(":e2e"))

--- a/codeSnippets/snippets/client-custom-plugin-auth/build.gradle.kts
+++ b/codeSnippets/snippets/client-custom-plugin-auth/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -18,12 +17,12 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-auth:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.logging)
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.auth)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation("junit:junit:$junit_version")
     testImplementation("org.hamcrest:hamcrest:$hamcrest_version")

--- a/codeSnippets/snippets/client-custom-plugin-data-transformation/build.gradle.kts
+++ b/codeSnippets/snippets/client-custom-plugin-data-transformation/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -18,11 +17,11 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.logging)
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation("junit:junit:$junit_version")
     testImplementation("org.hamcrest:hamcrest:$hamcrest_version")

--- a/codeSnippets/snippets/client-custom-plugin/build.gradle.kts
+++ b/codeSnippets/snippets/client-custom-plugin/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -18,9 +17,9 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.logging)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation("junit:junit:$junit_version")
     testImplementation("org.hamcrest:hamcrest:$hamcrest_version")

--- a/codeSnippets/snippets/client-default-request/build.gradle.kts
+++ b/codeSnippets/snippets/client-default-request/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -18,8 +17,8 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation("junit:junit:$junit_version")
     testImplementation("org.hamcrest:hamcrest:$hamcrest_version")

--- a/codeSnippets/snippets/client-download-file-range/build.gradle.kts
+++ b/codeSnippets/snippets/client-download-file-range/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val junit_version: String by project
 
@@ -17,8 +16,8 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-apache:$ktor_version")
-    testImplementation("io.ktor:ktor-client-mock:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.apache)
+    testImplementation(ktorLibs.client.mock)
     testImplementation("junit:junit:$junit_version")
 }

--- a/codeSnippets/snippets/client-download-file/build.gradle.kts
+++ b/codeSnippets/snippets/client-download-file/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val junit_version: String by project
 
@@ -17,8 +16,8 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-apache:$ktor_version")
-    testImplementation("io.ktor:ktor-client-mock:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.apache)
+    testImplementation(ktorLibs.client.mock)
     testImplementation("junit:junit:$junit_version")
 }

--- a/codeSnippets/snippets/client-download-streaming/build.gradle.kts
+++ b/codeSnippets/snippets/client-download-streaming/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 
@@ -17,9 +16,9 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.logging)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation("junit:junit:$junit_version")
     testImplementation(project(":e2e"))

--- a/codeSnippets/snippets/client-engine-curl/build.gradle.kts
+++ b/codeSnippets/snippets/client-engine-curl/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -34,8 +33,8 @@ kotlin {
     sourceSets {
         val nativeMain by getting {
             dependencies {
-                implementation("io.ktor:ktor-client-core:$ktor_version")
-                implementation("io.ktor:ktor-client-curl:$ktor_version")
+                implementation(ktorLibs.client.core)
+                implementation(ktorLibs.client.curl)
             }
         }
         val nativeTest by getting {

--- a/codeSnippets/snippets/client-engine-darwin/build.gradle.kts
+++ b/codeSnippets/snippets/client-engine-darwin/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -30,8 +29,8 @@ kotlin {
     sourceSets {
         val nativeMain by getting {
             dependencies {
-                implementation("io.ktor:ktor-client-core:$ktor_version")
-                implementation("io.ktor:ktor-client-darwin:$ktor_version")
+                implementation(ktorLibs.client.core)
+                implementation(ktorLibs.client.darwin)
             }
         }
         val nativeTest by getting {

--- a/codeSnippets/snippets/client-engine-js/build.gradle.kts
+++ b/codeSnippets/snippets/client-engine-js/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlinx_html_version: String by project
 
 plugins {
@@ -27,10 +26,11 @@ kotlin {
         val jsMain by getting {
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-html:$kotlinx_html_version")
-                implementation("io.ktor:ktor-client-core:$ktor_version")
-                implementation("io.ktor:ktor-client-js:$ktor_version")
-                implementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
-                implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")            }
+                implementation(ktorLibs.client.core)
+                implementation(ktorLibs.client.js)
+                implementation(ktorLibs.client.contentNegotiation)
+                implementation(ktorLibs.serialization.kotlinx.json)
+            }
         }
     }
 }

--- a/codeSnippets/snippets/client-engine-winhttp/build.gradle.kts
+++ b/codeSnippets/snippets/client-engine-winhttp/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -30,8 +29,8 @@ kotlin {
     sourceSets {
         val nativeMain by getting {
             dependencies {
-                implementation("io.ktor:ktor-client-core:$ktor_version")
-                implementation("io.ktor:ktor-client-winhttp:$ktor_version")
+                implementation(ktorLibs.client.core)
+                implementation(ktorLibs.client.winhttp)
             }
         }
         val nativeTest by getting {

--- a/codeSnippets/snippets/client-http-send/build.gradle.kts
+++ b/codeSnippets/snippets/client-http-send/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -18,8 +17,8 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-apache5:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.apache5)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation("junit:junit:$junit_version")
     testImplementation("org.hamcrest:hamcrest:$hamcrest_version")

--- a/codeSnippets/snippets/client-io-interop/build.gradle.kts
+++ b/codeSnippets/snippets/client-io-interop/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 
 plugins {
@@ -16,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
     implementation("ch.qos.logback:logback-classic:$logback_version")
 }

--- a/codeSnippets/snippets/client-json-kotlinx/build.gradle.kts
+++ b/codeSnippets/snippets/client-json-kotlinx/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -19,14 +18,14 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-xml:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-cbor:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-protobuf:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.contentNegotiation)
+    implementation(ktorLibs.serialization.kotlinx.json)
+    implementation(ktorLibs.serialization.kotlinx.xml)
+    implementation(ktorLibs.serialization.kotlinx.cbor)
+    implementation(ktorLibs.serialization.kotlinx.protobuf)
+    implementation(ktorLibs.client.logging)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     implementation(project(":json-kotlinx"))
     implementation(project(":e2e"))

--- a/codeSnippets/snippets/client-json/build.gradle.kts
+++ b/codeSnippets/snippets/client-json/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 
 plugins {
@@ -16,9 +15,9 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-apache5:$ktor_version")
-    implementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
-    implementation("io.ktor:ktor-serialization-gson:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.apache5)
+    implementation(ktorLibs.client.contentNegotiation)
+    implementation(ktorLibs.serialization.gson)
     implementation("ch.qos.logback:logback-classic:$logback_version")
 }

--- a/codeSnippets/snippets/client-logging-napier/build.gradle.kts
+++ b/codeSnippets/snippets/client-logging-napier/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val napier_version: String by project
 
 plugins {
@@ -16,8 +15,8 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.logging)
     implementation("io.github.aakira:napier:$napier_version")
 }

--- a/codeSnippets/snippets/client-logging/build.gradle.kts
+++ b/codeSnippets/snippets/client-logging/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -18,9 +17,9 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.logging)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation("junit:junit:$junit_version")
     testImplementation("org.hamcrest:hamcrest:$hamcrest_version")

--- a/codeSnippets/snippets/client-parallel-requests/build.gradle.kts
+++ b/codeSnippets/snippets/client-parallel-requests/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -18,12 +17,12 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.logging)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-core:$ktor_version")
-    testImplementation("io.ktor:ktor-server-cio:$ktor_version")
+    testImplementation(ktorLibs.server.core)
+    testImplementation(ktorLibs.server.cio)
     testImplementation("junit:junit:$junit_version")
     testImplementation("org.hamcrest:hamcrest:$hamcrest_version")
     testImplementation(project(":e2e"))

--- a/codeSnippets/snippets/client-retry/build.gradle.kts
+++ b/codeSnippets/snippets/client-retry/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -18,9 +17,9 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.logging)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     implementation(project(":simulate-slow-server"))
     implementation(project(":e2e"))

--- a/codeSnippets/snippets/client-sse/build.gradle.kts
+++ b/codeSnippets/snippets/client-sse/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -23,10 +22,10 @@ tasks.named<JavaExec>("run") {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.logging)
+    implementation(ktorLibs.serialization.kotlinx.json)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation("junit:junit:$junit_version")
     testImplementation("org.hamcrest:hamcrest:$hamcrest_version")

--- a/codeSnippets/snippets/client-ssl-config/build.gradle.kts
+++ b/codeSnippets/snippets/client-ssl-config/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val slf4j_version: String by project
@@ -18,12 +17,12 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-apache5:$ktor_version")
-    implementation("io.ktor:ktor-client-java:$ktor_version")
-    implementation("io.ktor:ktor-client-jetty-jakarta:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.apache5)
+    implementation(ktorLibs.client.java)
+    implementation(ktorLibs.client.jetty)
     implementation("org.eclipse.jetty:jetty-alpn-java-client:11.0.20")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-android:$ktor_version")
-    implementation("io.ktor:ktor-client-okhttp:$ktor_version")
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.android)
+    implementation(ktorLibs.client.okhttp)
 }

--- a/codeSnippets/snippets/client-submit-form/build.gradle.kts
+++ b/codeSnippets/snippets/client-submit-form/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -18,9 +17,9 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.logging)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     implementation(project(":post-form-parameters"))
     implementation(project(":e2e"))

--- a/codeSnippets/snippets/client-testing-mock/build.gradle.kts
+++ b/codeSnippets/snippets/client-testing-mock/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 
 plugins {
@@ -17,11 +16,11 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.contentNegotiation)
+    implementation(ktorLibs.serialization.kotlinx.json)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-client-mock:$ktor_version")
+    testImplementation(ktorLibs.client.mock)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/client-timeout/build.gradle.kts
+++ b/codeSnippets/snippets/client-timeout/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -18,8 +17,8 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     implementation(project(":simulate-slow-server"))
     implementation(project(":e2e"))

--- a/codeSnippets/snippets/client-type-safe-requests/build.gradle.kts
+++ b/codeSnippets/snippets/client-type-safe-requests/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -19,9 +18,9 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-resources:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.resources)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     implementation(project(":resource-routing"))
     implementation(project(":e2e"))

--- a/codeSnippets/snippets/client-upload-binary-data/build.gradle.kts
+++ b/codeSnippets/snippets/client-upload-binary-data/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 
@@ -17,9 +16,9 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.logging)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation("junit:junit:$junit_version")
     testImplementation(project(":e2e"))

--- a/codeSnippets/snippets/client-upload-progress/build.gradle.kts
+++ b/codeSnippets/snippets/client-upload-progress/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 
@@ -17,9 +16,9 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.logging)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation("junit:junit:$junit_version")
     testImplementation(project(":e2e"))

--- a/codeSnippets/snippets/client-upload/build.gradle.kts
+++ b/codeSnippets/snippets/client-upload/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 
@@ -17,9 +16,9 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.logging)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation("junit:junit:$junit_version")
     testImplementation(project(":e2e"))

--- a/codeSnippets/snippets/client-validate-2xx-response/build.gradle.kts
+++ b/codeSnippets/snippets/client-validate-2xx-response/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -19,12 +18,12 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.contentNegotiation)
+    implementation(ktorLibs.serialization.kotlinx.json)
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     implementation(project(":json-kotlinx"))
     implementation(project(":e2e"))

--- a/codeSnippets/snippets/client-validate-non-2xx-response/build.gradle.kts
+++ b/codeSnippets/snippets/client-validate-non-2xx-response/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 
@@ -17,9 +16,9 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.logging)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation("junit:junit:$junit_version")
     testImplementation(project(":e2e"))

--- a/codeSnippets/snippets/client-websockets-serialization/build.gradle.kts
+++ b/codeSnippets/snippets/client-websockets-serialization/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -23,14 +22,14 @@ tasks.named<JavaExec>("run") {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-websockets:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-xml:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-cbor:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-protobuf:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.websockets)
+    implementation(ktorLibs.serialization.kotlinx.json)
+    implementation(ktorLibs.serialization.kotlinx.xml)
+    implementation(ktorLibs.serialization.kotlinx.cbor)
+    implementation(ktorLibs.serialization.kotlinx.protobuf)
+    implementation(ktorLibs.client.logging)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation("junit:junit:$junit_version")
     testImplementation("org.hamcrest:hamcrest:$hamcrest_version")

--- a/codeSnippets/snippets/client-websockets/build.gradle.kts
+++ b/codeSnippets/snippets/client-websockets/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 val junit_version: String by project
 val hamcrest_version: String by project
@@ -22,10 +21,10 @@ tasks.named<JavaExec>("run") {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-websockets:$ktor_version")
-    implementation("io.ktor:ktor-client-logging:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
+    implementation(ktorLibs.client.websockets)
+    implementation(ktorLibs.client.logging)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation("junit:junit:$junit_version")
     testImplementation("org.hamcrest:hamcrest:$hamcrest_version")

--- a/codeSnippets/snippets/compression/build.gradle.kts
+++ b/codeSnippets/snippets/compression/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,11 +17,11 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-compression:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.compression)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }
 

--- a/codeSnippets/snippets/conditional-headers/build.gradle.kts
+++ b/codeSnippets/snippets/conditional-headers/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val kotlin_css_version: String by project
 val logback_version: String by project
@@ -19,10 +18,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-conditional-headers:$ktor_version")
-    implementation("io.ktor:ktor-server-html-builder:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.conditionalHeaders)
+    implementation(ktorLibs.server.htmlBuilder)
     implementation("org.jetbrains.kotlin-wrappers:kotlin-css:$kotlin_css_version")
     implementation("ch.qos.logback:logback-classic:$logback_version")
 }

--- a/codeSnippets/snippets/cors/build.gradle.kts
+++ b/codeSnippets/snippets/cors/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val junit_version: String by project
@@ -20,14 +19,14 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-cors:$ktor_version")
-    implementation("io.ktor:ktor-server-content-negotiation:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
-    implementation("io.ktor:ktor-server-html-builder:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.cors)
+    implementation(ktorLibs.server.contentNegotiation)
+    implementation(ktorLibs.serialization.kotlinx.json)
+    implementation(ktorLibs.server.htmlBuilder)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
-    testImplementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
+    testImplementation(ktorLibs.client.contentNegotiation)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/css-dsl/build.gradle.kts
+++ b/codeSnippets/snippets/css-dsl/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val kotlin_css_version: String by project
 val logback_version: String by project
@@ -19,11 +18,11 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-html-builder:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.htmlBuilder)
     implementation("org.jetbrains.kotlin-wrappers:kotlin-css:$kotlin_css_version")
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/custom-plugin-authorization/build.gradle.kts
+++ b/codeSnippets/snippets/custom-plugin-authorization/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,10 +17,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-auth:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.auth)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/custom-plugin-base-api/build.gradle.kts
+++ b/codeSnippets/snippets/custom-plugin-base-api/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,9 +17,9 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/custom-plugin/build.gradle.kts
+++ b/codeSnippets/snippets/custom-plugin/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,10 +17,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-config-yaml:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.config.yaml)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/data-conversion/build.gradle.kts
+++ b/codeSnippets/snippets/data-conversion/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,11 +17,11 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-data-conversion:$ktor_version")
-    implementation("io.ktor:ktor-server-html-builder:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.dataConversion)
+    implementation(ktorLibs.server.htmlBuilder)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/deployment-ktor-plugin/build.gradle.kts
+++ b/codeSnippets/snippets/deployment-ktor-plugin/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.5.2"
+    alias(ktorLibs.plugins.ktor)
 }
 
 application {
@@ -18,10 +18,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core-jvm")
-    implementation("io.ktor:ktor-server-cio-jvm")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.cio)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }
 

--- a/codeSnippets/snippets/double-receive/build.gradle.kts
+++ b/codeSnippets/snippets/double-receive/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val junit_version: String by project
@@ -19,11 +18,11 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-double-receive:$ktor_version")
-    implementation("io.ktor:ktor-server-call-logging:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.doubleReceive)
+    implementation(ktorLibs.server.callLogging)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/download-file/build.gradle.kts
+++ b/codeSnippets/snippets/download-file/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val junit_version: String by project
@@ -19,11 +18,11 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-partial-content:$ktor_version")
-    implementation("io.ktor:ktor-server-auto-head-response:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.partialContent)
+    implementation(ktorLibs.server.autoHeadResponse)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("junit:junit:$junit_version")
 }

--- a/codeSnippets/snippets/dropwizard-metrics/build.gradle.kts
+++ b/codeSnippets/snippets/dropwizard-metrics/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val dropwizard_version: String by project
@@ -19,9 +18,9 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-metrics:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.metrics)
     implementation("io.dropwizard.metrics:metrics-jmx:$dropwizard_version")
     implementation("ch.qos.logback:logback-classic:$logback_version")
 }

--- a/codeSnippets/snippets/e2e/build.gradle.kts
+++ b/codeSnippets/snippets/e2e/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val junit_version: String by project
 
 plugins {
@@ -12,8 +11,8 @@ repositories {
 
 dependencies {
     implementation("junit:junit:$junit_version")
-    api("io.ktor:ktor-server-core:$ktor_version")
-    api("io.ktor:ktor-server-cio:$ktor_version")
+    api(ktorLibs.server.core)
+    api(ktorLibs.server.cio)
 }
 
 kotlin {

--- a/codeSnippets/snippets/embedded-server-modules/build.gradle.kts
+++ b/codeSnippets/snippets/embedded-server-modules/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,9 +17,9 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/embedded-server-multiple-connectors/build.gradle.kts
+++ b/codeSnippets/snippets/embedded-server-multiple-connectors/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val junit_version: String by project
@@ -19,9 +18,9 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/embedded-server-native/build.gradle.kts
+++ b/codeSnippets/snippets/embedded-server-native/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -33,12 +32,12 @@ kotlin {
     }
     sourceSets {
         nativeMain.dependencies {
-            implementation("io.ktor:ktor-server-core:$ktor_version")
-            implementation("io.ktor:ktor-server-cio:$ktor_version")
+            implementation(ktorLibs.server.core)
+            implementation(ktorLibs.server.cio)
         }
         nativeTest.dependencies {
             implementation(kotlin("test"))
-            implementation("io.ktor:ktor-server-test-host:$ktor_version")
+            implementation(ktorLibs.server.testHost)
         }
     }
 }

--- a/codeSnippets/snippets/embedded-server/build.gradle.kts
+++ b/codeSnippets/snippets/embedded-server/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val junit_version: String by project
@@ -27,13 +26,13 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
 
     testImplementation("junit:junit:$junit_version")
     testImplementation(project(":e2e"))
 
-    testImplementation("io.ktor:ktor-client-core:$ktor_version")
-    testImplementation("io.ktor:ktor-client-cio:$ktor_version")
+    testImplementation(ktorLibs.client.core)
+    testImplementation(ktorLibs.client.cio)
 }

--- a/codeSnippets/snippets/engine-main-custom-environment/build.gradle.kts
+++ b/codeSnippets/snippets/engine-main-custom-environment/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.5.2"
+    alias(ktorLibs.plugins.ktor)
 }
 
 application {
@@ -18,10 +18,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core-jvm")
-    implementation("io.ktor:ktor-server-netty-jvm")
-    implementation("io.ktor:ktor-server-config-yaml-jvm")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.config.yaml)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/engine-main-modules/build.gradle.kts
+++ b/codeSnippets/snippets/engine-main-modules/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,10 +17,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-config-yaml:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.config.yaml)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/engine-main-yaml/build.gradle.kts
+++ b/codeSnippets/snippets/engine-main-yaml/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,10 +17,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-config-yaml:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.config.yaml)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/engine-main/build.gradle.kts
+++ b/codeSnippets/snippets/engine-main/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,9 +17,9 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/events/build.gradle.kts
+++ b/codeSnippets/snippets/events/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,9 +17,9 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/forwarded-header/build.gradle.kts
+++ b/codeSnippets/snippets/forwarded-header/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.5.2"
+    alias(ktorLibs.plugins.ktor)
 }
 
 application {
@@ -18,10 +18,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core-jvm")
-    implementation("io.ktor:ktor-server-netty-jvm")
-    implementation("io.ktor:ktor-server-forwarded-header-jvm")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.forwardedHeader)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/freemarker/build.gradle.kts
+++ b/codeSnippets/snippets/freemarker/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val junit_version: String by project
@@ -19,11 +18,11 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-freemarker:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.freemarker)
     implementation("ch.qos.logback:logback-classic:$logback_version")
 
     testImplementation("junit:junit:$junit_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
 }

--- a/codeSnippets/snippets/google-appengine-standard/build.gradle.kts
+++ b/codeSnippets/snippets/google-appengine-standard/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.google.cloud.tools.gradle.appengine.appyaml.AppEngineAppYamlExtension
 
-val ktor_version: String by project
 val kotlin_version: String by project
 val gce_logback_version: String by project
 
@@ -32,9 +31,9 @@ configure<AppEngineAppYamlExtension> {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("com.google.cloud:google-cloud-logging-logback:$gce_logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/gson/build.gradle.kts
+++ b/codeSnippets/snippets/gson/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,15 +17,15 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-compression:$ktor_version")
-    implementation("io.ktor:ktor-server-call-logging:$ktor_version")
-    implementation("io.ktor:ktor-server-default-headers:$ktor_version")
-    implementation("io.ktor:ktor-server-content-negotiation:$ktor_version")
-    implementation("io.ktor:ktor-serialization-gson:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.compression)
+    implementation(ktorLibs.server.callLogging)
+    implementation(ktorLibs.server.defaultHeaders)
+    implementation(ktorLibs.server.contentNegotiation)
+    implementation(ktorLibs.serialization.gson)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.client.contentNegotiation)
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/guice/build.gradle.kts
+++ b/codeSnippets/snippets/guice/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val guice_version: String by project
@@ -19,11 +18,11 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-html-builder:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.htmlBuilder)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     implementation("com.google.inject:guice:$guice_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/html-templates/build.gradle.kts
+++ b/codeSnippets/snippets/html-templates/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,10 +17,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-html-builder:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.htmlBuilder)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/html/build.gradle.kts
+++ b/codeSnippets/snippets/html/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,10 +17,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-html-builder:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.htmlBuilder)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/htmx-integration/build.gradle.kts
+++ b/codeSnippets/snippets/htmx-integration/build.gradle.kts
@@ -4,7 +4,7 @@ val logback_version: String by project
 
 plugins {
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.5.2"
+    alias(ktorLibs.plugins.ktor)
 }
 
 group = "com.example"
@@ -19,15 +19,15 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-server-core-jvm")
-    implementation("io.ktor:ktor-server-netty")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    implementation("io.ktor:ktor-server-core")
-    implementation("io.ktor:ktor-server-htmx")
-    implementation("io.ktor:ktor-htmx")
-    implementation("io.ktor:ktor-htmx-html")
-    implementation("io.ktor:ktor-server-html-builder")
-    implementation("io.ktor:ktor-server-config-yaml")
-    testImplementation("io.ktor:ktor-server-test-host")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.htmx)
+    implementation(ktorLibs.htmx)
+    implementation(ktorLibs.htmx.html)
+    implementation(ktorLibs.server.htmlBuilder)
+    implementation(ktorLibs.server.config.yaml)
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
 }

--- a/codeSnippets/snippets/http2-jetty/build.gradle.kts
+++ b/codeSnippets/snippets/http2-jetty/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,8 +17,8 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-jetty-jakarta:$ktor_version")
-    implementation("io.ktor:ktor-server-html-builder:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.jetty)
+    implementation(ktorLibs.server.htmlBuilder)
     implementation("ch.qos.logback:logback-classic:$logback_version")
 }

--- a/codeSnippets/snippets/http2-netty/build.gradle.kts
+++ b/codeSnippets/snippets/http2-netty/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val tcnative_version = "2.0.72.Final"
@@ -27,9 +26,9 @@ val tcnative_classifier = when {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-html-builder:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.htmlBuilder)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     if (tcnative_classifier != null) {
         implementation("io.netty:netty-tcnative-boringssl-static:$tcnative_version:$tcnative_classifier")

--- a/codeSnippets/snippets/http2-push/build.gradle.kts
+++ b/codeSnippets/snippets/http2-push/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val tcnative_version = "2.0.72.Final"
@@ -27,13 +26,13 @@ val tcnative_classifier = when {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-html-builder:$ktor_version")
-    implementation("io.ktor:ktor-server-default-headers:$ktor_version")
-    implementation("io.ktor:ktor-server-call-logging:$ktor_version")
-    implementation("io.ktor:ktor-network-tls:$ktor_version")
-    implementation("io.ktor:ktor-network-tls-certificates:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.htmlBuilder)
+    implementation(ktorLibs.server.defaultHeaders)
+    implementation(ktorLibs.server.callLogging)
+    implementation(ktorLibs.network.tls)
+    implementation(ktorLibs.network.tls.certificates)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     if (tcnative_classifier != null) {
         implementation("io.netty:netty-tcnative-boringssl-static:$tcnative_version:$tcnative_classifier")

--- a/codeSnippets/snippets/jackson/build.gradle.kts
+++ b/codeSnippets/snippets/jackson/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val jackson_version = "2.17.2"
@@ -19,15 +18,15 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-compression:$ktor_version")
-    implementation("io.ktor:ktor-server-call-logging:$ktor_version")
-    implementation("io.ktor:ktor-server-default-headers:$ktor_version")
-    implementation("io.ktor:ktor-server-content-negotiation:$ktor_version")
-    implementation("io.ktor:ktor-serialization-jackson:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.compression)
+    implementation(ktorLibs.server.callLogging)
+    implementation(ktorLibs.server.defaultHeaders)
+    implementation(ktorLibs.server.contentNegotiation)
+    implementation(ktorLibs.serialization.jackson)
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version")
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/jetty-war/build.gradle.kts
+++ b/codeSnippets/snippets/jetty-war/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -21,10 +20,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-servlet-jakarta:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.servlet)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }
 

--- a/codeSnippets/snippets/json-kotlinx-method-override/build.gradle.kts
+++ b/codeSnippets/snippets/json-kotlinx-method-override/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -19,12 +18,12 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-content-negotiation:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
-    implementation("io.ktor:ktor-server-method-override:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.contentNegotiation)
+    implementation(ktorLibs.serialization.kotlinx.json)
+    implementation(ktorLibs.server.methodOverride)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
 }

--- a/codeSnippets/snippets/json-kotlinx-openapi/build.gradle.kts
+++ b/codeSnippets/snippets/json-kotlinx-openapi/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version = "2.2.20"
 val logback_version: String by project
 val swagger_codegen_version: String by project
@@ -20,17 +19,17 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-swagger:$ktor_version")
-    implementation("io.ktor:ktor-server-openapi:$ktor_version")
-    implementation("io.ktor:ktor-server-cors:$ktor_version")
-    implementation("io.ktor:ktor-server-content-negotiation:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
-    implementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
-    implementation("io.ktor:ktor-server-routing-openapi:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.swagger)
+    implementation(ktorLibs.server.openapi)
+    implementation(ktorLibs.server.cors)
+    implementation(ktorLibs.server.contentNegotiation)
+    implementation(ktorLibs.serialization.kotlinx.json)
+    implementation(ktorLibs.client.contentNegotiation)
+    implementation(ktorLibs.server.routingOpenapi)
     implementation("io.swagger.codegen.v3:swagger-codegen-generators:$swagger_codegen_version")
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
 }

--- a/codeSnippets/snippets/json-kotlinx/build.gradle.kts
+++ b/codeSnippets/snippets/json-kotlinx/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -19,15 +18,15 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-content-negotiation:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-xml:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-cbor:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-protobuf:$ktor_version")
-    implementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.contentNegotiation)
+    implementation(ktorLibs.serialization.kotlinx.json)
+    implementation(ktorLibs.serialization.kotlinx.xml)
+    implementation(ktorLibs.serialization.kotlinx.cbor)
+    implementation(ktorLibs.serialization.kotlinx.protobuf)
+    implementation(ktorLibs.client.contentNegotiation)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
 }

--- a/codeSnippets/snippets/jte/build.gradle.kts
+++ b/codeSnippets/snippets/jte/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val jte_version: String by project
@@ -18,12 +17,12 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-jte:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.jte)
     implementation("gg.jte:jte-kotlin:$jte_version")
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }
 

--- a/codeSnippets/snippets/logging/build.gradle.kts
+++ b/codeSnippets/snippets/logging/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val log4j_version: String by project
@@ -19,9 +18,9 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-call-logging:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.callLogging)
     implementation("ch.qos.logback:logback-classic:$logback_version")
 /*    implementation("org.apache.logging.log4j:log4j-core:$log4j_version")
     implementation("org.apache.logging.log4j:log4j-slf4j2-impl:$log4j_version")*/

--- a/codeSnippets/snippets/micrometer-metrics/build.gradle.kts
+++ b/codeSnippets/snippets/micrometer-metrics/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val prometheus_version: String by project
@@ -19,11 +18,11 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-metrics-micrometer:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.metrics.micrometer)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     implementation("io.micrometer:micrometer-registry-prometheus:$prometheus_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/mustache/build.gradle.kts
+++ b/codeSnippets/snippets/mustache/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,10 +17,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-mustache:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.mustache)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/openapi-spec-gen/build.gradle.kts
+++ b/codeSnippets/snippets/openapi-spec-gen/build.gradle.kts
@@ -1,11 +1,10 @@
-val ktor_version: String by project
 val kotlin_version = "2.2.20"
 val logback_version: String by project
 
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.5.2"
+    alias(ktorLibs.plugins.ktor)
 }
 
 application {
@@ -27,14 +26,14 @@ ktor {
 
 
 dependencies {
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-routing-openapi:$ktor_version")
-    implementation("io.ktor:ktor-server-openapi:$ktor_version")
-    implementation("io.ktor:ktor-server-content-negotiation:${ktor_version}")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:${ktor_version}")
-    implementation("io.ktor:ktor-server-swagger:${ktor_version}")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.routingOpenapi)
+    implementation(ktorLibs.server.openapi)
+    implementation(ktorLibs.server.contentNegotiation)
+    implementation(ktorLibs.serialization.kotlinx.json)
+    implementation(ktorLibs.server.swagger)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/pebble/build.gradle.kts
+++ b/codeSnippets/snippets/pebble/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,10 +17,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-pebble:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.pebble)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/post-form-parameters/build.gradle.kts
+++ b/codeSnippets/snippets/post-form-parameters/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,10 +17,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-html-builder:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.htmlBuilder)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/post-raw-data/build.gradle.kts
+++ b/codeSnippets/snippets/post-raw-data/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,9 +17,9 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/proguard/build.gradle.kts
+++ b/codeSnippets/snippets/proguard/build.gradle.kts
@@ -17,7 +17,7 @@ buildscript {
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.5.2"
+    alias(ktorLibs.plugins.ktor)
 }
 
 application {
@@ -31,8 +31,8 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core-jvm")
-    implementation("io.ktor:ktor-server-netty-jvm")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
 }
 

--- a/codeSnippets/snippets/rate-limit/build.gradle.kts
+++ b/codeSnippets/snippets/rate-limit/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,11 +17,11 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-rate-limit:$ktor_version")
-    implementation("io.ktor:ktor-server-status-pages:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.rateLimit)
+    implementation(ktorLibs.server.statusPages)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/request-validation/build.gradle.kts
+++ b/codeSnippets/snippets/request-validation/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -19,14 +18,14 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-request-validation:$ktor_version")
-    implementation("io.ktor:ktor-server-status-pages:$ktor_version")
-    implementation("io.ktor:ktor-server-content-negotiation:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.requestValidation)
+    implementation(ktorLibs.server.statusPages)
+    implementation(ktorLibs.server.contentNegotiation)
+    implementation(ktorLibs.serialization.kotlinx.json)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
-    testImplementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
+    testImplementation(ktorLibs.client.contentNegotiation)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/resource-routing/build.gradle.kts
+++ b/codeSnippets/snippets/resource-routing/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -19,11 +18,11 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-resources:$ktor_version")
-    implementation("io.ktor:ktor-server-html-builder:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.resources)
+    implementation(ktorLibs.server.htmlBuilder)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/server-di/build.gradle.kts
+++ b/codeSnippets/snippets/server-di/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -21,13 +20,13 @@ tasks.withType<Test> {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-server-core-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-di:$ktor_version")
-    implementation("io.ktor:ktor-server-netty-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-config-yaml:${ktor_version}")
-    implementation("io.ktor:ktor-server-content-negotiation-jvm:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json-jvm:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.di)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.config.yaml)
+    implementation(ktorLibs.server.contentNegotiation)
+    implementation(ktorLibs.serialization.kotlinx.json)
     implementation("ch.qos.logback:logback-classic:${logback_version}")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation(kotlin("test"))
 }

--- a/codeSnippets/snippets/server-http-request-lifecycle/build.gradle.kts
+++ b/codeSnippets/snippets/server-http-request-lifecycle/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -19,12 +18,12 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
-    testImplementation("io.ktor:ktor-server-netty")
-    testImplementation("io.ktor:ktor-client-cio")
+    testImplementation(ktorLibs.server.testHost)
+    testImplementation(ktorLibs.server.netty)
+    testImplementation(ktorLibs.client.cio)
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
     testImplementation(kotlin("test"))
 }

--- a/codeSnippets/snippets/server-io-interop/build.gradle.kts
+++ b/codeSnippets/snippets/server-io-interop/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,9 +17,9 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/server-sse/build.gradle.kts
+++ b/codeSnippets/snippets/server-sse/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -19,11 +18,11 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-sse:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.sse)
+    implementation(ktorLibs.serialization.kotlinx.json)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/server-websockets-serialization/build.gradle.kts
+++ b/codeSnippets/snippets/server-websockets-serialization/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -19,14 +18,14 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-websockets:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-xml:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-cbor:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-protobuf:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.websockets)
+    implementation(ktorLibs.serialization.kotlinx.json)
+    implementation(ktorLibs.serialization.kotlinx.xml)
+    implementation(ktorLibs.serialization.kotlinx.cbor)
+    implementation(ktorLibs.serialization.kotlinx.protobuf)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/server-websockets-sharedflow/build.gradle.kts
+++ b/codeSnippets/snippets/server-websockets-sharedflow/build.gradle.kts
@@ -1,11 +1,10 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.5.2"
+    alias(ktorLibs.plugins.ktor)
     kotlin("plugin.serialization").version("2.2.20")
 }
 
@@ -19,11 +18,11 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-server-core-jvm")
-    implementation("io.ktor:ktor-server-websockets-jvm")
-    implementation("io.ktor:ktor-server-netty-jvm")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.websockets)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.serialization.kotlinx.json)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
 }

--- a/codeSnippets/snippets/server-websockets/build.gradle.kts
+++ b/codeSnippets/snippets/server-websockets/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,10 +17,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-websockets:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.websockets)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/session-cookie-client/build.gradle.kts
+++ b/codeSnippets/snippets/session-cookie-client/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -19,11 +18,11 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-sessions:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.sessions)
+    implementation(ktorLibs.serialization.kotlinx.json)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/session-cookie-server/build.gradle.kts
+++ b/codeSnippets/snippets/session-cookie-server/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -19,11 +18,11 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-sessions:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.sessions)
+    implementation(ktorLibs.serialization.kotlinx.json)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/session-header-server/build.gradle.kts
+++ b/codeSnippets/snippets/session-header-server/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -19,11 +18,11 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-sessions:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.sessions)
+    implementation(ktorLibs.serialization.kotlinx.json)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/shutdown-url/build.gradle.kts
+++ b/codeSnippets/snippets/shutdown-url/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,10 +17,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-config-yaml:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.config.yaml)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/simulate-slow-server/build.gradle.kts
+++ b/codeSnippets/snippets/simulate-slow-server/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,9 +17,9 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/single-page-application/build.gradle.kts
+++ b/codeSnippets/snippets/single-page-application/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,9 +17,9 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/sockets-client-tls/build.gradle.kts
+++ b/codeSnippets/snippets/sockets-client-tls/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -22,7 +21,7 @@ tasks.named<JavaExec>("run") {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-network:$ktor_version")
-    implementation("io.ktor:ktor-network-tls:$ktor_version")
+    implementation(ktorLibs.network)
+    implementation(ktorLibs.network.tls)
     implementation("ch.qos.logback:logback-classic:$logback_version")
 }

--- a/codeSnippets/snippets/sockets-client/build.gradle.kts
+++ b/codeSnippets/snippets/sockets-client/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -22,7 +21,7 @@ tasks.named<JavaExec>("run") {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-network:$ktor_version")
-    implementation("io.ktor:ktor-network-tls:$ktor_version")
+    implementation(ktorLibs.network)
+    implementation(ktorLibs.network.tls)
     implementation("ch.qos.logback:logback-classic:$logback_version")
 }

--- a/codeSnippets/snippets/sockets-server/build.gradle.kts
+++ b/codeSnippets/snippets/sockets-server/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,6 +17,6 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-network:$ktor_version")
+    implementation(ktorLibs.network)
     implementation("ch.qos.logback:logback-classic:$logback_version")
 }

--- a/codeSnippets/snippets/ssl-embedded-server/build.gradle.kts
+++ b/codeSnippets/snippets/ssl-embedded-server/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val junit_version: String by project
@@ -19,12 +18,12 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-network-tls-certificates:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.network.tls.certificates)
     implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation("junit:junit:$junit_version")
     testImplementation(project(":e2e"))
-    testImplementation("io.ktor:ktor-client-core:$ktor_version")
-    testImplementation("io.ktor:ktor-client-cio:$ktor_version")
+    testImplementation(ktorLibs.client.core)
+    testImplementation(ktorLibs.client.cio)
 }

--- a/codeSnippets/snippets/ssl-engine-main-hsts/build.gradle.kts
+++ b/codeSnippets/snippets/ssl-engine-main-hsts/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val junit_version: String by project
@@ -19,12 +18,12 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-http-redirect:$ktor_version")
-    implementation("io.ktor:ktor-server-forwarded-header:$ktor_version")
-    implementation("io.ktor:ktor-server-hsts:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.httpRedirect)
+    implementation(ktorLibs.server.forwardedHeader)
+    implementation(ktorLibs.server.hsts)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/ssl-engine-main-redirect/build.gradle.kts
+++ b/codeSnippets/snippets/ssl-engine-main-redirect/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val junit_version: String by project
@@ -19,12 +18,12 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-http-redirect:$ktor_version")
-    implementation("io.ktor:ktor-server-forwarded-header:$ktor_version")
-    implementation("io.ktor:ktor-server-hsts:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.httpRedirect)
+    implementation(ktorLibs.server.forwardedHeader)
+    implementation(ktorLibs.server.hsts)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/ssl-engine-main/build.gradle.kts
+++ b/codeSnippets/snippets/ssl-engine-main/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val junit_version: String by project
@@ -19,10 +18,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-config-yaml:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.config.yaml)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/static-files/build.gradle.kts
+++ b/codeSnippets/snippets/static-files/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,10 +17,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-conditional-headers:${ktor_version}")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.conditionalHeaders)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/static-resources/build.gradle.kts
+++ b/codeSnippets/snippets/static-resources/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,9 +17,9 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/static-zip/build.gradle.kts
+++ b/codeSnippets/snippets/static-zip/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,9 +17,9 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/status-pages/build.gradle.kts
+++ b/codeSnippets/snippets/status-pages/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,10 +17,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-status-pages:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.statusPages)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/thymeleaf-auto-reload/build.gradle.kts
+++ b/codeSnippets/snippets/thymeleaf-auto-reload/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,10 +17,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-thymeleaf:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.thymeleaf)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/thymeleaf/build.gradle.kts
+++ b/codeSnippets/snippets/thymeleaf/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,10 +17,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-thymeleaf:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.thymeleaf)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/timeout/build.gradle.kts
+++ b/codeSnippets/snippets/timeout/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,16 +17,16 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-html-builder:$ktor_version")
-    implementation("io.ktor:ktor-server-auth-ldap:$ktor_version")
-    implementation("io.ktor:ktor-server-auth:$ktor_version")
-    implementation("io.ktor:ktor-server-auth-jwt:$ktor_version")
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-apache:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.htmlBuilder)
+    implementation(ktorLibs.server.auth.ldap)
+    implementation(ktorLibs.server.auth)
+    implementation(ktorLibs.server.auth.jwt)
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.apache)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-client-mock-jvm:$ktor_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.client.mock)
+    testImplementation(ktorLibs.server.testHost)
 }
 

--- a/codeSnippets/snippets/tomcat-war-ssl/build.gradle.kts
+++ b/codeSnippets/snippets/tomcat-war-ssl/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val slf4j_version: String by project
 
@@ -22,7 +21,7 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
-    implementation("io.ktor:ktor-server-servlet-jakarta:$ktor_version")
+    implementation(ktorLibs.server.servlet)
     implementation("org.slf4j:slf4j-jdk14:$slf4j_version")
 }
 

--- a/codeSnippets/snippets/tomcat-war/build.gradle.kts
+++ b/codeSnippets/snippets/tomcat-war/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val slf4j_version: String by project
 
@@ -20,9 +19,9 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-server-servlet-jakarta:$ktor_version")
+    implementation(ktorLibs.server.servlet)
     implementation("org.slf4j:slf4j-jdk14:$slf4j_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }
 

--- a/codeSnippets/snippets/tutorial-client-get-started/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-client-get-started/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val logback_version: String by project
 
 plugins {
@@ -16,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
+    implementation(ktorLibs.client.core)
+    implementation(ktorLibs.client.cio)
     implementation("ch.qos.logback:logback-classic:$logback_version")
 }

--- a/codeSnippets/snippets/tutorial-server-docker-compose/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-server-docker-compose/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val postgres_version: String by project
@@ -8,7 +7,7 @@ val h2_version: String by project
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.5.2"
+    alias(ktorLibs.plugins.ktor)
     id("org.jetbrains.kotlin.plugin.serialization") version "2.2.20"
 }
 
@@ -25,20 +24,20 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-server-core-jvm")
-    implementation("io.ktor:ktor-server-host-common-jvm")
-    implementation("io.ktor:ktor-server-status-pages-jvm")
-    implementation("io.ktor:ktor-serialization-kotlinx-json-jvm")
-    implementation("io.ktor:ktor-server-content-negotiation-jvm")
+    implementation(ktorLibs.server.core)
+    implementation("io.ktor:ktor-server-host-common:${ktorLibs.versions.ktor.get()}")
+    implementation(ktorLibs.server.statusPages)
+    implementation(ktorLibs.serialization.kotlinx.json)
+    implementation(ktorLibs.server.contentNegotiation)
     implementation("org.postgresql:postgresql:$postgres_version")
     implementation("com.h2database:h2:$h2_version")
     implementation("org.jetbrains.exposed:exposed-core:$exposed_version")
     implementation("org.jetbrains.exposed:exposed-jdbc:$exposed_version")
     implementation("org.jetbrains.exposed:exposed-dao:$exposed_version")
-    implementation("io.ktor:ktor-server-netty-jvm")
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    implementation("io.ktor:ktor-server-config-yaml:$ktor_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm")
-    testImplementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
+    implementation(ktorLibs.server.config.yaml)
+    testImplementation(ktorLibs.server.testHost)
+    testImplementation(ktorLibs.client.contentNegotiation)
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
 }

--- a/codeSnippets/snippets/tutorial-website-static/build.gradle.kts
+++ b/codeSnippets/snippets/tutorial-website-static/build.gradle.kts
@@ -1,11 +1,10 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
 plugins {
     application
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.5.2"
+    alias(ktorLibs.plugins.ktor)
 }
 
 application {
@@ -18,10 +17,10 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-server-core-jvm")
-    implementation("io.ktor:ktor-server-freemarker-jvm")
-    implementation("io.ktor:ktor-server-netty-jvm")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.freemarker)
+    implementation(ktorLibs.server.netty)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
 }

--- a/codeSnippets/snippets/upload-file/build.gradle.kts
+++ b/codeSnippets/snippets/upload-file/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,10 +17,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-html-builder:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.htmlBuilder)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/velocity/build.gradle.kts
+++ b/codeSnippets/snippets/velocity/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 
@@ -18,10 +17,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-velocity:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.velocity)
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/codeSnippets/snippets/webjars/build.gradle.kts
+++ b/codeSnippets/snippets/webjars/build.gradle.kts
@@ -1,4 +1,3 @@
-val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
 val bootstrap_version: String by project
@@ -19,11 +18,11 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-webjars:$ktor_version")
+    implementation(ktorLibs.server.core)
+    implementation(ktorLibs.server.netty)
+    implementation(ktorLibs.server.webjars)
     implementation("org.webjars:bootstrap:$bootstrap_version")
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")
+    testImplementation(ktorLibs.server.testHost)
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }


### PR DESCRIPTION
Made this change to make it easier to copy and paste Ktor libraries used in code snippets into projects using the latest Ktor versions