### PR TITLE
KTOR-9795 Add docs for the ktor-client-engine-defaults artifact

### DIFF
--- a/topics/client-dependencies.md
+++ b/topics/client-dependencies.md
@@ -85,7 +85,7 @@ First, define the artifact in your `gradle/libs.versions.toml` file:
 ktor-client-engine-defaults = { module = "io.ktor:ktor-client-engine-defaults", version.ref = "ktor" }
 ```
 
-Then, add it to the commonMain source set:
+Then, add it to the `commonMain` source set:
 
 ```kotlin
 kotlin {
@@ -99,7 +99,7 @@ kotlin {
 }
 ```
 
-##### Use a specific engine
+##### Use a specific engine {id="kmp-specific-engine"}
 
 If you need a specific engine, add its dependency to the corresponding platform source set instead. For example, to use
 `OkHttp` on Android, define the `ktor-client-okhttp` artifact:

--- a/topics/client-dependencies.md
+++ b/topics/client-dependencies.md
@@ -63,33 +63,59 @@ Then, add `ktor-client-core` as a dependency to the `commonMain` source set:
 
 ### Engine dependency {id="engine-dependency"}
 
-An [engine](client-engines.md) is responsible for processing network requests. There are different client engines
-available for various platforms, such as Apache, CIO, Android, iOS, and so on. For example, you can add a `CIO` engine
-dependency as follows:
+An [engine](client-engines.md) is responsible for processing network requests. Ktor provides different client engines for
+different platforms.
+
+For example, you can add the `CIO` engine as follows:
 
 <var name="artifact_name" value="ktor-client-cio"/>
 <include from="lib.topic" element-id="add_ktor_artifact"/>
 
 #### Multiplatform {id="engine-dependency-multiplatform"}
 
-For a multiplatform project, you need to add a dependency for the required engine to a corresponding source set.
+##### Use default engines
 
-For example, to add the `OkHttp` engine dependency for Android, you can first define the Ktor version and
-the `ktor-client-okhttp` artifact in the `gradle/libs.versions.toml` file:
+For a multiplatform project, you can use the `ktor-client-engine-defaults` artifact to provide a curated client engine
+for each target platform.
 
-```kotlin
+First, define the artifact in your `gradle/libs.versions.toml` file:
+
+```toml
+[libraries]
+ktor-client-engine-defaults = { module = "io.ktor:ktor-client-engine-defaults", version.ref = "ktor" }
 ```
 
-{src="snippets/tutorial-client-kmp/gradle/libs.versions.toml" include-lines="1,15,17-18,30"}
+Then, add it to the commonMain source set:
 
-Then, add `ktor-client-okhttp` as a dependency to the `androidMain` source set:
+```kotlin
+kotlin {
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(libs.ktor.client.engine.defaults)
+            }
+        }
+    }
+}
+```
+
+##### Use a specific engine
+
+If you need a specific engine, add its dependency to the corresponding platform source set instead. For example, to use
+`OkHttp` on Android, define the `ktor-client-okhttp` artifact:
+
+```toml
+```
+{src="snippets/tutorial-client-kmp/gradle/libs.versions.toml" include-lines="18,30"}
+
+Then, add it as a dependency to the `androidMain` source set:
 
 ```kotlin
 ```
 
 {src="snippets/tutorial-client-kmp/shared/build.gradle.kts" include-lines="25,30-32,39"}
 
-For a full list of dependencies required for a specific engine, see [](client-engines.md#dependencies).
+For the dependencies required by each engine, see [](client-engines.md#dependencies).
 
 ### Logging dependency
 

--- a/topics/client-engines.md
+++ b/topics/client-engines.md
@@ -9,10 +9,13 @@ Learn about engines that process network requests.
 The [Ktor HTTP client](client-create-and-configure.md) is multiplatform and runs on JVM,
 [Android](https://kotlinlang.org/docs/android-overview.html), [JavaScript](https://kotlinlang.org/docs/js-overview.html)
 (including WebAssembly), and [Native](https://kotlinlang.org/docs/native-overview.html) targets. Each platform requires
-a specific engine to process network requests.
-For example, you can use `Apache` or `Jetty` for JVM applications, `OkHttp` or `Android`
-for Android, `Curl` for desktop applications targeting Kotlin/Native. Every engine differs slightly in features and
-configuration, so you can choose the one that best meets your platform and use-case needs.
+a specific client engine to process network requests.
+
+Ktor provides several engines for different platforms. For example, you can use `Apache` or `Jetty` for JVM applications,
+`OkHttp` or `Android` for Android, `Curl` for desktop applications targeting Kotlin/Native.
+
+Each engine supports different features and configuration options. For multiplatform projects, you can use Ktor's default
+engines or select specific engines for individual targets.
 
 ## Supported platforms {id="platforms"}
 
@@ -50,7 +53,31 @@ enable [Java 8 API desugaring](https://developer.android.com/studio/write/java8-
 ## Add an engine dependency {id="dependencies"}
 
 In addition to the [`ktor-client-core`](client-dependencies.md) artifact, the Ktor client requires a dependency for a
-specific engine. Each supported platform has a set of available engines, described in the corresponding sections:
+specific engine.
+
+### Use default engines in multiplatform projects {id="default-engines"}
+
+For most Kotlin Multiplatform projects, use the `ktor-client-engine-defaults` artifact. It provides a curated client
+engine for each target platform, so you don't need to declare separate engine dependencies in platform-specific
+source sets.
+
+Add the `ktor-client-engine-defaults` artifact to your `commonMain` source set:
+
+```kotlin
+kotlin {
+    sourceSets {
+        commonMain {
+            dependencies {
+                api("io.ktor:ktor-client-engine-defaults:%ktor_version%")
+            }
+        }
+    }
+}
+```
+
+### Use a specific engine
+
+Each supported platform has a set of available engines, described in the corresponding sections:
 
 * [JVM](#jvm)
 * [JVM and Android](#jvm-android)
@@ -84,10 +111,9 @@ If you omit the engine argument, the client will choose an engine automatically 
 
 {src="snippets/_misc_client/DefaultEngineCreate.kt"}
 
-This is especially useful in multiplatform projects. For example, for a project targeting
-both [Android and iOS](client-create-multiplatform-application.md), you can add the [Android](#jvm-android) dependency
-to the `androidMain` source set and the [Darwin](#darwin) dependency to the `iosMain` source set. The appropriate
-engine is selected at run time upon `HttpClient` creation. 
+For Kotlin Multiplatform projects, the [`ktor-client-engine-defaults` dependency](#default-engines) provides a default
+engine for each target. Alternatively, you can [add specific engine dependencies](#use-a-specific-engine) to the 
+corresponding platform source sets.
 
 ## Configure an engine {id="configure"}
 

--- a/topics/client-engines.md
+++ b/topics/client-engines.md
@@ -55,6 +55,21 @@ enable [Java 8 API desugaring](https://developer.android.com/studio/write/java8-
 In addition to the [`ktor-client-core`](client-dependencies.md) artifact, the Ktor client requires a dependency for a
 specific engine.
 
+### Use a specific engine
+
+Each supported platform has a set of available engines, described in the corresponding sections:
+
+* [JVM](#jvm)
+* [JVM and Android](#jvm-android)
+* [JavaScript](#js)
+* [Native](#native)
+
+> Ktor provides platform-specific artifacts with suffixes such as `-jvm` or `-js`. For example, `ktor-client-cio-jvm`.
+> Dependency resolution differs by build tool. While Gradle resolves artifacts appropriate for a given platform, Maven
+> doesn't support this capability. This means that for Maven, you need to specify the platform suffix manually.
+>
+{type="note"}
+
 ### Use default engines in multiplatform projects {id="default-engines"}
 
 For most Kotlin Multiplatform projects, use the `ktor-client-engine-defaults` artifact. It provides a curated client
@@ -75,21 +90,6 @@ kotlin {
 }
 ```
 
-### Use a specific engine
-
-Each supported platform has a set of available engines, described in the corresponding sections:
-
-* [JVM](#jvm)
-* [JVM and Android](#jvm-android)
-* [JavaScript](#js)
-* [Native](#native)
-
-> Ktor provides platform-specific artifacts with suffixes such as `-jvm` or `-js`. For example, `ktor-client-cio-jvm`.
-> Dependency resolution differs by build tool. While Gradle resolves artifacts appropriate for a given platform, Maven
-> doesn't support this capability. This means that for Maven, you need to specify the platform suffix manually.
->
-{type="note"}
-
 ## Specify an engine {id="create"}
 
 To use a specific engine, pass the engine class to the [
@@ -101,15 +101,20 @@ following example creates a client with the `CIO` engine:
 
 {src="snippets/_misc_client/CioCreate.kt"}
 
-## Default engine {id="default"}
+## Automatic engine selection {id="default"}
 
-If you omit the engine argument, the client will choose an engine automatically based on the dependencies
+If you omit the engine argument, the client chooses an engine automatically from the engine dependencies available
 [in your build script](#dependencies).
 
 ```kotlin
 ```
-
 {src="snippets/_misc_client/DefaultEngineCreate.kt"}
+
+If only one engine is available for the target platform, Ktor uses that engine. If multiple engines are available, Ktor
+selects the engine with the highest priority.
+
+By default, `CIO` has the lowest priority. This means that if `CIO` and another supported engine are available for the
+same platform, Ktor selects the other engine. `CIO` is used when no higher-priority engine is available.
 
 For Kotlin Multiplatform projects, the [`ktor-client-engine-defaults` dependency](#default-engines) provides a default
 engine for each target. Alternatively, you can [add specific engine dependencies](#use-a-specific-engine) to the 

--- a/topics/whats-new-360.md
+++ b/topics/whats-new-360.md
@@ -69,6 +69,40 @@ It is now deprecated in favor of `.respondHtmlPartial()`.
 
 ## Ktor Client
 
+### Default client engines for multiplatform projects
+
+Ktor 3.6.0 introduces the `ktor-client-engine-defaults` artifact, which provides a curated set of HTTP [client engines](client-engines.md)
+for [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatform/get-started.html) projects.
+
+Add the dependency to the `commonMain` source set:
+
+```kotlin
+kotlin {
+    sourceSets {
+        commonMain {
+            dependencies {
+                api("io.ktor:ktor-client-engine-defaults:3.6.0-SNAPSHOT")
+            }
+        }
+    }
+}
+```
+
+You can then create an HttpClient without specifying an engine:
+
+```kotlin
+val client = HttpClient()
+```
+
+For each target platform, Ktor uses the default engine provided by `ktor-client-engine-defaults`. This removes the
+need to declare separate engine dependencies for each platform in most multiplatform projects.
+
+If your multiplatform project currently uses `CIO` across all supported targets, consider replacing the `CIO` dependency
+with `ktor-client-engine-defaults`. This lets Ktor provide a curated default engine for each platform while keeping
+engine selection out of your common source set.
+
+You can still declare a specific client engine when you need engine-specific configuration or behavior.
+
 ### WebRTC client support for JVM
 <primary-label ref="experimental"/>
 

--- a/topics/whats-new-360.md
+++ b/topics/whats-new-360.md
@@ -81,7 +81,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                api("io.ktor:ktor-client-engine-defaults:3.6.0-SNAPSHOT")
+                api("io.ktor:ktor-client-engine-defaults:3.6.0")
             }
         }
     }

--- a/topics/whats-new-360.md
+++ b/topics/whats-new-360.md
@@ -88,7 +88,7 @@ kotlin {
 }
 ```
 
-You can then create an HttpClient without specifying an engine:
+You can then create an `HttpClient` without specifying an engine:
 
 ```kotlin
 val client = HttpClient()
@@ -101,7 +101,8 @@ If your multiplatform project currently uses `CIO` across all supported targets,
 with `ktor-client-engine-defaults`. This lets Ktor provide a curated default engine for each platform while keeping
 engine selection out of your common source set.
 
-You can still declare a specific client engine when you need engine-specific configuration or behavior.
+You can still [declare a specific client engine](client-dependencies.md#kmp-specific-engine) when you need engine-specific
+configuration or behavior.
 
 ### WebRTC client support for JVM
 <primary-label ref="experimental"/>

--- a/topics/whats-new-360.md
+++ b/topics/whats-new-360.md
@@ -94,8 +94,9 @@ You can then create an `HttpClient` without specifying an engine:
 val client = HttpClient()
 ```
 
-For each target platform, Ktor uses the default engine provided by `ktor-client-engine-defaults`. This removes the
-need to declare separate engine dependencies for each platform in most multiplatform projects.
+For each target platform, Ktor uses the default engine provided by `ktor-client-engine-defaults`. If more than one engine
+is available, the client selects the engine with the highest priority. `CIO` has the lowest priority by default, so the
+client selects another available engine over `CIO`.
 
 If your multiplatform project currently uses `CIO` across all supported targets, consider replacing the `CIO` dependency
 with `ktor-client-engine-defaults`. This lets Ktor provide a curated default engine for each platform while keeping


### PR DESCRIPTION
**Description:**
- Add a what's new entry.
- Edit the multiplatform engine section in _Adding dependencies_.
- Add a new default engines sub-section in _Client engines_.

**Related issue:**
[KTOR-9795](https://youtrack.jetbrains.com/issue/KTOR-9795) Documentation for Client curated multi-platform facade module