### PR TITLE
KTOR-6628 Add MockEngine examples for multiple endpoints and call chains

### DIFF
--- a/codeSnippets/snippets/client-testing-mock/src/main/kotlin/com/example/Application.kt
+++ b/codeSnippets/snippets/client-testing-mock/src/main/kotlin/com/example/Application.kt
@@ -5,8 +5,8 @@ import io.ktor.client.call.*
 import io.ktor.client.engine.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.serialization.kotlinx.json.*
 import io.ktor.client.request.*
+import io.ktor.serialization.kotlinx.json.*
 import kotlinx.coroutines.*
 import kotlinx.serialization.*
 
@@ -29,4 +29,8 @@ class ApiClient(engine: HttpClientEngine) {
     }
 
     suspend fun getIp(): IpResponse = httpClient.get("https://api.ipify.org/?format=json").body()
+
+    suspend fun getUser(): String = httpClient.get("https://api.example.com/user").body()
+
+    suspend fun getOrders(): String = httpClient.get("https://api.example.com/orders").body()
 }

--- a/codeSnippets/snippets/client-testing-mock/src/test/kotlin/ApplicationTest.kt
+++ b/codeSnippets/snippets/client-testing-mock/src/test/kotlin/ApplicationTest.kt
@@ -1,11 +1,16 @@
 package com.example
 
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.engine.*
 import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
-import org.junit.*
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class ApiClientTest {
     @Test
@@ -20,7 +25,56 @@ class ApiClientTest {
             }
             val apiClient = ApiClient(mockEngine)
 
-            Assert.assertEquals("127.0.0.1", apiClient.getIp().ip)
+            assertEquals("127.0.0.1", apiClient.getIp().ip)
+        }
+    }
+
+    @Test
+    fun mockMultipleEndpoints() {
+        runBlocking {
+            val mockEngine = MockEngine { request ->
+                when (request.url.encodedPath) {
+                    "/user" -> respondOk("user-1")
+                    "/orders" -> respondOk("order-1,order-2")
+                    else -> error("Unhandled ${request.url}")
+                }
+            }
+            val apiClient = ApiClient(mockEngine)
+
+            assertEquals("user-1", apiClient.getUser())
+            assertEquals("order-1,order-2", apiClient.getOrders())
+        }
+    }
+
+    @Test
+    fun mockCallChain() {
+        runBlocking {
+            val mockEngine = MockEngine.config {
+                reuseHandlers = false
+                addHandler { respondOk("step-1") }
+                addHandler { respondOk("step-2") }
+            }
+            val client = HttpClient(mockEngine)
+
+            assertEquals("step-1", client.get("https://api.example.com/a").body())
+            assertEquals("step-2", client.get("https://api.example.com/b").body())
+            assertFailsWith<IllegalStateException> {
+                client.get("https://api.example.com/c").body<String>()
+            }
+        }
+    }
+
+    @Test
+    fun mockCallChainWithQueue() {
+        runBlocking {
+            val engine = MockEngine.Queue()
+            val client = HttpClient(engine)
+
+            engine += { respondOk("first") }
+            engine += { respondOk("second") }
+
+            assertEquals("first", client.get("https://api.example.com/a").body())
+            assertEquals("second", client.get("https://api.example.com/b").body())
         }
     }
 }

--- a/topics/client-testing.md
+++ b/topics/client-testing.md
@@ -1,6 +1,6 @@
 [//]: # (title: Testing in Ktor Client)
 
-<show-structure for="chapter" depth="2"/>
+<show-structure for="chapter" depth="3"/>
 
 <var name="artifact_name" value="ktor-client-mock"/>
 
@@ -40,13 +40,13 @@ To test this client, its configuration needs to be shared with a test client, wh
 
 ```kotlin
 ```
-{src="snippets/client-testing-mock/src/main/kotlin/com/example/Application.kt" include-lines="13-15,24-32"}
+{src="snippets/client-testing-mock/src/main/kotlin/com/example/Application.kt" include-lines="13-14,24-36"}
 
 Then, you can use the `ApiClient` as follows to create an HTTP client with the `CIO` engine and make a request.
 
 ```kotlin
 ```
-{src="snippets/client-testing-mock/src/main/kotlin/com/example/Application.kt" include-lines="16-22"}
+{src="snippets/client-testing-mock/src/main/kotlin/com/example/Application.kt" include-lines="16-21"}
 
 ### Test a client {id="test-client"}
 
@@ -54,12 +54,44 @@ To test a client, you need to create a `MockEngine` instance with a handler that
 
 ```kotlin
 ```
-{src="snippets/client-testing-mock/src/test/kotlin/ApplicationTest.kt" include-lines="14-20"}
+{src="snippets/client-testing-mock/src/test/kotlin/ApplicationTest.kt" include-lines="19-25"}
 
 Then, you can pass the created `MockEngine` to initialize `ApiClient` and make required assertions.
 
 ```kotlin
 ```
-{src="snippets/client-testing-mock/src/test/kotlin/ApplicationTest.kt" include-lines="10-26"}
+{src="snippets/client-testing-mock/src/test/kotlin/ApplicationTest.kt" include-lines="15-30"}
+
+### Mock multiple endpoints {id="multiple-endpoints"}
+
+When a client calls several URLs, use a single reusable handler and branch on the request
+(for example, `request.url.encodedPath` or the host). This keeps mocks independent of call order:
+
+```kotlin
+```
+{src="snippets/client-testing-mock/src/test/kotlin/ApplicationTest.kt" include-lines="35-41"}
+
+In the `else` branch, fail on unexpected URLs so tests do not silently accept missing mocks.
+You can also match on `request.url.host` when the same path is used on different hosts.
+
+### Mock a call chain {id="call-chain"}
+
+To return different responses for consecutive calls in a fixed order, register multiple handlers with
+[`addHandler`](https://api.ktor.io/ktor-client-mock/io.ktor.client.engine.mock/-mock-engine-config/add-handler.html)
+and set `reuseHandlers = false` so each handler is used once:
+
+```kotlin
+```
+{src="snippets/client-testing-mock/src/test/kotlin/ApplicationTest.kt" include-lines="52-56"}
+
+By default, `reuseHandlers` is `true` and handlers are reused in a cycle. With `reuseHandlers = false`,
+a further request after the last handler fails with an “Unhandled …” error.
+
+For tests that build the client first and enqueue responses later, use
+[`MockEngine.Queue`](https://api.ktor.io/ktor-client-mock/io.ktor.client.engine.mock/-mock-engine/-queue/index.html):
+
+```kotlin
+```
+{src="snippets/client-testing-mock/src/test/kotlin/ApplicationTest.kt" include-lines="70-74"}
 
 You can find the full example here: [client-testing-mock](https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-testing-mock).


### PR DESCRIPTION
## Summary
- Document MockEngine patterns for multiple endpoints (branch on URL) and ordered call chains (`addHandler` / `MockEngine.Queue`).
- Extend the `client-testing-mock` snippet with matching tests.