### PR TITLE
KTOR-9667 Add docs for `ContentNegotiation` acceptHeaderMergeStrategy

### DIFF
--- a/topics/client-serialization.md
+++ b/topics/client-serialization.md
@@ -18,36 +18,48 @@
 The ContentNegotiation plugin serves two primary purposes: negotiating media types between the client and server and serializing/deserializing the content in a specific format when sending requests and receiving responses.
 </link-summary>
 
-The [ContentNegotiation](https://api.ktor.io/ktor-client-content-negotiation/io.ktor.client.plugins.contentnegotiation/-content-negotiation)
+The [`ContentNegotiation`](https://api.ktor.io/ktor-client-content-negotiation/io.ktor.client.plugins.contentnegotiation/-content-negotiation)
 plugin serves two primary purposes:
-* Negotiating media types between the client and server. For this, it uses the `Accept` and `Content-Type` headers.
-* Serializing/deserializing the content in a specific format when sending [requests](client-requests.md) and receiving [responses](client-responses.md). Ktor supports the following formats out-of-the-box: JSON, XML, CBOR, and ProtoBuf.
+* Negotiating media types between the client and server, using the `Accept` and `Content-Type` headers.
+* Serializing [request](client-requests.md) bodies and deserializing [response](client-responses.md) bodies in supported
+  formats. Ktor provides built-in support for JSON, XML, CBOR, and ProtoBuf.
 
-> On the server, Ktor provides the [ContentNegotiation](server-serialization.md) plugin for serializing/deserializing content.
-
+> On the server, Ktor provides the [`ContentNegotiation`](server-serialization.md) plugin for serializing and deserializing
+> content.
+>
+{style="tip"}
 
 ## Add dependencies {id="add_dependencies"}
-### ContentNegotiation {id="add_content_negotiation_dependency"}
+
+### Content negotiation {id="add_content_negotiation_dependency"}
 
 <include from="lib.topic" element-id="add_ktor_artifact_intro"/>
 <include from="lib.topic" element-id="add_ktor_artifact"/>
-<include from="lib.topic" element-id="add_ktor_client_artifact_tip"/>
 
-Note that serializers for specific formats require additional artifacts. For example, kotlinx.serialization requires the `ktor-serialization-kotlinx-json` dependency for JSON. Depending on the included artifacts, Ktor chooses a default serializer automatically. If required, you can [specify the serializer](#configure_serializer) explicitly and configure it.
+> Serializers for specific formats require additional artifacts.
+> 
+> For example, `kotlinx.serialization` requires the `ktor-serialization-kotlinx-json` dependency for JSON. Depending on
+> the included artifacts, Ktor chooses a default serializer automatically. If required, you can [specify the serializer](#configure_serializer)
+> explicitly and configure it.
+> 
+{style="note"}
+
+<include from="lib.topic" element-id="add_ktor_client_artifact_tip"/>
 
 ### Serialization {id="serialization_dependency"}
 
-Before using kotlinx.serialization converters, you need to add the Kotlin serialization plugin
-as described in the [Setup](https://github.com/Kotlin/kotlinx.serialization#setup) section.
+Before using `kotlinx.serialization` converters, add the Kotlin serialization plugin as described in the
+[Setup](https://github.com/Kotlin/kotlinx.serialization#setup) section.
 
 #### JSON {id="add_json_dependency"}
 
-To serialize/deserialize JSON data, you can choose one of the following libraries: kotlinx.serialization, Gson, or Jackson.
+To serialize and deserialize JSON data, add a serialization library to your project. Ktor supports
+`kotlinx.serialization`, Gson, or Jackson.
 
 <tabs group="json-libraries">
 <tab title="kotlinx.serialization" group-key="kotlinx">
 
-Add the `ktor-serialization-kotlinx-json` artifact in the build script:
+Add the `ktor-serialization-kotlinx-json` artifact in your build script:
 
 <var name="artifact_name" value="ktor-serialization-kotlinx-json"/>
 <include from="lib.topic" element-id="add_ktor_artifact"/>
@@ -55,7 +67,7 @@ Add the `ktor-serialization-kotlinx-json` artifact in the build script:
 </tab>
 <tab title="Gson" group-key="gson">
 
-Add the `ktor-serialization-gson` artifact in the build script:
+Add the `ktor-serialization-gson` artifact in your build script:
 
 <var name="artifact_name" value="ktor-serialization-gson"/>
 <include from="lib.topic" element-id="add_ktor_artifact"/>
@@ -63,7 +75,7 @@ Add the `ktor-serialization-gson` artifact in the build script:
 </tab>
 <tab title="Jackson" group-key="jackson">
 
-Add the `ktor-serialization-jackson` artifact in the build script:
+Add the `ktor-serialization-jackson` artifact in your build script:
 
 <var name="artifact_name" value="ktor-serialization-jackson"/>
 <include from="lib.topic" element-id="add_ktor_artifact"/>
@@ -71,39 +83,38 @@ Add the `ktor-serialization-jackson` artifact in the build script:
 </tab>
 </tabs>
 
-
 #### XML {id="add_xml_dependency"}
 
-To serialize/deserialize XML, add the `ktor-serialization-kotlinx-xml` in the build script:
+To serialize and deserialize XML, add the `ktor-serialization-kotlinx-xml` artifact in your build script:
 
 <var name="artifact_name" value="ktor-serialization-kotlinx-xml"/>
 <include from="lib.topic" element-id="add_ktor_artifact"/>
 
 #### CBOR {id="add_cbor_dependency"}
 
-To serialize/deserialize CBOR, add the `ktor-serialization-kotlinx-cbor` in the build script:
+To serialize and deserialize CBOR, add the `ktor-serialization-kotlinx-cbor` artifact in your build script:
 
 <var name="artifact_name" value="ktor-serialization-kotlinx-cbor"/>
 <include from="lib.topic" element-id="add_ktor_artifact"/>
 
 #### ProtoBuf {id="add_protobuf_dependency"}
 
-To serialize/deserialize ProtoBuf, add the `ktor-serialization-kotlinx-protobuf` in the build script:
+To serialize and deserialize ProtoBuf, add the `ktor-serialization-kotlinx-protobuf` artifact in your build script:
 
 <var name="artifact_name" value="ktor-serialization-kotlinx-protobuf"/>
 <include from="lib.topic" element-id="add_ktor_artifact"/>
 
-## Install ContentNegotiation {id="install_plugin"}
+## Install `ContentNegotiation` {id="install_plugin"}
 
-To install `ContentNegotiation`, pass it to the `install` function inside a [client configuration block](client-create-and-configure.md#configure-client):
+To install the `ContentNegotiation` plugin, pass it to the `install` function in the [client configuration block](client-create-and-configure.md#configure-client):
 
 ```kotlin
 val client = HttpClient(CIO) {
     install(ContentNegotiation)
 }
 ```
-Now you can [configure](#configure_serializer) the required JSON serializer.
 
+You can then [configure](#configure_serializer) the required JSON serializer.
 
 ## Configure a serializer {id="configure_serializer"}
 
@@ -112,7 +123,8 @@ Now you can [configure](#configure_serializer) the required JSON serializer.
 <tabs group="json-libraries">
 <tab title="kotlinx.serialization" group-key="kotlinx">
 
-To register the JSON serializer in your application, call the `json` method:
+To register the JSON serializer in your application, call the `json()` function:
+
 ```kotlin
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.serialization.kotlinx.json.*
@@ -124,17 +136,23 @@ val client = HttpClient(CIO) {
 }
 ```
 
-In the `json` constructor, you can access the [JsonBuilder](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-json/kotlinx.serialization.json/-json-builder/) API, for example:
+To customize JSON serialization, pass a `Json` configuration in the `json()` constructor:
+
 ```kotlin
 ```
 {src="snippets/client-json-kotlinx/src/main/kotlin/com/example/Application.kt" include-lines="24-31"}
 
-You can find the full example here: [client-json-kotlinx](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-json-kotlinx).
+For available configuration options, see [`JsonBuilder`](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-json/kotlinx.serialization.json/-json-builder/).
+
+> For the full example, see [client-json-kotlinx](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-json-kotlinx).
+>
+{style="tip"}
 
 </tab>
 <tab title="Gson" group-key="gson">
 
-To register the Gson serializer in your application, call the [gson](https://api.ktor.io/ktor-serialization-gson/io.ktor.serialization.gson/gson.html) method:
+To register the Gson serializer in your application, call the [`gson()`](https://api.ktor.io/ktor-serialization-gson/io.ktor.serialization.gson/gson.html) function:
+
 ```kotlin
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.serialization.gson.*
@@ -146,12 +164,13 @@ val client = HttpClient(CIO) {
 }
 ```
 
-The `gson` method also allows you to adjust serialization settings provided by [GsonBuilder](https://www.javadoc.io/doc/com.google.code.gson/gson/latest/com.google.gson/com/google/gson/GsonBuilder.html).
+To customize Gson serialization, pass a `Json` configuration in the `gson()` constructor. For available configuration
+options, see [`GsonBuilder`](https://www.javadoc.io/doc/com.google.code.gson/gson/latest/com.google.gson/com/google/gson/GsonBuilder.html).
 
 </tab>
 <tab title="Jackson" group-key="jackson">
 
-To register the Jackson serializer in your application, call the [jackson](https://api.ktor.io/ktor-serialization-jackson/io.ktor.serialization.jackson/jackson.html) method:
+To register the Jackson serializer in your application, call the [`jackson()`](https://api.ktor.io/ktor-serialization-jackson/io.ktor.serialization.jackson/jackson.html) function:
 
 ```kotlin
 import io.ktor.client.plugins.contentnegotiation.*
@@ -164,7 +183,7 @@ val client = HttpClient(CIO) {
 }
 ```
 
-The `jackson` method also allows you to adjust serialization settings provided by [ObjectMapper](https://fasterxml.github.io/jackson-databind/javadoc/2.17.2/com/fasterxml/jackson/databind/ObjectMapper.html), for example:
+To customize Jackson serialization, use the settings provided by [`ObjectMapper`](https://fasterxml.github.io/jackson-databind/javadoc/2.17.2/com/fasterxml/jackson/databind/ObjectMapper.html):
 
 ```kotlin
 import io.ktor.client.plugins.contentnegotiation.*
@@ -187,7 +206,8 @@ val client = HttpClient(CIO) {
 
 ### XML serializer {id="register_xml"}
 
-To register the XML serializer in your application, call the `xml` method:
+To register the XML serializer in your application, call the `xml()` function:
+
 ```kotlin
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.serialization.kotlinx.xml.*
@@ -199,7 +219,7 @@ val client = HttpClient(CIO) {
 }
 ```
 
-The `xml` method also allows you to access XML serialization settings, for example:
+To customize XML serialization, pass the required options to the `xml()` function:
 
 ```kotlin
 import io.ktor.client.plugins.contentnegotiation.*
@@ -217,7 +237,9 @@ val client = HttpClient(CIO) {
 ```
 
 ### CBOR serializer {id="register_cbor"}
-To register the CBOR serializer in your application, call the `cbor` method:
+
+To register the CBOR serializer in your application, call the `cbor()` function:
+
 ```kotlin
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.serialization.kotlinx.cbor.*
@@ -229,7 +251,7 @@ val client = HttpClient(CIO) {
 }
 ```
 
-The `cbor` method also allows you to access CBOR serialization settings provided by [CborBuilder](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-cbor/kotlinx.serialization.cbor/-cbor-builder/), for example:
+To customize CBOR serialization, pass a `Cbor` configuration in the `cbor()` constructor:
 
 ```kotlin
 import io.ktor.client.plugins.contentnegotiation.*
@@ -245,8 +267,13 @@ val client = HttpClient(CIO) {
 }
 ```
 
+For available configuration
+options, see [`CborBuilder`](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-cbor/kotlinx.serialization.cbor/-cbor-builder/)
+
 ### ProtoBuf serializer {id="register_protobuf"}
-To register the ProtoBuf serializer in your application, call the `protobuf` method:
+
+To register the ProtoBuf serializer in your application, call the `protobuf()` function:
+
 ```kotlin
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.serialization.kotlinx.protobuf.*
@@ -258,7 +285,7 @@ val client = HttpClient(CIO) {
 }
 ```
 
-The `protobuf` method also allows you to access ProtoBuf serialization settings provided by [ProtoBufBuilder](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-protobuf/kotlinx.serialization.protobuf/-proto-buf-builder/), for example:
+To customize ProtoBuf serialization, pass a `ProtoBuf` configuration to the `protobuf()` function:
 
 ```kotlin
 import io.ktor.client.plugins.contentnegotiation.*
@@ -274,17 +301,39 @@ val client = HttpClient(CIO) {
 }
 ```
 
+For available options, see [`ProtoBufBuilder`](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-protobuf/kotlinx.serialization.protobuf/-proto-buf-builder/).
 
+## Configure the `Accept` header {id="configure_accept_header"}
 
-## Receive and send data {id="receive_send_data"}
+By default, the `ContentNegotiation` plugin adds registered content types to the `Accept` header of outgoing requests.
+
+If you set an `Accept` header explicitly and don't want the plugin to add registered content types, set
+the `acceptHeaderMergeStrategy` property to `ContentTypeMergeStrategy.SkipIfPresent`:
+
+```kotlin
+val client = HttpClient(CIO) {
+    install(ContentNegotiation) {
+        register(ContentType.Application.Json, noOpJsonConverter)
+        acceptHeaderMergeStrategy = ContentTypeMergeStrategy.SkipIfPresent
+    }
+}
+```
+
+With `SkipIfPresent`, the plugin preserves an existing `Accept` header. If the request doesn't contain an `Accept` header,
+the plugin adds the registered content types as usual.
+
+## Send and receive data {id="receive_send_data"}
+
 ### Create a data class {id="create_data_class"}
 
-To receive and send data, you need to have a data class, for example:
+The following examples use a `Customer` data class to represent the data sent and received by the client:
+
 ```kotlin
 ```
 {src="snippets/client-json-kotlinx/src/main/kotlin/com/example/Application.kt" include-lines="19"}
 
-If you use kotlinx.serialization, make sure that this class has the `@Serializable` annotation:
+If you use `kotlinx.serialization`, annotate the class with `@Serializable`:
+
 ```kotlin
 ```
 {src="snippets/client-json-kotlinx/src/main/kotlin/com/example/Application.kt" include-lines="18-19"}
@@ -293,19 +342,31 @@ If you use kotlinx.serialization, make sure that this class has the `@Serializab
 
 ### Send data {id="send_data"}
 
-To send a [class instance](#create_data_class) within a [request](client-requests.md) body as JSON, assign this instance using `setBody` function and set the content type to `application/json` by calling `contentType`:
+To send a [class instance](#create_data_class) in a [request](client-requests.md) body, assign this instance using the `setBody()`
+function and set the content type using the `contentType()` function.
+
+The following example sends a `Customer` object as JSON:
 
 ```kotlin
 ```
 {src="snippets/client-json-kotlinx/src/main/kotlin/com/example/Application.kt" include-lines="33-36"}
 
-To send data as XML or CBOR, set `contentType` to `ContentType.Application.Xml` or `ContentType.Application.Cbor`, respectively.
+The `ContentNegotiation` plugin uses the configured serializer to convert the request body to the specified format.
+
+To send data in another registered format, specify the corresponding content type, such as `ContentType.Application.Xml`
+or `ContentType.Application.Cbor`.
 
 ### Receive data {id="receive_data"}
 
-When a server sends a [response](client-responses.md) with the `application/json`, `application/xml`, or `application/cbor` content, you can deserialize it by specifying a [data class](#create_data_class) as a parameter of a function used to receive a response payload (`body` in the example below):
+When the server returns a [response](client-responses.md) with a supported content type, the `ContentNegotiation` plugin can deserialize
+the response body into the expected type.
+
+For example, to deserialize a JSON response into a `Customer` object, call the `body()` function:
+
 ```kotlin
 ```
 {src="snippets/client-json-kotlinx/src/main/kotlin/com/example/Application.kt" include-lines="39"}
 
-You can find the full example here: [client-json-kotlinx](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-json-kotlinx).
+> For the full example, see [client-json-kotlinx](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-json-kotlinx).
+>
+{style="tip"}

--- a/topics/whats-new-360.md
+++ b/topics/whats-new-360.md
@@ -109,3 +109,24 @@ val client = HttpClient {
 </compare>
 
 This replaces the JVM-specific setup that creates a `File` before passing it to `FileStorage()`.
+
+### Control `Accept` header merging in `ContentNegotiation`
+
+You can now control how the client [`ContentNegotiation`](client-serialization.md) plugin merges registered content types
+with an existing `Accept` header.
+
+By default, the `ContentNegotiation` plugin adds registered content types that aren't already represented in the request's
+`Accept` header.
+
+If you set an `Accept` header explicitly and don't want the plugin to add registered content types, set
+the `acceptHeaderMergeStrategy` property to `ContentTypeMergeStrategy.SkipIfPresent`:
+
+```kotlin
+install(ContentNegotiation) {
+    register(ContentType.Application.Json, noOpJsonConverter)
+    acceptHeaderMergeStrategy = ContentTypeMergeStrategy.SkipIfPresent
+}
+```
+
+With `SkipIfPresent`, the plugin preserves an existing `Accept` header. If the request doesn't contain an `Accept` header,
+the plugin adds the registered content types as usual.


### PR DESCRIPTION
**Description**
- Add a what's new entry.
- Add a new section for configuring the `Accept` header in the _Content negotiation and serialization_ topic.
- Fix formatting and language in the _Content negotiation and serialization_  topic. 

**Related issue**
[KTOR-9667](https://youtrack.jetbrains.com/issue/KTOR-9667) Documentation for ContentNegotiation: Add a way to prevent changing Accept and Content-Type headers