### PR TITLE
KTOR-9754 Add a what's new entry for new parseClientCookies() function

### DIFF
--- a/topics/whats-new-360.md
+++ b/topics/whats-new-360.md
@@ -262,3 +262,26 @@ val client = HttpClient(Js) {
 
 This is useful when integrating with JavaScript libraries that provide their own `fetch()` wrapper, such as [AWS WAF](https://aws.amazon.com/waf/).
 If you don't configure `fetch`, the engine continues to use the global `fetch()` function.
+
+## Shared
+
+### Preserve duplicate cookies when parsing cookie headers
+
+You can now use the `parseClientCookies()` function to parse `Cookie` headers that contain multiple cookies with the
+same name.
+
+Unlike the `parseClientCookiesHeader()` function, which returns a `Map<String, String>` and keeps only the last value
+for duplicate names, the `parseClientCookies()` function returns a `List<Pair<String, String>>` and preserves duplicate
+cookie entries:
+
+```kotlin
+val header = "name=value1; name=value2"
+
+val cookies = parseClientCookies(header)
+// [("name", "value1"), ("name", "value2")]
+
+val cookieMap = parseClientCookiesHeader(header)
+// {"name"="value2"}
+```
+
+Use `parseClientCookies()` when duplicate cookie names need to be preserved.


### PR DESCRIPTION
[KTOR-9754](https://youtrack.jetbrains.com/issue/KTOR-9754) Documentation for Ktor Cookie.parseClientCookiesHeader returns Map, which breaks Cookie header contract