### PR TITLE
docs: feat: KTOR-9751 Additional type support for request parameters﻿

### DIFF
--- a/topics/server-data-conversion.md
+++ b/topics/server-data-conversion.md
@@ -20,8 +20,10 @@ The %plugin_name% plugin for the Ktor server allows you to add custom converters
 </link-summary>
 
 The [%plugin_name%](https://api.ktor.io/ktor-utils/io.ktor.util.converters/-data-conversion/index.html) plugin
-allows you to serialize and deserialize a list of values. By default, Ktor handles primitive types and enums through the
-[DefaultConversionService](https://api.ktor.io/ktor-utils/io.ktor.util.converters/-default-conversion-service/index.html).
+allows you to serialize and deserialize a list of values. By default, Ktor handles strings and common types,
+including numeric types, unsigned integer types, `Uuid`, and enums through
+[`DefaultConversionService`](https://api.ktor.io/ktor-utils/io.ktor.util.converters/-default-conversion-service/index.html).
+
 You can extend this service to handle additional types by installing and configuring the `%plugin_name%` plugin.
 
 ## Add dependencies {id="add_dependencies"}
@@ -57,9 +59,7 @@ functions to serialize and deserialize a list of values:
       }
   ```
 
-## Access the service
-
-{id="service"}
+## Access the service {id="service"}
 
 You can access the `%plugin_name%` service from the current context:
 

--- a/topics/whats-new-360.md
+++ b/topics/whats-new-360.md
@@ -11,5 +11,27 @@ Ktor 3.6.0 delivers a range of improvements across server and client. Highlights
 
 ## Ktor Server
 
+### Additional type support for request parameters
+
+Ktor 3.6.0 expands the set of types supported by default when converting request parameters to typed values.
+
+The following types are now supported:
+
+* `Uuid`
+* `Byte`
+* `java.lang.Byte`
+* `UByte`
+* `UShort`
+* `UInt`
+* `ULong`
+
+For example, you can retrieve a `Uuid` parameter directly inside a route handler through property delegation:
+
+```kotlin
+get {
+    val uuid: Uuid by call.parameters
+}
+```
+
 
 ## Ktor Client


### PR DESCRIPTION
**Description:**

- Add a what's new entry.
- Fix the intro of Data conversion plugin topic to clarify supported types.

**Related issue:**

[KTOR-9751](https://youtrack.jetbrains.com/issue/KTOR-9751) Documentation for DefaultConversionService: Support Uuid type introduced in Kotlin 2.0