### PR TITLE
KTOR-9833 Update the http2 topic and add docs for using h2c and http2 on same server

### DIFF
--- a/topics/server-http2.md
+++ b/topics/server-http2.md
@@ -8,29 +8,34 @@
 </p>
 </tldr>
 
-[HTTP/2](https://en.wikipedia.org/wiki/HTTP/2) is a modern binary duplex multiplexing protocol designed as a replacement for HTTP/1.x.
+[HTTP/2](https://en.wikipedia.org/wiki/HTTP/2) is a modern binary multiplexing protocol designed as a replacement for
+HTTP/1.x.
 
-Jetty and Netty engines provide HTTP/2 implementations that Ktor can use. However, there are significant differences, and each engine requires additional configuration. 
-Once your host is configured properly for Ktor, HTTP/2 support will be activated automatically.
+Ktor supports HTTP/2 with the Jetty and Netty server engines. However, there are significant differences, and each engine
+requires additional configuration. Once your host is configured, HTTP/2 support is activated automatically.
 
-Key requirements:
+For HTTP/2 over TLS, you typically need:
 
-* An SSL certificate (can be self-signed).
-* An ALPN implementation suitable for a particular engine (see corresponding sections for Netty and Jetty).
+* [An SSL certificate](#ssl_certificate), which can be self-signed.
+* [An ALPN implementation](#apln_implementation) supported by the selected engine.
 
-## SSL certificate {id="ssl_certificate"}
+[HTTP/2 over cleartext (h2c)](#h2c) is available with the Netty engine and doesn't require SSL or ALPN configuration.
 
-As per the specification, HTTP/2 does not require encryption, but all browsers will require encrypted connections to be used with HTTP/2.
-That's why a working TLS environment is a prerequisite for enabling HTTP/2. Therefore, a certificate is required to enable encryption.
-For testing purposes, it can be generated with `keytool` from the JDK ...
+## Configure an SSL certificate {id="ssl_certificate"}
+
+HTTP/2 doesn't require TLS, but browsers typically support HTTP/2 only over encrypted connections. To use HTTP/2 over
+TLS, you need to configure an SSL certificate for your server.
+
+For testing, you can generate a self-signed certificate using the JDK `keytool` utility:
 
 ```bash
 keytool -keystore test.jks -genkeypair -alias testkey -keyalg RSA -keysize 4096 -validity 5000 -dname 'CN=localhost, OU=ktor, O=ktor, L=Unspecified, ST=Unspecified, C=US'
 ```
 
-... or by using the [buildKeyStore](server-ssl.md) function.
+You can also create a keystore programmatically using the [`buildKeyStore()`](server-ssl.md) function.
 
-The next step is configuring Ktor to use your keystore. See the example `application.conf` / `application.yaml` [configuration files](server-configuration-file.topic):
+Then, configure Ktor to use the keystore in your
+<path>application.conf</path> or <path>application.yaml</path> [configuration file](server-configuration-file.topic):
 
 <tabs group="config">
 <tab title="application.conf" group-key="hocon">
@@ -49,40 +54,48 @@ The next step is configuring Ktor to use your keystore. See the example `applica
 </tab>
 </tabs>
 
-## ALPN implementation {id="apln_implementation"}
+## Configure ALPN {id="apln_implementation"}
 
-HTTP/2 requires ALPN ([Application-Layer Protocol Negotiation](https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation)) to be enabled. The first option is to use an external ALPN implementation that needs to be added to the boot classpath.
-Another option is to use OpenSSL native bindings and precompiled native binaries. 
-Also, each particular engine can support only one of these methods.
+HTTP/2 over TLS uses [Application-Layer Protocol Negotiation (ALPN)](https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation) to negotiate the protocol between the client
+and server. ALPN configuration depends on the server engine.
 
 ### Jetty {id="jetty"}
 
-Since ALPN APIs are supported starting with Java 8, the Jetty engine doesn't require any specific configurations for using HTTP/2. So, you only need to:
+The Jetty engine handles ALPN without additional Ktor configuration.
+To use HTTP/2 over TLS with Jetty:
 1. [Create a server](server-engines.md#choose-create-server) with the Jetty engine.
-2. Add an SSL configuration as described in [](#ssl_certificate).
+2. [](#ssl_certificate).
 3. Configure `sslPort`.
 
-The [http2-jetty](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/http2-jetty) runnable example demonstrates HTTP/2 support for Jetty.
+> For a complete runnable example of HTTP/2 with Jetty, see [http2-jetty](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/http2-jetty) 
+>
+{style="tip"}
 
 ### Netty {id="netty"}
 
-To enable HTTP/2 in Netty, use OpenSSL bindings ([tcnative netty port](https://netty.io/wiki/forked-tomcat-native.html)).
-The example below shows how to add a native implementation (statically linked BoringSSL library, a fork of OpenSSL) to the `build.gradle.kts` file:
+To use HTTP/2 over TLS with Netty, add the [Netty `tcnative`](https://netty.io/wiki/forked-tomcat-native.html) OpenSSL bindings.
+
+The following example adds the statically linked BoringSSL implementation to the
+<path>build.gradle.kts</path> file:
 
 ```kotlin
 ```
 {src="snippets/http2-netty/build.gradle.kts" include-lines="20-28,34-39"}
 
-`tc.native.classifier` should be one of the following: `linux-x86_64`, `osx-x86_64`, or `windows-x86_64`. 
-The [http2-netty](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/http2-netty) runnable example demonstrates how to enable HTTP/2 support for Netty.
+The `tc.native.classifier` can be `linux-x86_64`, `osx-x86_64`, or `windows-x86_64`.
 
-#### HTTP/2 without TLS
+> For a complete runnable example of HTTP/2 with Netty, see [http2-netty](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/http2-netty).
+> 
+{style="tip"}
 
-The Netty engine also supports [HTTP/2 over cleartext (h2c)](https://httpwg.org/specs/rfc7540.html#discover-http).
-This allows HTTP/2 communication without TLS, typically within private networks where encryption is not required. 
-Clients can initiate communication with an HTTP/1.1 request and then upgrade to HTTP/2.
+## HTTP/2 without TLS {id="h2c"}
 
-To enable h2c, set the `enableH2c` flag to `true` in the engine configuration:
+The Netty engine supports [HTTP/2 over cleartext (h2c)](https://httpwg.org/specs/rfc7540.html#discover-http), which allows HTTP/2 communication without TLS.
+This can be useful within private networks where encryption is not required. 
+
+Clients can connect using h2c directly or upgrade an HTTP/1.1 connection to HTTP/2.
+
+To enable h2c, set both `enableH2c` and `enableHttp2` options to `true` in the engine configuration:
 
 ```kotlin
 embeddedServer(Netty, configure = {
@@ -94,5 +107,5 @@ embeddedServer(Netty, configure = {
 })
 ```
 
-
-Note that h2c requires `enableHttp2 = true` and cannot be used if an SSL connector is configured on the server.
+You can enable h2c and HTTP/2 over TLS on the same server. Cleartext connectors accept h2c connections, while SSL
+connectors use HTTP/2 over TLS.

--- a/topics/whats-new-360.md
+++ b/topics/whats-new-360.md
@@ -67,6 +67,31 @@ call.respondHtmlPartial(HttpStatusCode.Created) {
 The previous `.respondHtmlFragment()` function uses `FlowContent`, which restricts the HTML elements that can be returned.
 It is now deprecated in favor of `.respondHtmlPartial()`.
 
+### Use h2c alongside HTTP/2 over TLS
+
+The Netty server engine can now serve [HTTP/2 over cleartext (h2c)](server-http2.md#h2c) and HTTP/2 over TLS on the
+same server.
+
+This allows you to configure a cleartext connector and an SSL connector, then enable both HTTP/2 and h2c:
+
+```kotlin
+embeddedServer(Netty, configure = {
+    connector {
+        port = 8080
+    }
+    sslConnector(...) {
+        port = 8443
+    }
+
+    enableHttp2 = true
+    enableH2c = true
+}) {
+    // ...
+}
+```
+
+The cleartext connector accepts h2c connections, while the SSL connector serves HTTP/2 over TLS.
+
 ## Ktor Client
 
 ### Default client engines for multiplatform projects


### PR DESCRIPTION
**Description**
- Add a what's new entry.
- Fix formatting, structure and language in the server HTTP/2 topic.

**Related issue**
[KTOR-9833](https://youtrack.jetbrains.com/issue/KTOR-9833) Documentation for Allow H2C and HTTP/2 on same server