### PR TITLE
KTOR-9755 Add docs for zstd and deflate support for pre-compressed files

### DIFF
--- a/codeSnippets/snippets/static-files/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/static-files/src/main/kotlin/com/example/Application.kt
@@ -18,7 +18,12 @@ fun Application.module() {
         staticFiles("/resources", File("files"))
         staticFiles("/", File("files")) {
             default("index.html")
-            preCompressed(CompressedFileType.BROTLI, CompressedFileType.GZIP)
+            preCompressed(
+                CompressedFileType.BROTLI,
+                CompressedFileType.GZIP,
+                CompressedFileType.ZSTD,
+                CompressedFileType.DEFLATE
+            )
             modify { file, call ->
                 call.response.headers.append(HttpHeaders.ETag, file.name.toString())
             }

--- a/topics/server-static-content.md
+++ b/topics/server-static-content.md
@@ -31,7 +31,7 @@ function. In this case, relative paths are resolved using the current working di
  ```kotlin
  ```
 
-{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="17-18,59"}
+{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="17-18,64"}
 
 In the example above, any request from `/resources` is mapped to the `files` physical folder in the current working
 directory.
@@ -98,15 +98,20 @@ In this case, when `/custom` is requested, Ktor serves `/custom_index.html`.
 
 ### Pre-compressed files {id="precompressed"}
 
-Ktor provides the ability to serve pre-compressed files and avoid using [dynamic compression](server-compression.md).
-To use this functionality, define the `preCompressed()` function inside a block statement:
+Ktor can serve pre-compressed static files instead of compressing responses dynamically with the [Compression](server-compression.md)
+plugin.
+
+To enable this functionality, use the `preCompressed()` function and specify the supported compression formats:
 
 ```kotlin
 ```
+{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="19,21-26,30"}
 
-{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="19,21,25"}
+When a client requests a static file, Ktor checks the client's supported content encodings and serves a matching
+pre-compressed version when available.
 
-In this example, for a request made to `/js/script.js`, Ktor can serve `/js/script.js.br` or `/js/script.js.gz`.
+For example, for a request to `/js/script.js`, Ktor can serve a pre-compressed variant such as `/js/script.js.br` or
+`/js/script.js.gz`.
 
 ### HEAD requests {id="autohead"}
 
@@ -126,7 +131,7 @@ corresponding file.
 ```kotlin
 ```
 
-{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="19-20,25"}
+{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="19-20,30"}
 
 In this example when the client requests a resource that doesn't exist, the `index.html` file will
 be served as a response.
@@ -139,7 +144,7 @@ the `contentType()` function to set the `Content-Type` header explicitly.
 ```kotlin
 ```
 
-{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="26,37-42,49"}
+{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="31,42-47,54"}
 
 In this example, the response for the file `html-file.txt` will have the `Content-Type: text/html` header, and for every
 other file the default behavior will be applied.
@@ -151,7 +156,7 @@ The `cacheControl()` function allows you to configure the `Cache-Control` header
 ```kotlin
 ```
 
-{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="16-17,26,43-49,59-60,62-64"}
+{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="15,17,31,48-54,64-65,67-69"}
 
 When the [`ConditionalHeaders`](server-conditional-headers.md) plugin is installed, Ktor can serve static resources with 
 `ETag` and `LastModified` headers and process conditional headers to avoid sending the body of content if it hasn't changed
@@ -160,7 +165,7 @@ since the last request:
 ```kotlin
 ```
 
-{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="51-54"}
+{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="56-59"}
 
 In this example, the `etag` and `lastModified` values are calculated dynamically based on each resource and applied to the response.
 
@@ -169,7 +174,7 @@ To simplify `ETag` generation, you can also use a predefined provider:
 ```kotlin
 ```
 
-{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="56-58"}
+{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="61-63"}
 
 In this example, a strong `ETag` is generated using the SHA‑256 hash of the resource content.
 If an I/O error occurs, no `ETag` is generated.
@@ -186,7 +191,7 @@ the server will respond with a `403 Forbidden` status code.
 ```kotlin
 ```
 
-{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="26,28,49"}
+{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="31,33,54"}
 
 ### File extensions fallbacks {id="extensions"}
 
@@ -213,7 +218,7 @@ The example below shows how to redirect certain extensions, return a custom stat
 ```kotlin
 ```
 
-{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="26,29-36,49"}
+{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="31,34-41,54"}
 
 ### Custom modifications {id="modify"}
 
@@ -222,7 +227,7 @@ The `modify()` function allows you to apply custom modification to a resulting r
 ```kotlin
 ```
 
-{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="19,22-25"}
+{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="19,27-30"}
 
 ## Handle errors {id="errors"}
 

--- a/topics/whats-new-330.md
+++ b/topics/whats-new-330.md
@@ -29,7 +29,7 @@ To define custom fallback behaviour, use the `fallback()` function within `stati
 ```kotlin
 ```
 
-{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="26,29-36,49"}
+{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="31,34-41,54"}
 
 ### LastModified and Etag headers for static content
 
@@ -40,7 +40,7 @@ the last request:
 ```kotlin
 ```
 
-{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="51-54"}
+{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="56-59"}
 
 The values are calculated dynamically based on each resource and applied to the response.
 
@@ -50,7 +50,7 @@ content:
 ```kotlin
 ```
 
-{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="56-58"}
+{src="snippets/static-files/src/main/kotlin/com/example/Application.kt" include-lines="61-63"}
 
 ### Development mode auto-reload limitations
 

--- a/topics/whats-new-360.md
+++ b/topics/whats-new-360.md
@@ -33,6 +33,22 @@ get {
 }
 ```
 
+### Zstandard (zstd) and DEFLATE support for pre-compressed static files
+
+Ktor can now serve pre-compressed static content in Zstandard (zstd) and DEFLATE formats.
+
+To enable the new formats, use `CompressedFileType.ZSTD` and `CompressedFileType.DEFLATE` with the `preCompressed()`
+function:
+
+```kotlin
+staticResources("staticResources", "public") {
+    preCompressed(
+        CompressedFileType.ZSTD,
+        CompressedFileType.DEFLATE
+    )
+}
+```
+
 ### OpenAPI tag descriptions
 
 You can now define descriptions for OpenAPI tags directly in the [`openAPI {}`](server-openapi.md) and [`swaggerUI {}`](server-swagger-ui.md)


### PR DESCRIPTION
**Description**
- Add a what's new entry.
- Update the `static-files` code example.
- Update affected code block lines.
- Reword the "Pre-compressed files" section in "Serving static content".

**Related issue**
[KTOR-9755](https://youtrack.jetbrains.com/issue/KTOR-9755) Documentation for Support at least zstd and deflate formats of precompressed files