### PR TITLE
KTOR-9791 Add docs for onCallValidators and rate limiting authenticated users

### DIFF
--- a/codeSnippets/snippets/custom-plugin/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/custom-plugin/src/main/kotlin/com/example/Application.kt
@@ -28,5 +28,11 @@ fun Application.module() {
             val data = call.receive<Int>()
             call.respond(data)
         }
+        authenticate("auth") {
+            install(UserValidationPlugin)
+            get("/api") {
+                call.respondText("OK")
+            }
+        }
     }
 }

--- a/codeSnippets/snippets/custom-plugin/src/main/kotlin/com/example/plugins/UserValidationPlugin.kt
+++ b/codeSnippets/snippets/custom-plugin/src/main/kotlin/com/example/plugins/UserValidationPlugin.kt
@@ -3,8 +3,8 @@ package com.example.plugins
 import io.ktor.server.application.*
 
 val UserValidationPlugin = createRouteScopedPlugin("UserValidationPlugin") {
-    onCallValidators {
-        call -> val principal = call.principal<UserIdPrincipal>()
+    onCallValidators { call ->
+        val principal = call.principal<UserIdPrincipal>()
 
         if (principal != null) {
             application.log.info("Validating request for ${principal.name}")

--- a/codeSnippets/snippets/custom-plugin/src/main/kotlin/com/example/plugins/UserValidationPlugin.kt
+++ b/codeSnippets/snippets/custom-plugin/src/main/kotlin/com/example/plugins/UserValidationPlugin.kt
@@ -1,0 +1,13 @@
+package com.example.plugins
+
+import io.ktor.server.application.*
+
+val UserValidationPlugin = createRouteScopedPlugin("UserValidationPlugin") {
+    onCallValidators {
+        call -> val principal = call.principal<UserIdPrincipal>()
+
+        if (principal != null) {
+            application.log.info("Validating request for ${principal.name}")
+        }
+    }
+}

--- a/topics/lib.topic
+++ b/topics/lib.topic
@@ -8,16 +8,16 @@
 
     <snippet id="install_plugin">
         <p>
-            To <a href="server-plugins.md" anchor="install">install</a> the <code>%plugin_name%</code> plugin to the application,
+            To <a href="server-plugins.md" anchor="install">install</a> the <code>%plugin_name%</code> plugin to your application,
             pass it to the <code>install</code> function in the specified <a href="server-modules.md">module</a>.
-            The code snippets below show how to install <code>%plugin_name%</code> ...
+            The following examples show how to install <code>%plugin_name%</code>:
         </p>
         <list>
             <li>
-                ... inside the <code>embeddedServer</code> function call.
+                In an <code>embeddedServer()</code> function call.
             </li>
             <li>
-                ... inside the explicitly defined <code>module</code>, which is an extension function of the <code>Application</code> class.
+                In an explicitly defined <code>module()</code> extension function on the <code>Application</code> class.
             </li>
         </list>
         <tabs>
@@ -60,7 +60,7 @@
 
     <snippet id="add_ktor_artifact_intro">
         <p>
-            To use <code>%plugin_name%</code>, you need to include the <code>%artifact_name%</code> artifact in the build script:
+            To use <code>%plugin_name%</code>, add the <code>%artifact_name%</code> artifact to your build script:
         </p>
     </snippet>
 

--- a/topics/server-custom-plugins-base-api.md
+++ b/topics/server-custom-plugins-base-api.md
@@ -26,7 +26,7 @@ To create a custom plugin with the base API:
 
 ### Create a companion object {id="create-companion"}
 
-A custom plugin's class muat have a companion object that implements one of the following interfaces:
+A custom plugin's class must have a companion object that implements one of the following interfaces:
 
 * [`BaseApplicationPlugin`](https://api.ktor.io/ktor-server-core/io.ktor.server.application/-base-application-plugin/index.html) for application-level plugins.
 * [`BaseRouteScopedPlugin`](https://api.ktor.io/ktor-server-core/io.ktor.server.application/-base-route-scoped-plugin/index.html) for plugins that are [installed on a specific route](server-plugins.md#install-route).
@@ -118,7 +118,7 @@ First, define a configuration class inside the plugin class:
 ```
 {src="snippets/custom-plugin-base-api/src/main/kotlin/com/example/plugins/CustomHeader.kt" include-lines="11-14"}
 
-Plugin configuration properties are mutable during plugin installation. If the plugin uses these values in interceptors,
+You can update plugin configuration properties during plugin installation. If the plugin uses these values in interceptors,
 store them in local variables inside the `install()` function:
 
 ```kotlin
@@ -133,7 +133,8 @@ Then, in the `install()` function, read the configuration and use its properties
 
 ### Install a plugin {id="install"}
 
-To [install](server-plugins.md#install) a custom plugin to your application, call the `install()` function and pass the required [configuration](#plugin-configuration) parameters:
+To [install](server-plugins.md#install) a custom plugin to your application, call the `Application.install()` function and pass the required
+[configuration](#plugin-configuration) parameters:
 
 ```kotlin
 ```

--- a/topics/server-custom-plugins-base-api.md
+++ b/topics/server-custom-plugins-base-api.md
@@ -7,33 +7,35 @@
 <include from="lib.topic" element-id="download_example"/>
 </tldr>
 
-> Starting with v2.0.0, Ktor provides a new simplified API for [creating custom plugins](server-custom-plugins.md).
->
-{type="note"}
+Ktor provides a base API for developing custom [plugins](server-plugins.md) that implement reusable functionality across
+multiple applications.
 
-Ktor exposes API for developing custom [plugins](server-plugins.md) that implement common functionalities and can be reused in multiple applications. 
-This API allows you to intercept different [pipeline](#pipelines) phases to add custom logic to request/response processing.
-For example, you can intercept the `Monitoring` phase to log incoming requests or collect metrics.
+The base API lets you intercept different [pipeline](#pipelines) phases and add custom logic to request and response
+processing. For example, you can intercept the `Monitoring` phase to log incoming requests or collect metrics.
 
 ## Create a plugin {id="create"}
-To create a custom plugin, follow the steps below:
 
-1. Create a plugin class and [declare a companion object](#create-companion) that implements one of the following interfaces:
-   - [BaseApplicationPlugin](https://api.ktor.io/ktor-server-core/io.ktor.server.application/-base-application-plugin/index.html) if a plugin should work on an application level.
-   - [BaseRouteScopedPlugin](https://api.ktor.io/ktor-server-core/io.ktor.server.application/-base-route-scoped-plugin/index.html) if a plugin can be [installed to a specific route](server-plugins.md#install-route).
-2. [Implement](#implement) the `key` and `install` members of this companion object.
+To create a custom plugin with the base API:
+
+1. Create a plugin class and [declare a companion object](#create-companion) that implements a plugin interface.
+2. [Implement](#implement) the `key` property and the `install()` function in the companion object.
 3. Provide a [plugin configuration](#plugin-configuration).
-4. [Handle calls](#call-handling) by intercepting the required pipeline phases. 
-5. [Install a plugin](#install).
+4. [Handle calls](#call-handling) by intercepting the required pipeline phases.
+5. [Install the plugin](#install).
 
 
 ### Create a companion object {id="create-companion"}
 
-A custom plugin's class should have a companion object that implements the `BaseApplicationPlugin` or `BaseRouteScopedPlugin` interface.
-The `BaseApplicationPlugin` interface accepts three type parameters:
-- A type of pipeline this plugin is compatible with.
-- A [configuration object type](#plugin-configuration) for this plugin.
-- An instance type of the plugin object.
+A custom plugin's class muat have a companion object that implements one of the following interfaces:
+
+* [`BaseApplicationPlugin`](https://api.ktor.io/ktor-server-core/io.ktor.server.application/-base-application-plugin/index.html) for application-level plugins.
+* [`BaseRouteScopedPlugin`](https://api.ktor.io/ktor-server-core/io.ktor.server.application/-base-route-scoped-plugin/index.html) for plugins that are [installed on a specific route](server-plugins.md#install-route).
+
+The `BaseApplicationPlugin` interface accepts the following type parameters:
+
+* The pipeline type that the plugin supports.
+* The [configuration type](#plugin-configuration) for the plugin.
+* The plugin instance type.
 
 ```kotlin
 class CustomHeader() {
@@ -43,11 +45,14 @@ class CustomHeader() {
 }
 ```
 
-### Implement the 'key' and 'install' members {id="implement"}
+### Implement the 'key' property and 'install()' function {id="implement"}
 
-As a descendant of the `BaseApplicationPlugin` interface, a companion object should implement two members:
-- The `key` property is used to identify a plugin. Ktor has a map of all attributes, and each plugin adds itself to this map using the specified key.
-- The `install` function allows you to configure how your plugin works. Here you need to intercept a pipeline and return a plugin instance. We'll take a look at how to intercept a pipeline and handle calls in the [next chapter](#call-handling).
+A companion object that implements `BaseApplicationPlugin` must define the following:
+
+* The `key` property identifies the plugin. Ktor stores plugin instances in the application's attributes and uses this key
+  to access the plugin instance.
+* The `install()` function configures the plugin. In this function, intercept the required pipeline phases and return the
+  plugin instance. The [Handle calls](#call-handling) section shows how to intercept a pipeline phase.
 
 ```kotlin
 class CustomHeader() {
@@ -64,13 +69,20 @@ class CustomHeader() {
 
 ### Handle calls {id="call-handling"}
 
-In your custom plugin, you can handle requests and responses by intercepting [existing pipeline phases](#pipelines) or newly defined ones. For example, the [Authentication](server-auth.md) plugin adds the `Authenticate` and `Challenge` custom phases to the default pipeline. So, intercepting a specific pipeline allows you to access different stages of a call, for instance:
+In a custom plugin, you can handle requests and responses by intercepting [existing pipeline phases](#pipelines) or newly defined
+ones. For example, the [Authentication](server-auth.md) plugin adds the `Authenticate` and `Challenge` custom phases to the default
+pipeline.
 
-- `ApplicationCallPipeline.Monitoring`: intercepting this phase can be used for request logging or collecting metrics.
-- `ApplicationCallPipeline.Plugins`: can be used to modify response parameters, for instance, append custom headers.
-- `ApplicationReceivePipeline.Transform` and `ApplicationSendPipeline.Transform`: allow you to obtain and [transform data](#transform) received from the client and transform data before sending it back.
+Intercepting a specific phase gives you access to a specific stage of call processing:
 
-The example below demonstrates how to intercept the `ApplicationCallPipeline.Plugins` phase and append a custom header to each response:
+* `ApplicationCallPipeline.Monitoring`: use this phase for request logging, metrics, tracing, and similar monitoring
+  tasks.
+* `ApplicationCallPipeline.Plugins`: use this phase to handle calls or modify response parameters, such as appending
+  custom headers.
+* `ApplicationReceivePipeline.Transform` and `ApplicationSendPipeline.Transform`: use these phases to access and
+  [transform](#transform) data received from the client or sent to the client.
+
+The following example intercepts the `ApplicationCallPipeline.Plugins` phase and appends a custom header to each response:
 
 ```kotlin
 class CustomHeader() {
@@ -87,36 +99,41 @@ class CustomHeader() {
 }
 ```
 
-Note that a custom header name and value in this plugin are hardcoded. You can make this plugin more flexible by [providing a configuration](#plugin-configuration) for passing the required custom header name/value.
+In this example, the header name and value are hardcoded. To make the plugin reusable, [provide a configuration](#plugin-configuration)
+that lets users specify the header name and value.
 
-> Custom plugins allow you to share any value related to a call, so you can access this value inside any handler processing this call. You can learn more from [](server-custom-plugins.md#call-state).
-
+> Custom plugins can share values associated with a call between different handlers. To learn more, see
+> [](server-custom-plugins.md#call-state).
+>
+{style="tip"}
 
 ### Provide plugin configuration {id="plugin-configuration"}
 
-The [previous chapter](#call-handling) shows how to create a plugin that appends a predefined custom header to each response. Let's make this plugin more useful and provide a configuration for passing the required custom header name/value. First, you need to define a configuration class inside a plugin's class:
+The [previous section](#call-handling) shows how to create a plugin that appends a predefined custom header to each
+response. To make this plugin reusable, define a configuration that lets users specify the header name and value.
+
+First, define a configuration class inside the plugin class:
 
 ```kotlin
 ```
 {src="snippets/custom-plugin-base-api/src/main/kotlin/com/example/plugins/CustomHeader.kt" include-lines="11-14"}
 
-Given that plugin configuration fields are mutable, saving them in local variables is recommended:
+Plugin configuration properties are mutable during plugin installation. If the plugin uses these values in interceptors,
+store them in local variables inside the `install()` function:
 
 ```kotlin
 ```
 {src="snippets/custom-plugin-base-api/src/main/kotlin/com/example/plugins/CustomHeader.kt" include-lines="7-14,27"}
 
-Finally, in the `install` function, you can get this configuration and use its properties 
+Then, in the `install()` function, read the configuration and use its properties:
 
 ```kotlin
 ```
 {src="snippets/custom-plugin-base-api/src/main/kotlin/com/example/plugins/CustomHeader.kt" include-lines="7-27"}
 
-
-
 ### Install a plugin {id="install"}
 
-To [install](server-plugins.md#install) a custom plugin to your application, call the `install` function and pass the desired [configuration](#plugin-configuration) parameters:
+To [install](server-plugins.md#install) a custom plugin to your application, call the `install()` function and pass the required [configuration](#plugin-configuration) parameters:
 
 ```kotlin
 ```
@@ -125,12 +142,15 @@ To [install](server-plugins.md#install) a custom plugin to your application, cal
 
 ## Examples {id="examples"}
 
-The code snippets below demonstrate several examples of custom plugins.
-You can find the runnable project here: [custom-plugin-base-api](https://github.com/ktorio/ktor-documentation/blob/%ktor_version%/codeSnippets/snippets/custom-plugin-base-api)
+The following examples show several custom plugins built with the base API.
+
+> For the full runnable project, see [custom-plugin-base-api](https://github.com/ktorio/ktor-documentation/blob/%ktor_version%/codeSnippets/snippets/custom-plugin-base-api).
+>
+{style="tip"}
 
 ### Request logging {id="request-logging"}
 
-The example below shows how to create a custom plugin for logging incoming requests:
+The following example creates a custom plugin that logs incoming requests:
 
 ```kotlin
 ```
@@ -138,7 +158,7 @@ The example below shows how to create a custom plugin for logging incoming reque
 
 ### Custom header {id="custom-header"}
 
-This example demonstrates how to create a plugin that appends a custom header to each response:
+The following example creates a plugin that appends a custom header to each response:
 
 ```kotlin
 ```
@@ -147,9 +167,7 @@ This example demonstrates how to create a plugin that appends a custom header to
 
 ### Body transformation {id="transform"}
 
-The example below shows how to:
-- transform data received from the client; 
-- transform data to be sent to the client.
+The following example creates a plugin that transforms request and response bodies:
 
 ```kotlin
 ```
@@ -157,31 +175,37 @@ The example below shows how to:
 
 ## Pipelines {id="pipelines"}
 
-A [Pipeline](https://api.ktor.io/ktor-utils/io.ktor.util.pipeline/-pipeline/index.html) in Ktor is a collection of interceptors, grouped in one or more ordered phases. Each interceptor can perform custom logic before and after processing a request.
+A [`Pipeline`](https://api.ktor.io/ktor-utils/io.ktor.util.pipeline/-pipeline/index.html) in Ktor is a collection of
+interceptors grouped into one or more ordered phases. Each interceptor can run custom logic before and after request
+processing continues.
 
-[ApplicationCallPipeline](https://api.ktor.io/ktor-server-core/io.ktor.server.application/-application-call-pipeline/index.html) is a pipeline for executing application calls. This pipeline defines 5 phases:
+[`ApplicationCallPipeline`](https://api.ktor.io/ktor-server-core/io.ktor.server.application/-application-call-pipeline/index.html)
+executes application calls. It defines the following phases:
 
-- `Setup`: a phase used for preparing a call and its attributes for processing.
-- `Monitoring`: a phase for tracing calls. It might be useful for request logging, collecting metrics, error handling, and so on.
-- `Plugins`: a phase used to [handle calls](#call-handling). Most plugins intercept at this phase.
-- `Call`: a phase used to complete a call.
-- `Fallback`: a phase for handling unprocessed calls.
-
+* `Setup`: prepares a call and its attributes for processing.
+* `Monitoring`: traces calls. Use this phase for request logging, metrics, error handling, and similar tasks.
+* `Plugins`: handles calls. Most plugins intercept this phase.
+* `Call`: completes a call.
+* `Fallback`: handles calls that were not processed by earlier phases.
 
 ## Mapping of pipeline phases to new API handlers {id="mapping"}
 
-Starting with v2.0.0, Ktor provides a new simplified API for [creating custom plugins](server-custom-plugins.md).
-In general, this API doesn't require an understanding of internal Ktor concepts, such as pipelines, phases, and so on. Instead, you have access to different stages of [handling requests and responses](#call-handling) using various handlers, such as `onCall`, `onCallReceive`, `onCallRespond`, and so on.
-The table below shows how pipeline phases map to handlers in a new API.
+You can use the simplified [custom plugins API](server-custom-plugins.md) to create custom
+plugins. In most cases, this API does not require direct knowledge of internal Ktor concepts, such as pipelines and phases.
+Instead, it provides handlers such as `onCall()`, `onCallReceive()`, and `onCallRespond()` for different stages of
+[request and response handling](server-custom-plugins.md#call-handling).
 
-| Base API                               | New API                                                 |
-|----------------------------------------|---------------------------------------------------------|
-| before `ApplicationCallPipeline.Setup` | [on(CallFailed)](server-custom-plugins.md#other)               |
-| `ApplicationCallPipeline.Setup`        | [on(CallSetup)](server-custom-plugins.md#other)                |
-| `ApplicationCallPipeline.Plugins`      | [onCall](server-custom-plugins.md#on-call)                     |
-| `ApplicationReceivePipeline.Transform` | [onCallReceive](server-custom-plugins.md#on-call-receive)      |
-| `ApplicationSendPipeline.Transform`    | [onCallRespond](server-custom-plugins.md#on-call-respond)      |
-| `ApplicationSendPipeline.After`        | [on(ResponseBodyReadyForSend)](server-custom-plugins.md#other) |
-| `ApplicationSendPipeline.Engine`       | [on(ResponseSent)](server-custom-plugins.md#other)             |
-| after `Authentication.ChallengePhase`  | [on(AuthenticationChecked)](server-custom-plugins.md#other)    |
+The following table shows how base API pipeline phases map to simplified API handlers:
+
+| Base API                               | New API                                                             |
+|----------------------------------------|---------------------------------------------------------------------|
+| before `ApplicationCallPipeline.Setup` | [`on(CallFailed)`](server-custom-plugins.md#other)                  |
+| `ApplicationCallPipeline.Setup`        | [`on(CallSetup)`](server-custom-plugins.md#other)                   |
+| `ApplicationCallPipeline.Plugins`      | [`onCall()`](server-custom-plugins.md#on-call)                      |
+| `ApplicationCallPipeline.Call`         | [`onCallValidators()`](server-custom-plugins.md#on-call-validators) |
+| `ApplicationReceivePipeline.Transform` | [`onCallReceive()`](server-custom-plugins.md#on-call-receive)       |
+| `ApplicationSendPipeline.Transform`    | [`onCallRespond()`](server-custom-plugins.md#on-call-respond)       |
+| `ApplicationSendPipeline.After`        | [`on(ResponseBodyReadyForSend)`](server-custom-plugins.md#other)    |
+| `ApplicationSendPipeline.Engine`       | [`on(ResponseSent)`](server-custom-plugins.md#other)                |
+| after `Authentication.ChallengePhase`  | [`on(AuthenticationChecked)`](server-custom-plugins.md#other)       |
 

--- a/topics/server-custom-plugins.md
+++ b/topics/server-custom-plugins.md
@@ -11,84 +11,93 @@
 Learn how to create your own custom plugins.
 </link-summary>
 
-Starting with v2.0.0, Ktor provides a new API for creating custom [plugins](server-plugins.md). In general, this API doesn't
-require an understanding of internal Ktor concepts, such as pipelines, phases, and so on. Instead, you have access to
-different stages of [handling requests and responses](#call-handling) using the `onCall`, `onCallReceive`,
-and `onCallRespond` handlers.
-
-> The API described in this topic is in effect for v2.0.0 and higher. For the old versions, you can use
-the [base API](server-custom-plugins-base-api.md).
+Ktor allows you to create your own custom [plugins](server-plugins.md). In general, this API doesn't
+require an understanding of internal Ktor concepts, such as pipelines and phases. Instead, you use handlers such as
+`onCall()`, `onCallReceive()`, and `onCallRespond()` to access different stages of [requests and response handling](#call-handling).
 
 ## Create and install your first plugin {id="first-plugin"}
 
-In this section, we'll demonstrate how to create and install your first plugin.
+In this section, you'll learn how to create and install your first plugin.
+
 You can use an application created in the [](server-create-a-new-project.topic) tutorial as a starting project.
 
 1. To create a plugin, call
-   the [createApplicationPlugin](https://api.ktor.io/ktor-server-core/io.ktor.server.application/create-application-plugin.html)
-   function and pass a plugin name:
+   the [`createApplicationPlugin()`](https://api.ktor.io/ktor-server-core/io.ktor.server.application/create-application-plugin.html)
+   function and specify a plugin name:
+
    ```kotlin
    ```
    {src="snippets/custom-plugin/src/main/kotlin/com/example/plugins/SimplePlugin.kt" include-lines="3-7"}
 
-   This function returns the `ApplicationPlugin` instance that will be used in the next step to install a plugin.
-   > There is also
-   the [createRouteScopedPlugin](https://api.ktor.io/ktor-server-core/io.ktor.server.application/create-route-scoped-plugin.html)
-   function allowing you to create plugins that can be [installed to a specific route](server-plugins.md#install-route).
-2. To [install a plugin](server-plugins.md#install), pass the created `ApplicationPlugin` instance to the `install` function in
-   the application's initialization code:
+   This function returns the `ApplicationPlugin` instance that you can install in your application.
+   
+   > You can also use the
+   > [`createRouteScopedPlugin()`](https://api.ktor.io/ktor-server-core/io.ktor.server.application/create-route-scoped-plugin.html)
+   > function to create a plugin that can be [installed on a specific route](server-plugins.md#install-route).
+   >
+   {style="tip"}
+
+2. To [install a plugin](server-plugins.md#install), pass the created `ApplicationPlugin` instance to the `install()` function in
+   your application's initialization code:
+
    ```kotlin
    ```
    {src="snippets/custom-plugin/src/main/kotlin/com/example/Application.kt" include-lines="11-12,32"}
-3. Finally, [run](server-run.md) your application to see the plugin's greeting in the console output:
+
+3. [Run](server-run.md) your application to see the plugin message in the console output:
+
    ```Bash
    2021-10-14 14:54:08.269 [main] INFO  Application - Autoreload is disabled because the development mode is off.
    SimplePlugin is installed!
    2021-10-14 14:54:08.900 [main] INFO  Application - Responding at http://0.0.0.0:8080
    ```
 
-You can find the full example
-here: [SimplePlugin.kt](https://github.com/ktorio/ktor-documentation/blob/%ktor_version%/codeSnippets/snippets/custom-plugin/src/main/kotlin/com/example/plugins/SimplePlugin.kt).
-In the following sections, we'll look at how to handle calls on different stages and provide a plugin configuration.
+> For the full example, see [SimplePlugin.kt](https://github.com/ktorio/ktor-documentation/blob/%ktor_version%/codeSnippets/snippets/custom-plugin/src/main/kotlin/com/example/plugins/SimplePlugin.kt).
+> 
+{style="tip"}
 
 ## Handle calls {id="call-handling"}
 
 In your custom plugin, you can [handle requests](server-requests.md) and [responses](server-responses.md) by using a set
 of handlers that provide access to different stages of a call:
 
-* [onCall](#on-call) allows you to get request/response information, modify response parameters (for instance, append
-  custom headers), and so on.
-* [onCallReceive](#on-call-receive) allows you to obtain and transform data received from the client.
-* [onCallRespond](#on-call-respond) allows you to transform data before sending it to the client.
-* [on(...)](#other) allows you to invoke specific hooks that might be useful to handle other stages of a call or
-  exceptions that happened during a call.
-* If required, you can share a [call state](#call-state) between different handlers using `call.attributes`.
+* [`onCall()`](#on-call) allows you to access request and response information and modify response parameters, such as
+  headers.
+* [`onCallValidators()`](#on-call-validators) allows you perform call validation. For route-scoped plugins, validators
+  execute according to route nesting.
+* [`onCallReceive()`](#on-call-receive) allows you to transform data received from the client.
+* [`onCallRespond()`](#on-call-respond) allows you to transform data before sending it to the client.
+* [`on()`](#other) allows you to handle specific hooks for other stages of call processing or for
+  exceptions that occur during a call.
 
-### onCall {id="on-call"}
+You can also [share call state](#call-state) between handlers using `call.attributes`.
 
-The `onCall` handler accepts the `ApplicationCall` as a lambda argument. This allows you to access request/response
-information and modify response parameters (for instance, [append custom headers](#custom-header)). If you need to
-transform a request/response body, use [onCallReceive](#on-call-receive)/[onCallRespond](#on-call-respond).
+### `onCall()` {id="on-call"}
 
-#### Example 1: Request logging {id="request-logging"}
+The `onCall()` handler accepts `ApplicationCall` as a lambda argument. This allows you to access request and response
+information and modify response parameters, such as [appending custom headers](#custom-header).
 
-The example below shows how to use `onCall` to create a custom plugin for logging incoming requests:
+To transform a request or response body, use [`onCallReceive()`](#on-call-receive) and [`onCallRespond()`](#on-call-respond).
+
+#### Example 1: Log requests {id="request-logging"}
+
+The following example uses `onCall()` to create a plugin that logs incoming request URLs:
 
 ```kotlin
 ```
 
 {src="snippets/custom-plugin/src/main/kotlin/com/example/plugins/RequestLoggingPlugin.kt" include-lines="6-12"}
 
-If you install this plugin, the application will show requested URLs in a console, for example:
+When you install this plugin, it prints requested URLs to the console:
 
 ```Bash
 Request URL: http://0.0.0.0:8080/
 Request URL: http://0.0.0.0:8080/index
 ```
 
-#### Example 2: Custom header {id="custom-header"}
+#### Example 2: Add a custom header {id="custom-header"}
 
-This example demonstrates how to create a plugin that appends a custom header to each response:
+The following example creates a plugin that adds a custom header to each response:
 
 ```kotlin
 val CustomHeaderPlugin = createApplicationPlugin(name = "CustomHeaderPlugin") {
@@ -98,20 +107,22 @@ val CustomHeaderPlugin = createApplicationPlugin(name = "CustomHeaderPlugin") {
 }
 ```
 
-As a result, a custom header will be added to all responses:
+The resulting response includes the custom header:
 
 ```HTTP
 HTTP/1.1 200 OK
 X-Custom-Header: Hello, world!
 ```
 
-Note that a custom header name and value in this plugin are hardcoded. You can make this plugin more flexible by
-providing a [configuration](#plugin-configuration) for passing the required custom header name/value.
+In this example, the header name and value are hardcoded. To make them configurable, provide a 
+[plugin configuration](#plugin-configuration).
 
-### onCallReceive {id="on-call-receive"}
+### `onCallReceive()` {id="on-call-receive"}
 
-The `onCallReceive` handler provides the `transformBody` function and allows you to transform data received from the
-client. Suppose the client makes a sample `POST` request that contains `10` as `text/plain` in its body:
+The `onCallReceive()` handler allows you to transform data received from the client. Inside the handler, call `transformBody()`
+to transform the request body before it is passed to `call.receive()`.
+
+Suppose a client sends the following `POST` request that contains `10` as a `text/plain` body:
 
 ```HTTP
 ```
@@ -119,74 +130,96 @@ client. Suppose the client makes a sample `POST` request that contains `10` as `
 {src="snippets/custom-plugin/post.http"}
 
 To [receive this body](server-requests.md#objects) as an integer value, you need to create a route handler for `POST`
-requests and call `call.receive` with the `Int` parameter:
+requests and call `call.receive()` with the `Int` parameter:
 
 ```kotlin
 ```
 
 {src="snippets/custom-plugin/src/main/kotlin/com/example/Application.kt" include-lines="27-28,30"}
 
-Now let's create a plugin that receives a body as an integer value and adds `1` to it. To do this, we need to
-handle `transformBody` inside `onCallReceive` as follows:
+The following plugin receives a body as an integer value and adds `1` to it:
 
 ```kotlin
 ```
 
 {src="snippets/custom-plugin/src/main/kotlin/com/example/plugins/DataTransformationPlugin.kt" include-lines="6-16,27"}
 
-`transformBody` in the code snippet above works as follows:
+In the above example:
 
-1. `TransformBodyContext` is
-   a [lambda receiver](https://kotlinlang.org/docs/scope-functions.html#context-object-this-or-it) that contains type
-   information about the current request. In the example above, the `TransformBodyContext.requestedType` property is
-   used to check the requested data type.
-2. `data` is a lambda argument that allows you to receive a request body
-   as [ByteReadChannel](https://api.ktor.io/ktor-io/io.ktor.utils.io/-byte-read-channel/index.html) and convert it to
-   the required type. In the example above, `ByteReadChannel.readLine()` is used to read a request body.
-3. Finally, you need to transform and return data. In our example, `1` is added to the received integer value.
+* `TransformBodyContext` is
+   the [lambda receiver](https://kotlinlang.org/docs/scope-functions.html#context-object-this-or-it). Its `requestedType` property contains information about the type requested by `call.receive()`.
+* The `data` argument contains the current request body. In this case, it is a [`ByteReadChannel`](https://api.ktor.io/ktor-io/io.ktor.utils.io/-byte-read-channel/index.html)
+   and `ByteReadChannel.readLine()` reads its contents.
+* If the requested type is `Int`, the plugin converts the received value to an integer, adds `1`, and returns the
+   transformed value. Otherwise, it returns the body unchanged.
 
-You can find the full example
-here: [DataTransformationPlugin.kt](https://github.com/ktorio/ktor-documentation/blob/%ktor_version%/codeSnippets/snippets/custom-plugin/src/main/kotlin/com/example/plugins/DataTransformationPlugin.kt).
+> For the full example, see [DataTransformationPlugin.kt](https://github.com/ktorio/ktor-documentation/blob/%ktor_version%/codeSnippets/snippets/custom-plugin/src/main/kotlin/com/example/plugins/DataTransformationPlugin.kt).
+>
+{style="tip"}
 
-### onCallRespond {id="on-call-respond"}
+### `onCallRespond()` {id="on-call-respond"}
 
-`onCallRespond` also provides the `transformBody` handler and allows you to transform data to be sent to the client.
-This handler is executed when the `call.respond` function is invoked in a route handler. Let's continue with the example
-from [onCallReceive](#on-call-receive) where an integer value is received in a `POST` request handler:
+The `onCallRespond()` handler allows you to transform data before it is sent to the client.
+This handler is executed when the `call.respond` function is invoked in a route handler.
+
+For example, consider the following route:
 
 ```kotlin
 ```
-
 {src="snippets/custom-plugin/src/main/kotlin/com/example/Application.kt" include-lines="27-30"}
 
-Calling `call.respond` invokes `onCallRespond`, which in turn allows you to transform data to be sent to the client. For
-example, the code snippet below shows how to add `1` to the initial value:
+Calling `call.respond` invokes `onCallRespond()`, which in turn allows you to transform data to be sent to the client.
+
+Inside `onCallRespond()`, use `transformBody()` to transform the response body. The following example adds `1` to an
+integer response and converts it to a string:
 
 ```kotlin
 ```
-
 {src="snippets/custom-plugin/src/main/kotlin/com/example/plugins/DataTransformationPlugin.kt" include-lines="18-26"}
 
-You can find the full example
-here: [DataTransformationPlugin.kt](https://github.com/ktorio/ktor-documentation/blob/%ktor_version%/codeSnippets/snippets/custom-plugin/src/main/kotlin/com/example/plugins/DataTransformationPlugin.kt).
+> For the full example, see [DataTransformationPlugin.kt](https://github.com/ktorio/ktor-documentation/blob/%ktor_version%/codeSnippets/snippets/custom-plugin/src/main/kotlin/com/example/plugins/DataTransformationPlugin.kt).
+>
+{style="tip"}
+
+### `onCallValidators()` {id="on-call-validators"}
+
+The `onCallValidators()` handler allows you to perform validation for each incoming call.
+
+When multiple validators are applied to nested routes, validators on parent routes execute before validators on child
+routes. This allows a validator to use information produced earlier in the route hierarchy, such as an authenticated
+principal.
+
+For example, the following route-scoped plugin can access a principal provided by an authentication route:
+
+```kotlin
+```
+{src="snippets/custom-plugin/src/main/kotlin/com/example/plugins/UserValidationPlugin.kt" include-symbol="UserValidationPlugin"}
+
+Install the plugin inside the authenticated route to run it after authentication:
+
+```kotlin
+```
+{src="snippets/custom-plugin/src/main/kotlin/com/example/Application.kt" include-lines="20,31-37"}
+
+Use `onCallValidators()` when the order of route-scoped validation matters. For general request and response processing
+that does not depend on other validators, use `onCall()` instead.
 
 ### Other useful handlers {id="other"}
 
-Apart from the `onCall`, `onCallReceive`, and `onCallRespond` handlers, Ktor provides a set of specific hooks that might
-be useful to handle other stages of a call.
-You can handle these hooks using the `on` handler that accepts a `Hook` as a parameter.
-These hooks include:
+In addition to the call handlers described above, Ktor provides a set of hooks for handling other stages of call
+processing. Use the `on()` function to register a handler for a specific `Hook`.
 
-- `CallSetup` is invoked as a first step in processing a call.
-- `ResponseBodyReadyForSend` is invoked when a response body comes through all transformations and is ready to be sent.
-- `ResponseSent` is invoked when a response is successfully sent to a client.
-- `CallFailed` is invoked when a call fails with an exception.
-- [AuthenticationChecked](https://api.ktor.io/ktor-server-auth/io.ktor.server.auth/-authentication-checked/index.html)
-  is executed after [authentication](server-auth.md) credentials are checked. The following example shows how to use
-  this hook to implement
-  authorization: [custom-plugin-authorization](https://github.com/ktorio/ktor-documentation/blob/%ktor_version%/codeSnippets/snippets/custom-plugin-authorization).
+Available hooks include:
 
-The example below shows how to handle `CallSetup`:
+- `CallSetup` is invoked at the beginning of call processing.
+- `ResponseBodyReadyForSend` is invoked after a response body comes through all transformations and is ready to be sent.
+- `ResponseSent` is invoked after a response is successfully sent to a client.
+- `CallFailed` is invoked when call processing fails with an exception.
+- [`AuthenticationChecked`](https://api.ktor.io/ktor-server-auth/io.ktor.server.auth/-authentication-checked/index.html)
+  is invoked after [authentication](server-auth.md) credentials are checked. You can use this hook to implement
+  authorization. For an example, see [custom-plugin-authorization](https://github.com/ktorio/ktor-documentation/blob/%ktor_version%/codeSnippets/snippets/custom-plugin-authorization).
+
+The following example handles the `CallSetup` hook:
 
 ```kotlin
 on(CallSetup) { call->
@@ -194,38 +227,45 @@ on(CallSetup) { call->
 }
 ```
 
-> There is also the `MonitoringEvent` hook that allows you to [handle application events](#handle-app-events), such as
-application startup or shutdown.
+> You can also use the `MonitoringEvent` to [handle application events](#handle-app-events), such as
+> application startup or shutdown.
+> 
+{style="tip"}
 
 ### Share call state {id="call-state"}
 
-Custom plugins allow you to share any value related to a call, so you can access this value inside any handler
-processing this call. This value is stored as an attribute with a unique key in the `call.attributes` collection. The
-example below demonstrates how to use attributes to calculate the time between receiving a request and reading a body:
+Custom plugins can share values associated with a call between different handlers.
+These values are stored in the `call.attributes` collection using a unique `AttributeKey`.
+
+The following example stores the time when `onCall()` is invoked and uses it in `onCallReceive()` to calculate the delay
+before the request body is read:
 
 ```kotlin
 ```
-
 {src="snippets/custom-plugin/src/main/kotlin/com/example/plugins/DataTransformationBenchmarkPlugin.kt"
 include-lines="6-18"}
 
-If you make a `POST` request, the plugin prints a delay in a console:
+When you send a `POST` request, the plugin prints the delay to the console:
 
 ```Bash
 Request URL: http://localhost:8080/transform-data
 Read body delay (ms): 52
 ```
 
-You can find the full example
-here: [DataTransformationBenchmarkPlugin.kt](https://github.com/ktorio/ktor-documentation/blob/%ktor_version%/codeSnippets/snippets/custom-plugin/src/main/kotlin/com/example/plugins/DataTransformationBenchmarkPlugin.kt).
+> Fo the full example, see [DataTransformationBenchmarkPlugin.kt](https://github.com/ktorio/ktor-documentation/blob/%ktor_version%/codeSnippets/snippets/custom-plugin/src/main/kotlin/com/example/plugins/DataTransformationBenchmarkPlugin.kt).
+>
+{style="tip"}
 
-> You can also access call attributes in a [route handler](server-requests.md#request_information).
+> You can also access call attributes from a [route handler](server-requests.md#request_information).
+> 
+{style="tip"}
 
 ## Handle application events {id="handle-app-events"}
 
-The [on](#other) handler provides the ability to use the `MonitoringEvent` hook to handle events related to an
+The [`on()`](#other) handler provides the ability to use the `MonitoringEvent` hook to handle events related to an
 application's lifecycle.
-For example, you can pass the following [predefined events](server-events.md#predefined-events) to the `on` handler:
+
+Ktor provides the following [predefined events](server-events.md#predefined-events) to the `on()` handler:
 
 - `ApplicationStarting`
 - `ApplicationStarted`
@@ -233,50 +273,53 @@ For example, you can pass the following [predefined events](server-events.md#pre
 - `ApplicationStopping`
 - `ApplicationStopped`
 
-The code snippet below shows how to handle application shutdown using `ApplicationStopped`:
+The following example handles application shutdown using the `ApplicationStopped` event:
 
 ```kotlin
 ```
 
 {src="snippets/events/src/main/kotlin/com/example/plugins/ApplicationMonitoringPlugin.kt" lines="12-13,17"}
 
-This might be useful to release application resources.
+This approach is useful for cleaning up resources owned by a plugin, such as closing connections, stopping background
+tasks, or flushing buffered data.
 
 ## Provide plugin configuration {id="plugin-configuration"}
 
-The [Custom header](#custom-header) example demonstrates how to create a plugin that appends a predefined custom header
-to each response. Let's make this plugin more useful and provide a configuration for passing the required custom header
-name/value.
+The [custom header](#custom-header) example creates a plugin that appends a predefined header to each response.
+To make this plugin reusable, define a configuration that lets users specify the header name and value.
 
-1. First, you need to define a configuration class:
+1. Define a configuration class:
 
    ```kotlin
    ```
    {src="snippets/custom-plugin/src/main/kotlin/com/example/plugins/CustomHeaderPlugin.kt" include-lines="18-21"}
 
-2. To use this configuration in a plugin, pass a configuration class reference to `createApplicationPlugin`:
+2. Pass  configuration class reference to `createApplicationPlugin()`:
 
    ```kotlin
    ```
    {src="snippets/custom-plugin/src/main/kotlin/com/example/plugins/CustomHeaderPlugin.kt" include-lines="5-16"}
 
-   Given that plugin configuration fields are mutable, saving them in local variables is recommended.
+   Plugin configuration properties are mutable during plugin installation. If the plugin uses these values in handlers,
+   store them in local variables inside the plugin body.
 
-3. Finally, you can install and configure a plugin as follows:
+3. Install and configure the plugin:
 
    ```kotlin
    ```
    {src="snippets/custom-plugin/src/main/kotlin/com/example/Application.kt" include-lines="15-18"}
 
-> You can find the full example
-here: [CustomHeaderPlugin.kt](https://github.com/ktorio/ktor-documentation/blob/%ktor_version%/codeSnippets/snippets/custom-plugin/src/main/kotlin/com/example/plugins/CustomHeaderPlugin.kt).
+> For the full example, see [CustomHeaderPlugin.kt](https://github.com/ktorio/ktor-documentation/blob/%ktor_version%/codeSnippets/snippets/custom-plugin/src/main/kotlin/com/example/plugins/CustomHeaderPlugin.kt).
+>
+{style="tip"}
 
 ### Configuration in a file {id="configuration-file"}
 
-Ktor allows you to specify plugin settings in a [configuration file](server-create-and-configure.topic#engine-main).
-Let's see how to achieve this for `CustomHeaderPlugin`:
+Ktorcan load plugin settings from a [configuration file](server-create-and-configure.topic#engine-main).
 
-1. First, add a new group with the plugin settings to the `application.conf` or `application.yaml` file:
+The following example shows how to configure `CustomHeaderPlugin` from a file.
+
+1. Add a new group with the plugin settings to your `application.conf` or `application.yaml` file:
 
    <tabs group="config">
    <tab title="application.conf" group-key="hocon">
@@ -295,17 +338,17 @@ Let's see how to achieve this for `CustomHeaderPlugin`:
    </tab>
    </tabs>
 
-   In our example, the plugin settings are stored in the `http.custom_header` group.
+   In this example, the plugin settings are stored in the `http.custom_header` group.
 
 2. To get access to configuration file properties, pass `ApplicationConfig` to the configuration class constructor.
-   The `tryGetString` function returns the specified property value:
+   The `tryGetString()` function returns the value of the specified property:
 
    ```kotlin
    ```
    {src="snippets/custom-plugin/src/main/kotlin/com/example/plugins/CustomHeaderPluginConfigurable.kt"
    include-lines="20-23"}
 
-3. Finally, assign the `http.custom_header` value to the `configurationPath` parameter of the `createApplicationPlugin`
+3. Assign the `http.custom_header` value to the `configurationPath` parameter of the `createApplicationPlugin()`
    function:
 
    ```kotlin
@@ -313,16 +356,22 @@ Let's see how to achieve this for `CustomHeaderPlugin`:
    {src="snippets/custom-plugin/src/main/kotlin/com/example/plugins/CustomHeaderPluginConfigurable.kt"
    include-lines="6-18"}
 
-> You can find the full example
-here: [CustomHeaderPluginConfigurable.kt](https://github.com/ktorio/ktor-documentation/blob/%ktor_version%/codeSnippets/snippets/custom-plugin/src/main/kotlin/com/example/plugins/CustomHeaderPluginConfigurable.kt).
+> For the full example, see [CustomHeaderPluginConfigurable.kt](https://github.com/ktorio/ktor-documentation/blob/%ktor_version%/codeSnippets/snippets/custom-plugin/src/main/kotlin/com/example/plugins/CustomHeaderPluginConfigurable.kt).
+>
+{style="tip"}
 
 ## Access application settings {id="app-settings"}
 
+Custom plugins can access application-level settings from the plugin body. This is useful when plugin behavior depends on
+the server configuration or environment.
+
 ### Configuration {id="config"}
 
-You can access your server configuration using the `applicationConfig` property, which returns
-the [ApplicationConfig](https://api.ktor.io/ktor-server-core/io.ktor.server.config/-application-config/index.html)
-instance. The example below shows how to get a host and port used by the server:
+Use the `applicationConfig` property to access server configuration. This property returns an
+[`ApplicationConfig`](https://api.ktor.io/ktor-server-core/io.ktor.server.config/-application-config/index.html)
+instance.
+
+The following example reads the host and port used by the server:
 
 ```kotlin
 val SimplePlugin = createApplicationPlugin(name = "SimplePlugin") {
@@ -334,8 +383,8 @@ val SimplePlugin = createApplicationPlugin(name = "SimplePlugin") {
 
 ### Environment {id="environment"}
 
-To access the application's environment, use the `environment` property. For example, this property allows you to
-determine whether the [development mode](server-development-mode.topic) is enabled:
+Use the `environment` property to access the application's environment. For example, you can check whether
+[development mode](server-development-mode.topic) is enabled:
 
 ```kotlin
 val SimplePlugin = createApplicationPlugin(name = "SimplePlugin") {
@@ -352,8 +401,10 @@ val SimplePlugin = createApplicationPlugin(name = "SimplePlugin") {
 
 ### Store plugin state {id="plugin-state"}
 
-To store a plugin's state, you can capture any value from handler lambda. Note that it is recommended to make all state
-values thread safe by using concurrent data structures and atomic data types:
+A plugin can store state by capturing values in the plugin body and using them from handler lambdas.
+
+Because plugins can handle multiple calls concurrently, store shared mutable state in thread-safe structures, such as
+concurrent collections or atomic types:
 
 ```kotlin
 val SimplePlugin = createApplicationPlugin(name = "SimplePlugin") {
@@ -369,25 +420,32 @@ val SimplePlugin = createApplicationPlugin(name = "SimplePlugin") {
 
 ### Databases {id="databases"}
 
-* Can I use a custom plugin with suspendable databases?
+#### Use suspending database APIs
 
-  Yes. All the handlers are suspending functions, so you can perform any suspendable database operations inside your
-  plugin. But don't forget to deallocate resources for specific calls (for example, by
-  using [on(ResponseSent)](#other)).
+All custom plugin handlers are suspending functions. This means you can call suspending database APIs directly from a
+handler.
 
-* How to use a custom plugin with blocking databases?
+Remember to release resources that are scoped to a specific call. For example, you can use [`on(ResponseSent)`](#other) to
+clean up resources after a response has been sent.
 
-  As Ktor uses coroutines and suspending functions, making a request to a blocking database can be dangerous because a
-  coroutine that performs a blocking call can be blocked and then suspended forever. To prevent this, you need to create
-  a separate [CoroutineContext](https://kotlinlang.org/docs/coroutine-context-and-dispatchers.html):
-   ```kotlin
-   val databaseContext = newSingleThreadContext("DatabaseThread")
-   ```
-  Then, once your context is created, wrap each call to your database into `withContext` call:
-   ```kotlin
-   onCall {
-       withContext(databaseContext) {
-           database.access(...) // some call to your database
-       }
+#### Use blocking database APIs
+
+Ktor uses coroutines, so blocking database calls should not run on the default coroutine dispatcher. A blocking call can
+occupy a thread and prevent other coroutines from progressing.
+
+To call a blocking database API, create a separate
+[`CoroutineContext`](https://kotlinlang.org/docs/coroutine-context-and-dispatchers.html) for blocking work:
+
+```kotlin
+val databaseContext = newSingleThreadContext("DatabaseThread")
+```
+
+Then wrap each blocking database call in `withContext()`:
+
+```kotlin
+onCall {
+   withContext(databaseContext) {
+       database.access(...) // some call to your database
    }
-   ```
+}
+```

--- a/topics/server-custom-plugins.md
+++ b/topics/server-custom-plugins.md
@@ -37,7 +37,7 @@ You can use an application created in the [](server-create-a-new-project.topic) 
    >
    {style="tip"}
 
-2. To [install a plugin](server-plugins.md#install), pass the created `ApplicationPlugin` instance to the `install()` function in
+2. To [install a plugin](server-plugins.md#install), pass the created `ApplicationPlugin` instance to the `Application.install()` function in
    your application's initialization code:
 
    ```kotlin
@@ -294,7 +294,7 @@ To make this plugin reusable, define a configuration that lets users specify the
    ```
    {src="snippets/custom-plugin/src/main/kotlin/com/example/plugins/CustomHeaderPlugin.kt" include-lines="18-21"}
 
-2. Pass  configuration class reference to `createApplicationPlugin()`:
+2. Pass the configuration class reference to `createApplicationPlugin()`:
 
    ```kotlin
    ```
@@ -437,7 +437,7 @@ To call a blocking database API, create a separate
 [`CoroutineContext`](https://kotlinlang.org/docs/coroutine-context-and-dispatchers.html) for blocking work:
 
 ```kotlin
-val databaseContext = newSingleThreadContext("DatabaseThread")
+val databaseContext = Dispatchers.IO
 ```
 
 Then wrap each blocking database call in `withContext()`:
@@ -445,7 +445,7 @@ Then wrap each blocking database call in `withContext()`:
 ```kotlin
 onCall {
    withContext(databaseContext) {
-       database.access(...) // some call to your database
+       database.access(...) // A call to your database
    }
 }
 ```

--- a/topics/server-rate-limit.md
+++ b/topics/server-rate-limit.md
@@ -1,6 +1,6 @@
 [//]: # (title: Rate limiting)
 
-<show-structure for="chapter" depth="2"/>
+<show-structure for="chapter" depth="3"/>
 <primary-label ref="server-plugin"/>
 
 <var name="plugin_name" value="RateLimit"/>
@@ -21,42 +21,44 @@
 %plugin_name% provides the ability to validate a body of incoming requests.
 </link-summary>
 
-The [%plugin_name%](%plugin_api_link%) plugin allows you to limit the number of [requests](server-requests.md) 
-a client can make within a certain time period.
-Ktor provides different means for configuring rate limiting, for example:
-- You can enable rate limiting globally for a whole application or configure different rate limits for different [resources](server-routing.md).
-- You can configure rate limiting based on specific request parameters: an IP address, an API key or access token, and so on.
+The [`%plugin_name%`](%plugin_api_link%) plugin allows you to limit the number of [requests](server-requests.md) 
+a client can make within a specified time period.
 
+Ktor provides several ways to configure rate limiting:
+
+* Apply a rate limit globally to the entire application or configure different limits for specific [resources](server-routing.md).
+* Apply rate limits based on request parameters, such as an IP address, API key or access token.
 
 ## Add dependencies {id="add_dependencies"}
 
 <include from="lib.topic" element-id="add_ktor_artifact_intro"/>
 <include from="lib.topic" element-id="add_ktor_artifact"/>
 
-
 ## Install %plugin_name% {id="install_plugin"}
 
 <include from="lib.topic" element-id="install_plugin"/>
-
 
 ## Configure %plugin_name% {id="configure"}
 
 ### Overview {id="overview"}
 
 Ktor uses the _token bucket_ algorithm for rate limiting, which works as follows:
-1. In the beginning, we have a bucket defined by its capacity - the number of tokens.
-2. Each incoming request tries to consume one token from the bucket:
-    - If there is enough capacity, the server handles a request and sends a response with the following headers:
-        - `X-RateLimit-Limit`: a specified bucket capacity.
-        - `X-RateLimit-Remaining`: the number of tokens remaining in a bucket.
-        - `X-RateLimit-Reset`: a UTC timestamp (in seconds) that specifies the time of refilling a bucket.
-    - If there is insufficient capacity, the server rejects a request using a `429 Too Many Requests` response and adds the `Retry-After` header, indicating how long the client should wait (in seconds) before making a follow-up request.
-3. After a specified period of time, a bucket capacity is refilled.
-
+1. A bucket is created with a specified capacity, which defines the number of available tokens.
+2. Each incoming request consumes one token from the bucket:
+   * If there is enough capacity, the server processes the request and includes the following headers in the response:
+     * `X-RateLimit-Limit`: the bucket capacity.
+     * `X-RateLimit-Remaining`: the number of tokens remaining in the bucket.
+     * `X-RateLimit-Reset`: the UTC timestamp, in seconds, that specifies when the bucket is refilled.
+   * If there is insufficient capacity, the server rejects a request using a `429 Too Many Requests` response. The response
+     includes the `Retry-After` header, indicating how many seconds the client should wait before sending another request.
+3. After the specified refill period, the bucket is refilled.
 
 ### Register a rate limiter {id="register"}
-Ktor allows you to apply rate limiting globally to a whole application or to specific routes:
-- To apply rate limiting to a whole application, call the `global` method and pass a configured rate limiter.
+
+You can apply rate limiting globally to the entire application or register a rate limiter for specific routes:
+
+* To apply rate limiting globally, call the `global()` function and configure the rate limiter:
+
    ```kotlin
    install(RateLimit) {
        global {
@@ -65,86 +67,146 @@ Ktor allows you to apply rate limiting globally to a whole application or to spe
    }
    ```
 
-- The `register` method registers a rate limiter that can be applied to specific routes.
+* To configure rate limiting for specific routes, use the `register()` function to register a rate limiter:
+
    ```kotlin
    ```
    {src="snippets/rate-limit/src/main/kotlin/com/example/Application.kt" include-lines="14-17,33"}
 
-Code samples above demonstrate minimal configurations for the `%plugin_name%` plugin, 
-but for a rate limiter registered using the `register` method you also need to apply it to a [specific route](#rate-limiting-scope).
+The examples above show the minimal configuration required for the `%plugin_name%` plugin.
+If you use `register()`, you also need to apply the registered rate limiter to a [specific route](#rate-limiting-scope).
 
 
 ### Configure rate limiting {id="configure-rate-limiting"}
 
-In this section, we'll see how to configure rate limiting:
+You can configure a rate limiter using the options below.
 
-1. (Optional) The `register` method allows you to specify a rate limiter name that can be used to
-   apply rate limiting rules to [specific routes](#rate-limiting-scope):
-   ```kotlin
-       install(RateLimit) {
-           register(RateLimitName("protected")) {
-               // ...
-           }
-       }
-   ```
+#### Name a rate limiter
 
-2. The `rateLimiter` method creates a rate limiter with two parameters: 
-   `limit` defines the bucket capacity, while `refillPeriod` specifies a refill period for this bucket.
-   A rate limiter in the example below allows handling 30 requests per minute:
-   ```kotlin
-   ```
-   {src="snippets/rate-limit/src/main/kotlin/com/example/Application.kt" include-lines="21-22,32"}
+Use the `register()` function to assign a name to a rate limiter. You can then apply the named rate limiter to
+[specific routes](#rate-limiting-scope):
 
-3. (Optional) `requestKey` allows you to specify a function that returns a key for a request.
-   Requests with different keys have independent rate limits.
-   In the example below, the `login` [query parameter](server-requests.md#query_parameters) is a key 
-   used to distinguish different users:
-   ```kotlin
-   ```
-   {src="snippets/rate-limit/src/main/kotlin/com/example/Application.kt" include-lines="21,23-25,32"}
+```kotlin
+    install(RateLimit) {
+        register(RateLimitName("protected")) {
+            // ...
+        }
+    }
+```
 
-   > Note that keys should have good `equals` and `hashCode` implementations.
+#### Set the limit and refill period
 
-4. (Optional) `requestWeight` sets a function that returns how many tokens are consumed by a request.
-   In the example below, a request key is used to configure a request weight:
-   ```kotlin
-   ```
-   {src="snippets/rate-limit/src/main/kotlin/com/example/Application.kt" include-lines="21,23-32"}
+Use the `rateLimiter()` function to configure the bucket capacity and refill period:
 
-5. (Optional) `modifyResponse` allows you to override default `X-RateLimit-*` headers sent with each request:
-   ```kotlin
-   register(RateLimitName("protected")) {
-       modifyResponse { applicationCall, state ->
-           applicationCall.response.header("X-RateLimit-Custom-Header", "Some value")
-       }
-   }
-   ```
+* `limit` specifies the number of available tokens.
+* `refillPeriod` specifies how often the bucket is refilled.
 
+The following example allows up to 30 requests per minute:
+
+```kotlin
+```
+{src="snippets/rate-limit/src/main/kotlin/com/example/Application.kt" include-lines="21-22,32"}
+
+#### Distinguish requests by key
+
+Use the `requestKey()` function to return a key for each request. Requests with different keys have independent
+rate limits.
+
+The following example uses the `login` [query parameter](server-requests.md#query_parameters) to distinguish between users:
+
+```kotlin
+```
+{src="snippets/rate-limit/src/main/kotlin/com/example/Application.kt" include-lines="21,23-25,32"}
+
+> Ensure that request keys have appropriate `equals` and `hashCode` implementations.
+> 
+{style="tip"}
+
+#### Rate limit authenticated users
+
+You can use an authentication principal as a request key to apply rate limits per authenticated user.
+
+Nest `rateLimit()` inside `authenticate()`, then access the principal from `requestKey()`:
+
+```kotlin
+install(Authentication) {
+    basic("auth") { validate { UserIdPrincipal(it.name) } }
+}
+install(RateLimit) {
+    register(RateLimitName("per-user")) {
+        rateLimiter(limit = 10, refillPeriod = 60.seconds)
+        requestKey { call.principal<UserIdPrincipal>()?.name ?: "anonymous" }
+    }
+}
+
+routing {
+    authenticate("auth") {
+        rateLimit(RateLimitName("per-user")) {
+            get("/api") { call.respondText("OK") }
+        }
+    }
+}
+```
+
+#### Set the request weight
+
+Use the `requestWeight()` function to specify how many tokens each request consumes. The function receives the
+application call and the request key.
+
+In the following example, requests with the `jetbrains` key consume one token, while all other requests consume two:
+
+```kotlin
+```
+{src="snippets/rate-limit/src/main/kotlin/com/example/Application.kt" include-lines="21,23-32"}
+
+#### Customize the response
+
+Use the `modifyResponse()` function to customize the response when rate limiting is applied.
+
+For example, you can add custom rate-limit headers:
+
+```kotlin
+register(RateLimitName("protected")) {
+    modifyResponse { applicationCall, state ->
+        applicationCall.response.header("X-RateLimit-Custom-Header", "Some value")
+    }
+}
+```
 
 ### Define rate limiting scope {id="rate-limiting-scope"}
 
-After configuring a rate limiter, you can apply its rules to specific routes using the `rateLimit` method:
+After configuring a rate limiter, you can use the `rateLimit()` function to apply it to specific routes.
+
+#### Apply the default rate limiter
+
+Use the `rateLimit()` function without a name to apply the default registered rate limiter:
 
 ```kotlin
 ```
 {src="snippets/rate-limit/src/main/kotlin/com/example/Application.kt" include-lines="40-46,60"}
 
-This method can also accept a [rate limiter name](#configure-rate-limiting):
+#### Apply a named rate limiter
+
+Pass a `RateLimitName` to the `rateLimit()` function to apply a [named rate limiter](#configure-rate-limiting):
 
 ```kotlin
 ```
 {src="snippets/rate-limit/src/main/kotlin/com/example/Application.kt" include-lines="40,53-60"}
 
-
 ## Example {id="example"}
 
-The code sample below demonstrates how to use the `RateLimit` plugin to apply different rate limiters to different resources.
-The [StatusPages](server-status-pages.md) plugin is used to handle rejected requests,
-for which the `429 Too Many Requests` response was sent.
+The following example shows how to apply different rate limiters to different routes.
+It configures:
+
+* A default rate limiter for the home page.
+* A named public rate limiter for the public API.
+* A named protected rate limiter that uses request keys and weights.
+* The [`StatusPages`](server-status-pages.md) plugin to customize responses for requests rejected with a `429 Too Many Requests` response.
 
 ```kotlin
 ```
 {src="snippets/rate-limit/src/main/kotlin/com/example/Application.kt"}
 
-
-You can find the full example here: [rate-limit](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/rate-limit).
+> For the full example, see [rate-limit](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/rate-limit).
+>
+{style="tip"}

--- a/topics/whats-new-360.md
+++ b/topics/whats-new-360.md
@@ -120,6 +120,9 @@ routing {
 }
 ```
 
+You can also place `rateLimit()` outside `authenticate()` to apply rate limiting before authentication. Use this approach
+when the rate limit doesn't depend on an authenticated principal.
+
 ## Ktor Client
 
 ### Default client engines for multiplatform projects

--- a/topics/whats-new-360.md
+++ b/topics/whats-new-360.md
@@ -92,6 +92,34 @@ embeddedServer(Netty, configure = {
 
 The cleartext connector accepts h2c connections, while the SSL connector serves HTTP/2 over TLS.
 
+### Rate limiting with authenticated principals
+
+The [`RateLimit`](server-rate-limit.md) plugin can now access authentication principals during request validation.
+
+This allows you to nest the `rateLimit()` function inside `authenticate()` and use `call.principal()` in the
+`requestKey()` function to apply rate limits per authenticated user:
+
+```kotlin
+install(Authentication) {
+    basic("auth") { validate { UserIdPrincipal(it.name) } }
+}
+
+install(RateLimit) {
+    register(RateLimitName("per-user")) {
+        rateLimiter(limit = 10, refillPeriod = 60.seconds)
+        requestKey { call.principal<UserIdPrincipal>()?.name ?: "anonymous" }
+    }
+}
+
+routing {
+    authenticate("auth") {
+        rateLimit(RateLimitName("per-user")) {
+            get("/api") { call.respondText("OK") }
+        }
+    }
+}
+```
+
 ## Ktor Client
 
 ### Default client engines for multiplatform projects


### PR DESCRIPTION
**Description:**

- add a what's new entry for making `ApplicationCallPipeline.ApplicationPhase.Validators` public in 3.6.0
- add docs for the `onCallValidators()` handler in the custom plugins topic
  - update the custom plugins topic according to the docs style guide (formatting, language etc.)
  - add a code example in the `custom-plugins` project
- add a section for rate limit authenticated users in the plugin topic
- update the rate-limit topic

**Related issues:**
[KTOR-9791](https://youtrack.jetbrains.com/issue/KTOR-9791) Documentation for Make ApplicationCallPipeline.ApplicationPhase.Validators public in 3.6.0