### PR TITLE
KTOR-9803 Add docs for new ApplicationCall.respondHtmlPartial() function

### DIFF
--- a/codeSnippets/snippets/html/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/html/src/main/kotlin/com/example/Application.kt
@@ -26,7 +26,7 @@ fun Application.module() {
             }
         }
         get("/fragment") {
-            call.respondHtmlFragment(HttpStatusCode.Created) {
+            call.respondHtmlPartial(HttpStatusCode.Created) {
                 div("fragment") {
                     span { +"Created!" }
                 }

--- a/topics/server-html-dsl.md
+++ b/topics/server-html-dsl.md
@@ -82,7 +82,7 @@ For the full example, see [auth-form-html-dsl](https://github.com/ktorio/ktor-do
 
 ## Send partial HTML {id="html_fragments"}
 
-In addition to generating full HTML documents, you can also respond with HTML fragments using the `.respondHtmlFragment()`
+In addition to generating full HTML documents, you can also respond with HTML fragments using the `.respondHtmlPartial()`
 function.
 
 HTML fragments are useful when returning partial markup that does not require a full `<html>` document, such as dynamic

--- a/topics/server-responses.md
+++ b/topics/server-responses.md
@@ -43,7 +43,7 @@ To send full HTML documents built with Kotlin DSL, use the [`call.respondHtml()`
 #### Partial HTML fragments
 
 If you need to return only a fragment of HTML, without wrapping it in `<html>`, `<head>`, or `<body>`, you can use
-`call.respondHtmlFragment()`:
+`call.respondHtmlPartial()`:
 
 ```kotlin
 ```

--- a/topics/whats-new-360.md
+++ b/topics/whats-new-360.md
@@ -50,4 +50,21 @@ swaggerUI("/swagger") {
 
 The tag description is added to the top-level metadata of the generated OpenAPI document.
 
+### New `ApplicationCall.respondHtmlPartial()` function
+
+The new `.respondHtmlPartial()` function replaces `.respondHtmlFragment()` for responding
+with partial HTML content.
+
+It uses `TagConsumer<Appendable>` as the lambda receiver, which allows you to return unrestricted HTML content,
+such as table cells:
+
+```kotlin
+call.respondHtmlPartial(HttpStatusCode.Created) {
+    td { +"Created!" } 
+}
+```
+
+The previous `.respondHtmlFragment()` function uses `FlowContent`, which restricts the HTML elements that can be returned.
+It is now deprecated in favor of `.respondHtmlPartial()`.
+
 ## Ktor Client


### PR DESCRIPTION
**Description:**
- Add a what's new entry.
- Update code example and existing docs to use `respondHtmlPartial()` instead of `respondHtmlFragment()`

**Related issue:**
[KTOR-9803](https://youtrack.jetbrains.com/issue/KTOR-9803) Documentation for respondHtmlPartial