### PR TITLE
KTOR-9756 Add docs for OpenAPI tag() config

### DIFF
--- a/topics/server-openapi.md
+++ b/topics/server-openapi.md
@@ -44,12 +44,6 @@ In both cases, the OpenAPI plugin assembles the specification on the server and 
 
   You can replace `$swagger_codegen_version` with the required version of the `swagger-codegen-generators` artifact, for example, `%swagger_codegen_version%`.
 
-> In Ktor 3.4.0, the `OpenAPI` plugin requires the `ktor-server-routing-openapi` dependency.
-> This was not an intentional breaking change and will be corrected in Ktor 3.4.1.
-> Add the dependency manually if you are using Ktor 3.4.0 to avoid runtime errors.
->
-{style="warning"}
-
 ## Use a static OpenAPI file {id="static-openapi-file"}
 
 To serve OpenAPI documentation from an existing specification, use the [`openAPI()`](%plugin_api_link%) function with
@@ -95,15 +89,45 @@ application.
 
 ## Configure OpenAPI {id="configure-openapi"}
 
-By default, documentation is rendered using `StaticHtml2Codegen`. You can customize the renderer inside the `openAPI {}`
-block:
+The `openAPI {}` configuration block lets you configure the generated OpenAPI document and how Ktor renders the
+documentation.
+
+### Configure document metadata
+
+You can define top-level OpenAPI metadata directly in the configuration block.
+
+For example, use `info` to specify general API information and `tag()` to define tags and their descriptions:
+
+```kotlin
+openAPI("openapi") {
+    info = OpenApiInfo("Books API from routes", "1.0.0")
+    tag(
+        name = "Books",
+        description = "Operations on books"
+    )
+}
+```
+
+You can also configure other top-level OpenAPI properties, such as servers, security requirements, reusable components,
+external documentation, and specification extensions.
+
+> For the complete set of available options, see the [`OpenAPIConfig`](https://api.ktor.io/ktor-server-openapi/io.ktor.server.plugins.openapi/-open-a-p-i-config/index.html)
+> API reference.
+>
+{style="tip"}
+
+### Configure the document renderer
+
+By default, documentation is rendered using `StaticHtml2Codegen`.
+
+To use a different renderer, assign it to the `codegen` property:
+
+```kotlin
+```
+{src="snippets/json-kotlinx-openapi/src/main/kotlin/com/example/Application.kt" include-lines="40,56-58,59"}
 
 > `StaticHtmlCodegen` and `StaticHtml2Codegen` support only OpenAPI 3.0.x documents. Using them with OpenAPI 3.1 documents may
 > produce incomplete or incorrect HTML. For OpenAPI 3.1, use the [`swaggerUI()`](server-swagger-ui.md) function with Swagger UI
 > 5.x. If you need to keep using the OpenAPI plugin's HTML renderer, keep the specification at OpenAPI 3.0.3.
 >
 {style="note"}
-
-```kotlin
-```
-{src="snippets/json-kotlinx-openapi/src/main/kotlin/com/example/Application.kt" include-lines="40,56-58,59"}

--- a/topics/server-swagger-ui.md
+++ b/topics/server-swagger-ui.md
@@ -33,12 +33,6 @@ Serving Swagger UI requires adding the `%artifact_name%` artifact in the build s
 
 <include from="lib.topic" element-id="add_ktor_artifact"/>
 
-> In Ktor 3.4.0, the `SwaggerUI` plugin requires the `ktor-server-routing-openapi` dependency.
-> This was not an intentional breaking change and will be corrected in Ktor 3.4.1.
-> Add the dependency manually if you are using Ktor 3.4.0 to avoid runtime errors.
-> 
-{style="warning"}
-
 ## Use a static OpenAPI file {id="static-openapi-file"}
 
 To serve Swagger UI from an existing OpenAPI specification file, use the [`swaggerUI()`](%plugin_api_link%) function and
@@ -82,8 +76,34 @@ the application.
 
 ## Configure Swagger UI
 
-You can customize Swagger UI within the `swaggerUI {}` block, for example, by overriding the default Swagger UI
-version:
+The `swaggerUI {}` configuration block lets you configure the OpenAPI document and customize Swagger UI.
+
+### Configure document metadata
+
+You can define top-level OpenAPI metadata directly in the configuration block.
+
+For example, use `info` to specify general API information and `tag()` to define tags and their descriptions:
+
+```kotlin
+swaggerUI("/swagger") {
+    info = OpenApiInfo("Books API from routes", "1.0.0")
+    tag(
+        name = "Books",
+        description = "Operations on books"
+    )
+}
+```
+You can also configure other top-level OpenAPI properties, such as servers, security requirements, reusable components,
+external documentation, and specification extensions.
+
+> For the complete set of available options, see the [`SwaggerConfig`](https://api.ktor.io/ktor-server-swagger/io.ktor.server.plugins.swagger/-swagger-config/index.html)
+> API reference.
+> 
+{style="tip"}
+
+### Configure the Swagger UI version
+
+By default, Ktor uses a predefined Swagger UI version. To use a different version, set the `version` property:
 
 ```kotlin
 ```

--- a/topics/whats-new-360.md
+++ b/topics/whats-new-360.md
@@ -33,5 +33,21 @@ get {
 }
 ```
 
+### OpenAPI tag descriptions
+
+You can now define descriptions for OpenAPI tags directly in the [`openAPI {}`](server-openapi.md) and [`swaggerUI {}`](server-swagger-ui.md)
+configuration blocks:
+
+```kotlin
+swaggerUI("/swagger") {
+    info = OpenApiInfo("Books API from routes", "1.0.0")
+    tag(
+        name = "Books",
+        description = "Operations on books"
+    )
+}
+```
+
+The tag description is added to the top-level metadata of the generated OpenAPI document.
 
 ## Ktor Client


### PR DESCRIPTION
**Description:**

- Add a what's new entry.
- Edit the config sections of the OpenAPI and SwaggerUI plugin topics.
  - Show `tag()` in the example config.
  - Add a link to the API ref.
- Remove the warnings for the required dependency with Ktor 3.4.0.

**Related issue:**

[KTOR-9756](https://youtrack.jetbrains.com/issue/KTOR-9756) Documentation for OpenAPI: No way to set tag description